### PR TITLE
Add option `--prompt-hint` to enable customized header text for WAM prompts and web mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.1.0] - 2022-03-30
 ### Added
 - Initial project release.
-- Option `--caller` to support custom text to prompt caller in web and WAM mode.
+- Option `--prompt-hint` to support custom text to prompt caller in web and WAM mode.
 
 [Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.1.0...HEAD
 [v0.1.0]: https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.1.0] - 2022-03-30
 ### Added
 - Initial project release.
+- Option `--caller` to support custom text to prompt caller in web and WAM mode.
 
 [Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.1.0...HEAD
 [v0.1.0]: https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Option `--prompt-hint` to support custom text to prompt caller in web and WAM mode.
+
 ### Changed
 - Rename the `--auth-mode` flag to `--mode`.
 
@@ -14,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.1.0] - 2022-03-30
 ### Added
 - Initial project release.
-- Option `--prompt-hint` to support custom text to prompt caller in web and WAM mode.
 
 [Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.1.0...HEAD
 [v0.1.0]: https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/v0.1.0

--- a/src/AzureAuth.Test/AliasTest.cs
+++ b/src/AzureAuth.Test/AliasTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Authentication.AzureAuth.Test
             this.alias.Client = "unexpected client";
             this.alias.Domain = "unexpected domain";
             this.alias.Tenant = "unexpected tenant";
-            this.alias.Caller = "unexpected headertext";
+            this.alias.Caller = "unexpected caller";
             this.alias.Scopes = new List<string> { "unexpected scope" };
 
             Alias result = this.alias.Override(this.other);

--- a/src/AzureAuth.Test/AliasTest.cs
+++ b/src/AzureAuth.Test/AliasTest.cs
@@ -74,6 +74,20 @@ namespace Microsoft.Authentication.AzureAuth.Test
         }
 
         /// <summary>
+        /// The test to merge header text.
+        /// </summary>
+        [Test]
+        public void TestMergeHeaderText()
+        {
+            this.alias.Resource = "expected header text";
+            this.expected.Resource = "expected header text";
+
+            Alias result = this.alias.Override(this.other);
+
+            result.Should().BeEquivalentTo(this.expected);
+        }
+
+        /// <summary>
         /// The test to merge multiple members.
         /// </summary>
         [Test]
@@ -100,6 +114,7 @@ namespace Microsoft.Authentication.AzureAuth.Test
             this.alias.Client = "unexpected client";
             this.alias.Domain = "unexpected domain";
             this.alias.Tenant = "unexpected tenant";
+            this.alias.HeaderText = "unexpected headertext";
             this.alias.Scopes = new List<string> { "unexpected scope" };
 
             Alias result = this.alias.Override(this.other);

--- a/src/AzureAuth.Test/AliasTest.cs
+++ b/src/AzureAuth.Test/AliasTest.cs
@@ -74,13 +74,13 @@ namespace Microsoft.Authentication.AzureAuth.Test
         }
 
         /// <summary>
-        /// The test to merge caller text.
+        /// The test to merge prompt hints.
         /// </summary>
         [Test]
-        public void TestMergeCaller()
+        public void TestMergePromptHint()
         {
-            this.alias.Caller = "expected caller text";
-            this.expected.Caller = "expected caller text";
+            this.alias.PromptHint = "expected prompt hint";
+            this.expected.PromptHint = "expected prompt hint";
 
             Alias result = this.alias.Override(this.other);
 
@@ -114,7 +114,7 @@ namespace Microsoft.Authentication.AzureAuth.Test
             this.alias.Client = "unexpected client";
             this.alias.Domain = "unexpected domain";
             this.alias.Tenant = "unexpected tenant";
-            this.alias.Caller = "unexpected caller";
+            this.alias.PromptHint = "unexpected prompt hint";
             this.alias.Scopes = new List<string> { "unexpected scope" };
 
             Alias result = this.alias.Override(this.other);

--- a/src/AzureAuth.Test/AliasTest.cs
+++ b/src/AzureAuth.Test/AliasTest.cs
@@ -74,13 +74,13 @@ namespace Microsoft.Authentication.AzureAuth.Test
         }
 
         /// <summary>
