### PR TITLE
Use Mutex to prevent multiple prompts

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
+
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+        source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
+
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -270,7 +270,6 @@ Allowed values: [all, web, devicecode]";
                 TokenResult tokenResult = null;
 
                 // When running multiple AzureAuth processes with the same resource, client, and tenant IDs,
-
                 // They may prompt many times, which is annoying and unexpected.
                 // Use Mutex to ensure that only one process can access the corresponding resource at the same time.
                 string lockName = $"Local\\{this.Resource}_{this.Client}_{this.Tenant}";
@@ -283,7 +282,7 @@ Allowed values: [all, web, devicecode]";
                     try
                     {
                         // Wait for the other session to exit.
-                        lockAcquired = mutex.WaitOne(this.mutexTimeout);
+                        lockAcquired = mutex.WaitOne(this.promptMutexTimeout);
                     }
 
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -283,7 +283,7 @@ Allowed values: [all, web, devicecode]";
                     try
                     {
                         // Wait for the other session to exit.
-                        mutex.WaitOne();
+                        lockAcquired = mutex.WaitOne();
                     }
 
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Authentication.AzureAuth
     using System.IO.Abstractions;
     using System.Linq;
     using System.Runtime.CompilerServices;
-
+    using System.Threading;
     using McMaster.Extensions.CommandLineUtils;
 
     using Microsoft.Authentication.MSALWrapper;

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -283,7 +283,8 @@ Allowed values: [all, web, devicecode]";
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.
                     catch (AbandonedMutexException)
                     {
-                        // lock eventually acquired
+                        // If another process crashes or exits accidently, we can still acquire the lock.
+                        // In this case, basicly we can just leave a log warning, because the worst side effect is propmting more than once.
                         this.logger.LogWarning("The authentication attempt mutex was abandoned. Another thread or process may have exited unexpectedly.");
                     }
 

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -298,8 +298,7 @@ Allowed values: [all, web, devicecode]";
 
                     if (!lockAcquired)
                     {
-                        this.logger.LogError("Authentication failed. The application did not gain access in the expected time, possibly because the resource handler was occupied by another process for a long time.");
-                        return 1;
+                        throw new TimeoutException("Authentication failed. The application did not gain access in the expected time, possibly because the resource handler was occupied by another process for a long time.");
                     }
 
                     try

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -53,9 +53,9 @@ Allowed values: [all, web, devicecode]";
         private ITokenFetcher tokenFetcher;
 
         /// <summary>
-        /// MutexTimeout is the timeout of Mutex to prevent infinite waiting.
+        /// The maximum time we will wait to acquire a mutex around prompting the user.
         /// </summary>
-        private TimeSpan mutexTimeout = TimeSpan.FromMinutes(15);
+        private TimeSpan promptMutexTimeout = TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandMain"/> class.

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -281,7 +281,6 @@ Allowed values: [all, web, devicecode]";
                     }
 
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.
-
                     catch (AbandonedMutexException)
                     {
                         // lock eventually acquired

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -273,7 +273,7 @@ Allowed values: [all, web, devicecode]";
 
                 // They may prompt many times, which is annoying and unexpected.
                 // Use Mutex to ensure that only one process can access the corresponding resource at the same time.
-                string lockName = $"Global\\{this.Resource}_{this.Client}_{this.Tenant}";
+                string lockName = $"Local\\{this.Resource}_{this.Client}_{this.Tenant}";
 
                 // First parameter InitiallyOwned indicated whether this lock is owned by current thread.
                 // It should be false otherwise a dead lock could occur.
@@ -283,7 +283,7 @@ Allowed values: [all, web, devicecode]";
                     try
                     {
                         // Wait for the other session to exit.
-                        lockAcquired = mutex.WaitOne();
+                        lockAcquired = mutex.WaitOne(this.mutexTimeout);
                     }
 
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.


### PR DESCRIPTION
# Background
Some users encounter that when accessing a resource at the same time, if the token has not been cached, many authentication dialog boxes will pop up, which is quite annoying.

Ref: #3 may contains more context.
# Solution
To avoid multiple prompts, a named mutex is used, which can prevent in both single process and multiple processes.
See [Mutex: Local vs Global](https://docs.microsoft.com/en-us/dotnet/api/system.threading.mutex?view=net-6.0#remarks)

# Testcase
Run the following command parallel but in one terminal server sessions.
dotnet run --project ./src/AzureAuth --debug --resource={resource_id} --client={client_id} --tenant={tenant_id} -m web

After discussing with Kyle and Tucker, we can simplify by literally using Mutex. Since unit test on parallel scenario is difficult, we can test manually.