### PR TITLE
Enable AZUREAUTH_CONFIG env var fallback if not given as --config

### DIFF
--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -18,6 +18,7 @@
     <!-- Output an executable -->
     <PackageId>microsoft.authentication.azureauth</PackageId>
     <OutputType>Exe</OutputType>
+    <RootNamespace>Microsoft.Authentication.AzureAuth</RootNamespace>
 
     <NuspecFile>AzureAuth.nuspec</NuspecFile>
     <NuspecProperties>$(NuspecProperties);Configuration=$(Configuration);Version=$(Version)$(VersionSuffix)</NuspecProperties>

--- a/src/AzureAuth/EnvVars.cs
+++ b/src/AzureAuth/EnvVars.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AzureAuth
+{
+    /// <summary>
+    /// A static class to hold env var names.
+    /// </summary>
+    internal static class EnvVars
+    {
+        /// <summary>
+        /// Holds the name of the env var to get an application insights ingestion token.
+        /// </summary>
+        public static readonly string ApplicationInsightsIngestionTokenEnvVar = $"{EnvVarPrefix}_APPLICATION_INSIGHTS_INGESTION_TOKEN";
+
+        /// <summary>
+        /// Holds the name of the env var to get a config file from.
+        /// </summary>
+        public static readonly string Config = $"{EnvVarPrefix}_CONFIG";
+
+        private const string EnvVarPrefix = "AZUREAUTH";
+    }
+}

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -13,9 +13,6 @@ namespace Microsoft.Authentication.AzureAuth
     /// </summary>
     public class Program
     {
-        private const string EnvVarPrefix = "AZUREAUTH";
-        private static readonly string ApplicationInsightsIngestionTokenEnvVar = $"{EnvVarPrefix}_APPLICATION_INSIGHTS_INGESTION_TOKEN";
-
         private static void Main(string[] args)
         {
             CommandLineApplication app = new CommandLineApplication<CommandMain>();
@@ -34,7 +31,7 @@ namespace Microsoft.Authentication.AzureAuth
             // trigger telemetry before we ever get to disable it.
             //
             // To disable telemetry a user need only leave this environment variable unset. It's off by default.
-            string applicationInsightsIngestionToken = Environment.GetEnvironmentVariable(ApplicationInsightsIngestionTokenEnvVar);
+            string applicationInsightsIngestionToken = Environment.GetEnvironmentVariable(EnvVars.ApplicationInsightsIngestionTokenEnvVar);
             if (!string.IsNullOrEmpty(applicationInsightsIngestionToken))
             {
                 ingestionToken = applicationInsightsIngestionToken;


### PR DESCRIPTION
# Problem
We currently provide a `--config` option to load `Alias`s from a config file. In order to use `--alias` though you must always add a `--config`. This is okay for scripts with known paths, but is still very cumbersome when a developer wants to explicitly warm a particular auth path.

# Solution
Provide `AZUREAUTH_CONFIG` as an env var to check for a config file path if none is given on the CLI. This will enable developer environment setup scripts to set a known config file location without imposing any directory or naming structure on them. 