-        /// The test to merge header text.
+        /// The test to merge caller text.
         /// </summary>
         [Test]
-        public void TestMergeHeaderText()
+        public void TestMergeCaller()
         {
-            this.alias.Resource = "expected header text";
-            this.expected.Resource = "expected header text";
+            this.alias.Caller = "expected caller text";
+            this.expected.Caller = "expected caller text";
 
             Alias result = this.alias.Override(this.other);
 
@@ -114,7 +114,7 @@ namespace Microsoft.Authentication.AzureAuth.Test
             this.alias.Client = "unexpected client";
             this.alias.Domain = "unexpected domain";
             this.alias.Tenant = "unexpected tenant";
-            this.alias.HeaderText = "unexpected headertext";
+            this.alias.Caller = "unexpected headertext";
             this.alias.Scopes = new List<string> { "unexpected scope" };
 
             Alias result = this.alias.Override(this.other);

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -34,7 +34,7 @@ client = ""73e5793e-8f71-4da2-9f71-575cb3019b37""
 domain = ""contoso.com""
 tenant = ""a3be859b-7f9a-4955-98ed-f3602dbd954c""
 scopes = [ "".default"", ]
-header_text = ""sample header text.""
+caller = ""sample caller text.""
 ";
 
         private const string PartialAliasTOML = @"
@@ -163,7 +163,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                HeaderText = "sample header text.",
+                Caller = "sample caller text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -190,7 +190,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                HeaderText = "sample header text.",
+                Caller = "sample caller text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -220,7 +220,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                HeaderText = "sample header text.",
+                Caller = "sample caller text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -34,7 +34,7 @@ client = ""73e5793e-8f71-4da2-9f71-575cb3019b37""
 domain = ""contoso.com""
 tenant = ""a3be859b-7f9a-4955-98ed-f3602dbd954c""
 scopes = [ "".default"", ]
-caller = ""sample caller text.""
+prompt_hint = ""sample prompt hint.""
 ";
 
         private const string PartialAliasTOML = @"
@@ -163,7 +163,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                Caller = "sample caller text.",
+                PromptHint = "sample prompt hint.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -190,7 +190,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                Caller = "sample caller text.",
+                PromptHint = "sample prompt hint.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -220,7 +220,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
-                Caller = "sample caller text.",
+                PromptHint = "sample prompt hint.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -34,6 +34,7 @@ client = ""73e5793e-8f71-4da2-9f71-575cb3019b37""
 domain = ""contoso.com""
 tenant = ""a3be859b-7f9a-4955-98ed-f3602dbd954c""
 scopes = [ "".default"", ]
+header_text = ""sample header text.""
 ";
 
         private const string PartialAliasTOML = @"
@@ -162,6 +163,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
+                HeaderText = "sample header text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -188,6 +190,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
+                HeaderText = "sample header text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -217,6 +220,7 @@ invalid_key = ""this is not a valid alias key""
                 Domain = "contoso.com",
                 Tenant = "a3be859b-7f9a-4955-98ed-f3602dbd954c",
                 Scopes = new List<string> { ".default" },
+                HeaderText = "sample header text.",
             };
 
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();

--- a/src/AzureAuth/Alias.cs
+++ b/src/AzureAuth/Alias.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Authentication.AzureAuth
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized caller name (WAM prompts and web mode only).
+        /// Gets or sets the customized prompt hint.
         /// </summary>
-        public string Caller { get; set; }
+        public string PromptHint { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes.
@@ -58,7 +58,7 @@ namespace Microsoft.Authentication.AzureAuth
                 Client = other.Client ?? this.Client,
                 Domain = other.Domain ?? this.Domain,
                 Tenant = other.Tenant ?? this.Tenant,
-                Caller = other.Caller ?? this.Caller,
+                PromptHint = other.PromptHint ?? this.PromptHint,
                 Scopes = other.Scopes ?? this.Scopes,
             };
         }

--- a/src/AzureAuth/Alias.cs
+++ b/src/AzureAuth/Alias.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Authentication.AzureAuth
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized header text.
+        /// Gets or sets the customized header text (WAM prompts only).
         /// </summary>
         public string HeaderText { get; set; }
 

