### PR TITLE
Remove short flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Removed
-- Short flags for `--tenant`, `--clear`, `--domain`, `--auth-mode`, and `--output`.
+- The `-t`, `-c`, `-d`, `-m`, and `-o` short flags.
 
 ## [v0.1.0] - 2022-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Removed
+- Short flags for `--tenant`, `--clear`, `--domain`, `--auth-mode`, and `--output`.
+
+## [v0.1.0] - 2022-03-30
+### Added
+- Initial project release.
+
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/v0.1.0

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -310,7 +310,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Tenant = null;
 
             subject.EvaluateOptions().Should().BeFalse();
-            this.logTarget.Logs.Should().Contain("The -t|--tenant field is required.");
+            this.logTarget.Logs.Should().Contain("The --tenant field is required.");
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ invalid_key = ""this is not a valid alias key""
             {
                 "The --resource field is required.",
                 "The --client field is required.",
-                "The -t|--tenant field is required.",
+                "The --tenant field is required.",
             });
         }
 

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Authentication.AzureAuth
     {
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
-        private const string TenantOption = "-t|--tenant";
+        private const string TenantOption = "--tenant";
         private const string ScopeOption = "--scope";
-        private const string ClearOption = "-c|--clear";
-        private const string DomainOption = "-d|--domain";
-        private const string AuthModeOption = "-m|--auth-mode";
-        private const string OutputOption = "-o|--output";
+        private const string ClearOption = "--clear";
+        private const string DomainOption = "--domain";
+        private const string AuthModeOption = "--auth-mode";
+        private const string OutputOption = "--output";
         private const string AliasOption = "--alias";
         private const string ConfigOption = "--config";
 


### PR DESCRIPTION
This removes the short flags for `--tenant`, `--clear`, `--domain`, `--auth-mode`, and `--output`.

It also adds a `CHANGELOG.md` in the format described by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/), so that we can start tracking changes between versions.