--- a/src/AzureAuth/Alias.cs
+++ b/src/AzureAuth/Alias.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Authentication.AzureAuth
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized header text (WAM prompts only).
+        /// Gets or sets the customized caller name (WAM prompts and web mode only).
         /// </summary>
-        public string HeaderText { get; set; }
+        public string Caller { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes.
@@ -58,7 +58,7 @@ namespace Microsoft.Authentication.AzureAuth
                 Client = other.Client ?? this.Client,
                 Domain = other.Domain ?? this.Domain,
                 Tenant = other.Tenant ?? this.Tenant,
-                HeaderText = other.HeaderText ?? this.HeaderText,
+                Caller = other.Caller ?? this.Caller,
                 Scopes = other.Scopes ?? this.Scopes,
             };
         }

--- a/src/AzureAuth/Alias.cs
+++ b/src/AzureAuth/Alias.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Authentication.AzureAuth
         public string Tenant { get; set; }
 
         /// <summary>
+        /// Gets or sets the customized header text.
+        /// </summary>
+        public string HeaderText { get; set; }
+
+        /// <summary>
         /// Gets or sets the scopes.
         /// </summary>
         public List<string> Scopes { get; set; }
@@ -52,6 +57,7 @@ namespace Microsoft.Authentication.AzureAuth
                 Client = other.Client ?? this.Client,
                 Domain = other.Domain ?? this.Domain,
                 Tenant = other.Tenant ?? this.Tenant,
+                HeaderText = other.HeaderText ?? this.HeaderText,
                 Scopes = other.Scopes ?? this.Scopes,
             };
         }

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Authentication.AzureAuth
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
         private const string TenantOption = "-t|--tenant";
-        private const string HeaderTextOption = "--header";
+        private const string HeaderTextOption = "--header-text";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "-c|--clear";
         private const string DomainOption = "-d|--domain";

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Authentication.AzureAuth
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
         private const string TenantOption = "--tenant";
-        private const string HeaderTextOption = "--header-text";
+        private const string CallerOption = "--caller";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "--clear";
         private const string DomainOption = "--domain";
@@ -103,8 +103,8 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets the customized header text for WAM prompts.
         /// </summary>
-        [Option(HeaderTextOption, "The customized header text for WAM prompts only", CommandOptionType.SingleValue)]
-        public string HeaderText { get; set; }
+        [Option(CallerOption, "The caller name text for WAM prompts and web ", CommandOptionType.SingleValue)]
+        public string Caller { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes.
@@ -174,7 +174,7 @@ Allowed values: [all, web, devicecode]";
                 Client = this.Client,
                 Domain = this.PreferredDomain,
                 Tenant = this.Tenant,
-                HeaderText = this.HeaderText,
+                Caller = this.Caller,
                 Scopes = this.Scopes?.ToList(),
             };
 
@@ -321,7 +321,7 @@ Allowed values: [all, web, devicecode]";
                     new Guid(this.tokenFetcherOptions.Tenant),
                     osxKeyChainSuffix: Constants.AuthOSXKeyChainSuffix,
                     preferredDomain: this.tokenFetcherOptions.Domain,
-                    headerText: this.HeaderText);
+                    caller: this.Caller);
             }
 
             return this.tokenFetcher;

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Authentication.AzureAuth
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
         private const string TenantOption = "-t|--tenant";
-        private const string HeaderTextOption = "-h|--header";
+        private const string HeaderTextOption = "--header";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "-c|--clear";
         private const string DomainOption = "-d|--domain";
@@ -101,9 +101,9 @@ Allowed values: [all, web, devicecode]";
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized header text.
+        /// Gets or sets the customized header text for WAM prompts.
         /// </summary>
-        [Option(HeaderTextOption, "the customized header text", CommandOptionType.SingleValue)]
+        [Option(HeaderTextOption, "the customized header text for WAM prompts only", CommandOptionType.SingleValue)]
         public string HeaderText { get; set; }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Authentication.AzureAuth
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
         private const string TenantOption = "--tenant";
-        private const string CallerOption = "--caller";
+        private const string PromptHintOption = "--prompt-hint";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "--clear";
         private const string DomainOption = "--domain";
@@ -106,10 +106,10 @@ Allowed values: [all, web, devicecode]";
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized header text for WAM prompts and web mode.
+        /// Gets or sets the customized prompt hint text for WAM prompts and web mode.
         /// </summary>
-        [Option(CallerOption, "The caller name text for WAM prompts and web mode.", CommandOptionType.SingleValue)]
-        public string Caller { get; set; }
+        [Option(PromptHintOption, "The prompt hint text for WAM prompts and web mode.", CommandOptionType.SingleValue)]
+        public string PromptHint { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes.
@@ -179,7 +179,7 @@ Allowed values: [all, web, devicecode]";
                 Client = this.Client,
                 Domain = this.PreferredDomain,
                 Tenant = this.Tenant,
-                Caller = this.Caller,
+                PromptHint = this.PromptHint,
                 Scopes = this.Scopes?.ToList(),
             };
 
@@ -367,7 +367,7 @@ Allowed values: [all, web, devicecode]";
                     new Guid(this.tokenFetcherOptions.Tenant),
                     osxKeyChainSuffix: Constants.AuthOSXKeyChainSuffix,
                     preferredDomain: this.tokenFetcherOptions.Domain,
-                    caller: this.Caller);
+                    promptHint: this.PromptHint);
             }
 
             return this.tokenFetcher;

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -101,9 +101,9 @@ Allowed values: [all, web, devicecode]";
         public string Tenant { get; set; }
 
         /// <summary>
-        /// Gets or sets the customized header text for WAM prompts.
+        /// Gets or sets the customized header text for WAM prompts and web mode.
         /// </summary>
-        [Option(CallerOption, "The caller name text for WAM prompts and web ", CommandOptionType.SingleValue)]
+        [Option(CallerOption, "The caller name text for WAM prompts and web mode.", CommandOptionType.SingleValue)]
         public string Caller { get; set; }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Authentication.AzureAuth
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
         private const string TenantOption = "-t|--tenant";
+        private const string HeaderTextOption = "-h|--header";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "-c|--clear";
         private const string DomainOption = "-d|--domain";
@@ -100,6 +101,12 @@ Allowed values: [all, web, devicecode]";
         public string Tenant { get; set; }
 
         /// <summary>
+        /// Gets or sets the customized header text.
+        /// </summary>
+        [Option(HeaderTextOption, "the customized header text", CommandOptionType.SingleValue)]
+        public string HeaderText { get; set; }
+
+        /// <summary>
         /// Gets or sets the scopes.
         /// </summary>
         [Option(ScopeOption, "Scopes to request. By default, the only scope requested is <resource ID>\\.default.\nPassing in one or more values here will override the default.", CommandOptionType.MultipleValue)]
@@ -167,6 +174,7 @@ Allowed values: [all, web, devicecode]";
                 Client = this.Client,
                 Domain = this.PreferredDomain,
                 Tenant = this.Tenant,
+                HeaderText = this.HeaderText,
                 Scopes = this.Scopes?.ToList(),
             };
 
@@ -312,7 +320,8 @@ Allowed values: [all, web, devicecode]";
                     new Guid(this.tokenFetcherOptions.Client),
                     new Guid(this.tokenFetcherOptions.Tenant),
                     osxKeyChainSuffix: Constants.AuthOSXKeyChainSuffix,
-                    preferredDomain: this.tokenFetcherOptions.Domain);
+                    preferredDomain: this.tokenFetcherOptions.Domain,
+                    headerText: this.HeaderText);
             }
 
             return this.tokenFetcher;

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -103,7 +103,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets the customized header text for WAM prompts.
         /// </summary>
-        [Option(HeaderTextOption, "the customized header text for WAM prompts only", CommandOptionType.SingleValue)]
+        [Option(HeaderTextOption, "The customized header text for WAM prompts only", CommandOptionType.SingleValue)]
         public string HeaderText { get; set; }
 
         /// <summary>

--- a/src/MSALWrapper.Test/TokenFetcherPublicClientTest.cs
+++ b/src/MSALWrapper.Test/TokenFetcherPublicClientTest.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         /// <summary>
-        /// .
+        /// Ensure <see cref="IPCAWrapper.WithPromptHint"/> be invoked in <see cref="TokenFetcherPublicClient.GetTokenNormalFlowAsync"/>.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
         [Test]

--- a/src/MSALWrapper.Test/TokenFetcherPublicClientTest.cs
+++ b/src/MSALWrapper.Test/TokenFetcherPublicClientTest.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
         private TokenResult tokenResult;
 
+        private string promptHint = "test prompt hint";
+
         /// <summary>
         /// The setup.
         /// </summary>
@@ -73,7 +75,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .AddTransient<TokenFetcherPublicClient>((provider) =>
              {
                  var logger = provider.GetService<ILogger<TokenFetcherPublicClient>>();
-                 return new TokenFetcherPublicClient(logger, ResourceId, ClientId, TenantId);
+                 return new TokenFetcherPublicClient(logger, ResourceId, ClientId, TenantId, promptHint: this.promptHint);
              })
              .BuildServiceProvider();
 
@@ -372,6 +374,25 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         /// <summary>
+        /// .
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Test]
+        public async Task GetTokenNormalFlowAsync_GetTokenInteractive_WithPromptHint()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthResult();
+
+            // Act
+            var tokenFetcher = this.Subject();
+            var result = await tokenFetcher.GetTokenNormalFlowAsync(this.pcaMock.Object, this.scopes, this.testAccount.Object);
+
+            // Verify
+            this.pcaMock.Verify((pca) => pca.WithPromptHint(this.promptHint), Times.Once());
+            this.pcaMock.VerifyAll();
+        }
+
+        /// <summary>
         /// The get token_ device code_ flow_ happy path.
         /// </summary>
         [Test]
@@ -556,6 +577,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "UI is required"));
+            this.SetupInteractiveAuthWithPromptHint();
         }
 
         private void SilentAuthServiceException()
@@ -626,6 +648,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaMock
                 .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
+        }
+
+        private void SetupInteractiveAuthWithPromptHint()
+        {
+            this.pcaMock
+                .Setup(pca => pca.WithPromptHint(It.IsAny<string>()))
+                .Returns((string s) => this.pcaMock.Object);
         }
 
         private TokenFetcherPublicClient Subject() => this.serviceProvider.GetService<TokenFetcherPublicClient>();

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -83,6 +83,13 @@ namespace Microsoft.Authentication.MSALWrapper
         /// The <see cref="Task"/>.
         /// </returns>
         Task<TokenResult> GetTokenDeviceCodeAsync(IEnumerable<string> scopes, Func<DeviceCodeResult, Task> callback, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Customize the title bar by prompt hint(Web mode only).
+        /// </summary>
+        /// <param name="promptHint">The prompt hint text.</param>
+        /// <returns>This.</returns>
+        IPCAWrapper WithPromptHint(string promptHint);
     }
 
     /// <summary>
@@ -116,7 +123,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         /// <param name="promptHint">see <see cref="PromptHint"/>.</param>
         /// <returns>This.</returns>
-        public PCAWrapper WithPromptHint(string promptHint)
+        public IPCAWrapper WithPromptHint(string promptHint)
         {
             this.PromptHint = promptHint;
             return this;

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -107,18 +107,18 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
-        /// Gets or sets, The name of the caller displayed in the title bar.
+        /// Gets or sets, The prompt hint displayed in the title bar.
         /// </summary>
-        public string Caller { get; set; }
+        public string PromptHint { get; set; }
 
         /// <summary>
-        /// Customize the title bar by caller name(Web mode only).
+        /// Customize the title bar by prompt hint(Web mode only).
         /// </summary>
-        /// <param name="caller">see <see cref="Caller"/>.</param>
+        /// <param name="promptHint">see <see cref="PromptHint"/>.</param>
         /// <returns>This.</returns>
-        public PCAWrapper WithCallerName(string caller)
+        public PCAWrapper WithPromptHint(string promptHint)
         {
-            this.Caller = caller;
+            this.PromptHint = promptHint;
             return this;
         }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 .AcquireTokenInteractive(scopes)
                 .WithEmbeddedWebViewOptions(new EmbeddedWebViewOptions()
                 {
-                    Title = this.Caller,
+                    Title = this.PromptHint,
                 })
                 .WithAccount(account)
                 .ExecuteAsync(cancellationToken)
@@ -193,7 +193,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 .AcquireTokenInteractive(scopes)
                 .WithEmbeddedWebViewOptions(new EmbeddedWebViewOptions()
                 {
-                    Title = this.Caller,
+                    Title = this.PromptHint,
                 })
                 .WithClaims(claims)
                 .ExecuteAsync(cancellationToken)

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -107,6 +107,22 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
+        /// Gets or sets, The name of the caller displayed in the title bar.
+        /// </summary>
+        public string Caller { get; set; }
+
+        /// <summary>
+        /// Customize the title bar by caller name(Web mode only).
+        /// </summary>
+        /// <param name="caller">see <see cref="Caller"/>.</param>
+        /// <returns>This.</returns>
+        public PCAWrapper WithCallerName(string caller)
+        {
+            this.Caller = caller;
+            return this;
+        }
+
+        /// <summary>
         /// The get token silent async.
         /// </summary>
         /// <param name="scopes">
@@ -146,6 +162,10 @@ namespace Microsoft.Authentication.MSALWrapper
         {
             AuthenticationResult result = await this.pca
                 .AcquireTokenInteractive(scopes)
+                .WithEmbeddedWebViewOptions(new EmbeddedWebViewOptions()
+                {
+                    Title = this.Caller,
+                })
                 .WithAccount(account)
                 .ExecuteAsync(cancellationToken)
                 .ConfigureAwait(false);
@@ -171,6 +191,10 @@ namespace Microsoft.Authentication.MSALWrapper
         {
             AuthenticationResult result = await this.pca
                 .AcquireTokenInteractive(scopes)
+                .WithEmbeddedWebViewOptions(new EmbeddedWebViewOptions()
+                {
+                    Title = this.Caller,
+                })
                 .WithClaims(claims)
                 .ExecuteAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Authentication.MSALWrapper
         private readonly bool windows;
         private readonly bool windows10;
 
-        private readonly string headerText;
+        private readonly string caller;
 
         #region Required MSAL GUIDs
 
@@ -118,10 +118,10 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <param name="verifyPersistence">
         /// Optionally choose to verify the cache persistence layer when setting up the token cache.
         /// </param>
-        /// <param name="headerText">
+        /// <param name="caller">
         /// The customized header text in account picker for WAM prompts.
         /// </param>
-        public TokenFetcherPublicClient(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false, string headerText = null)
+        public TokenFetcherPublicClient(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false, string caller = null)
         {
             this.windows = PlatformUtils.IsWindows(logger);
             this.windows10 = PlatformUtils.IsWindows10(logger);
@@ -131,7 +131,7 @@ namespace Microsoft.Authentication.MSALWrapper
             this.resourceId = resourceId;
             this.clientId = clientId;
 
-            this.headerText = headerText;
+            this.caller = caller;
 
             this.osxKeyChainSuffix = osxKeyChainSuffix;
             this.verifyPersistence = verifyPersistence;
@@ -235,7 +235,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 var pca = this.PCABroker();
                 var pcaWrapper = new PCAWrapper(pca);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? PublicClientApplication.OperatingSystemAccount;
-                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
+                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, null);
             }
 
             if (result is null && authMode.IsWeb())
@@ -471,7 +471,6 @@ namespace Microsoft.Authentication.MSALWrapper
                 .WithHttpClientFactory(httpFactoryAdaptor)
                 .WithRedirectUri(Constants.AadRedirectUri.ToString())
                 .Build();
-
             this.SetupTokenCache(pca);
             return pca;
         }
@@ -481,7 +480,7 @@ namespace Microsoft.Authentication.MSALWrapper
             var pcaBuilder = this.PCABase();
             pcaBuilder.WithWindowsBrokerOptions(new WindowsBrokerOptions
             {
-                HeaderText = this.headerText,
+                HeaderText = this.caller,
             });
 
 #if NETFRAMEWORK

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -241,8 +241,7 @@ namespace Microsoft.Authentication.MSALWrapper
             {
                 this.logger.LogDebug("Trying Web Auth flow.");
                 var pca = this.PCAWeb();
-                var pcaWrapper = new PCAWrapper(pca)
-                    .WithPromptHint(this.promptHint);
+                var pcaWrapper = new PCAWrapper(pca);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? null;
                 result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
             }
@@ -342,7 +341,9 @@ namespace Microsoft.Authentication.MSALWrapper
                         var tokenResult = await this.CompleteWithin(
                             this.interactiveAuthTimeout,
                             "Interactive Auth",
-                            (cancellationToken) => pcaWrapper.GetTokenInteractiveAsync(scopes, account, cancellationToken)) // TODO: Need to pass account here
+                            (cancellationToken) => pcaWrapper
+                            .WithPromptHint(this.promptHint)
+                            .GetTokenInteractiveAsync(scopes, account, cancellationToken)) // TODO: Need to pass account here
                             .ConfigureAwait(false);
                         this.SetAuthenticationType(tokenResult, AuthType.Interactive);
                         return tokenResult;
@@ -355,7 +356,9 @@ namespace Microsoft.Authentication.MSALWrapper
                     var tokenResult = await this.CompleteWithin(
                         this.interactiveAuthTimeout,
                         "Interactive Auth (with extra claims)",
-                        (cancellationToken) => pcaWrapper.GetTokenInteractiveAsync(scopes, ex.Claims, cancellationToken))
+                        (cancellationToken) => pcaWrapper
+                        .WithPromptHint(this.promptHint)
+                        .GetTokenInteractiveAsync(scopes, ex.Claims, cancellationToken))
                         .ConfigureAwait(false);
                     this.SetAuthenticationType(tokenResult, AuthType.Interactive);
                     return tokenResult;

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -235,14 +235,15 @@ namespace Microsoft.Authentication.MSALWrapper
                 var pca = this.PCABroker();
                 var pcaWrapper = new PCAWrapper(pca);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? PublicClientApplication.OperatingSystemAccount;
-                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, null);
+                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
             }
 
             if (result is null && authMode.IsWeb())
             {
                 this.logger.LogDebug("Trying Web Auth flow.");
                 var pca = this.PCAWeb();
-                var pcaWrapper = new PCAWrapper(pca);
+                var pcaWrapper = new PCAWrapper(pca)
+                    .WithCallerName(this.caller);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? null;
                 result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
             }

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -490,7 +490,6 @@ namespace Microsoft.Authentication.MSALWrapper
             pcaBuilder.WithBroker();
 #endif
             var pca = pcaBuilder.Build();
-
             this.SetupTokenCache(pca);
             return pca;
         }

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Authentication.MSALWrapper
         private readonly bool windows;
         private readonly bool windows10;
 
-        private readonly string caller;
+        private readonly string promptHint;
 
         #region Required MSAL GUIDs
 
@@ -117,10 +117,10 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <param name="verifyPersistence">
         /// Optionally choose to verify the cache persistence layer when setting up the token cache.
         /// </param>
-        /// <param name="caller">
+        /// <param name="promptHint">
         /// The customized header text in account picker for WAM prompts.
         /// </param>
-        public TokenFetcherPublicClient(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false, string caller = null)
+        public TokenFetcherPublicClient(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false, string promptHint = null)
         {
             this.windows = PlatformUtils.IsWindows(logger);
             this.windows10 = PlatformUtils.IsWindows10(logger);
@@ -130,7 +130,7 @@ namespace Microsoft.Authentication.MSALWrapper
             this.resourceId = resourceId;
             this.clientId = clientId;
 
-            this.caller = caller;
+            this.promptHint = promptHint;
 
             this.osxKeyChainSuffix = osxKeyChainSuffix;
             this.verifyPersistence = verifyPersistence;
@@ -242,7 +242,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 this.logger.LogDebug("Trying Web Auth flow.");
                 var pca = this.PCAWeb();
                 var pcaWrapper = new PCAWrapper(pca)
-                    .WithCallerName(this.caller);
+                    .WithPromptHint(this.promptHint);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? null;
                 result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
             }
@@ -481,7 +481,7 @@ namespace Microsoft.Authentication.MSALWrapper
             var pcaBuilder = this.PCABase();
             pcaBuilder.WithWindowsBrokerOptions(new WindowsBrokerOptions
             {
-                HeaderText = this.caller,
+                HeaderText = this.promptHint,
             });
 
 #if NETFRAMEWORK

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Authentication.MSALWrapper
         public readonly string Authority;
         private readonly Guid resourceId;
         private readonly Guid clientId;
-
         #endregion
 
         #region Public configurable properties
@@ -472,6 +471,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 .WithHttpClientFactory(httpFactoryAdaptor)
                 .WithRedirectUri(Constants.AadRedirectUri.ToString())
                 .Build();
+
             this.SetupTokenCache(pca);
             return pca;
         }

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Optionally choose to verify the cache persistence layer when setting up the token cache.
         /// </param>
         /// <param name="headerText">
-        /// The customized header text in account picker.
+        /// The customized header text in account picker for WAM prompts.
         /// </param>
         public TokenFetcherPublicClient(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false, string headerText = null)
         {
@@ -235,7 +235,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 var pca = this.PCABroker();
                 var pcaWrapper = new PCAWrapper(pca);
                 IAccount account = await this.TryToGetCachedAccountAsync(pca, this.preferredDomain).ConfigureAwait(false) ?? PublicClientApplication.OperatingSystemAccount;
-                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, null);
+                result = await this.GetTokenNormalFlowAsync(pcaWrapper, scopes, account);
             }
 
             if (result is null && authMode.IsWeb())
@@ -470,10 +470,6 @@ namespace Microsoft.Authentication.MSALWrapper
             var pca = this.PCABase()
                 .WithHttpClientFactory(httpFactoryAdaptor)
                 .WithRedirectUri(Constants.AadRedirectUri.ToString())
-                .WithWindowsBrokerOptions(new WindowsBrokerOptions
-                {
-                    HeaderText = this.headerText,
-                })
                 .Build();
 
             this.SetupTokenCache(pca);


### PR DESCRIPTION
# Overview
Taking advantage of this feature will give us a small UX improvement to let WAM based dialogs show header text to indicate what application is requesting auth. When an Auth prompt launches either by native window or web prompt, it’s often hard to know what actually triggered it. Enabling header text in WAM window could help users to know that.
Ref: [microsoft-authentication-library-for-dotnet #3125](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3125)
# Change log
Add option `--prompt-hint` in command line and option `prompt_hint` in TOML config file.
# Test Case
``` cmd
--debug --resource=6e979987-a7c8-4604-9b37-e51f06f08f1a --client=5af6def2-05ec-4cab-b9aa-323d75b5df40 --tenant=9188040d-6c67-4c5b-b112-36a304b66dad --mode=broker --prompt-hint="test header text"
```
## Note
The resource ID `1a0aa568-29b5-4a0c-b895-89da91675dcc` and client ID `c332fbf4-f566-4550-ba1f-83a2f68fe068` are randomly generated. The tenant ID `9188040d-6c67-4c5b-b112-36a304b66dad` is Microsoft account tenant ID. See [Microsoft identity platform access tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens).
## Overcome Sample
![image](https://user-images.githubusercontent.com/6624474/161361114-3eaab88f-dd48-4605-8646-850991783b84.png)

# Update on Apr 7th, 2022:
Per discussed with @kyle-rader, `caller` is a better name than `header-text`. With API `WithEmbeddedWebViewOptions`, the title in web mode can also be modified. Therefore, web mode can be also supported.

## Web Mode Overcome
![image](https://user-images.githubusercontent.com/6624474/162278170-05708a9e-0a7e-4644-b639-f651bab2baf4.png)

# Update on Apr 13th, 2022:
* The final option name is `--prompt-hint`.
* Unit tests have been added.
