### PR TITLE
Add installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,22 @@ On Windows we provide a PowerShell bootstrap script, which will download and ext
 means of downloading the latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION`
 environment variable.
 
-To install the application, set the environment variable (`v0.1.0` is an example. See
-[releases](https://github.com/AzureAD/microsoft-authentication-cli/releases) for the latest).
+To install the application, run
 
 ```powershell
+# v0.1.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 $env:AZUREAUTH_VERSION = 'v0.1.0'
+iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) } -Verbose"
 ```
 
-Then execute the installation script (excuse the verbosity, we avoided using `Invoke-Expression`).
+Or, if you want a method more resilient to failure than `Invoke-Expression`, run
 
 ```powershell
-$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'; $script = "${env:TEMP}\install.ps1"; irm $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
+# v0.1.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = 'v0.1.0'
+$script = "${env:TEMP}\install.ps1"
+$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'
+Invoke-WebRequest $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
 ```
 
 **Note**: The script does not signal currently running processes to update their environments, so you'll need to
@@ -44,15 +49,11 @@ On macOS we provide a shell bootstrap script, which will download and extract th
 and automatically add the `azureauth` binary to your `$PATH`. We don't currently provide a means of downloading the
 latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION` environment variable.
 
-To install the application, set the environment variable (`v0.1.0` is an example. See
-[releases](https://github.com/AzureAD/microsoft-authentication-cli/releases) for the latest).
+To install the application, run
+
 ```bash
+# v0.1.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 export AZUREAUTH_VERSION='v0.1.0'
-```
-
-Then execute the installation script.
-
-```bash
 curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authenticatio
 **Note**: The script does not signal currently running processes to update their environments, so you'll need to
 relaunch applications before the `$PATH` changes take effect.
 
+## macOS
+
+On macOS we provide a shell bootstrap script, which will download and extract the application to `$HOME/.azureauth`
+and automatically add the `azureauth` binary to your `$PATH`. We don't currently provide a means of downloading the
+latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION` environment variable.
+
+To install the application, run
+
+```bash
+# v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+export AZUREAUTH_VERSION='v0.1.0'
+curl https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
+```
+
+**Note**: The script currently only updates the `$PATH` in `~/.bashrc` and `~/.zshrc`. It does not update the environment
+of currently running processes, so you'll need to relaunch applications (or source your shell profile) before the `$PATH`
+changes take effect.
+
 # Data Collection
 
 The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ To install the application, run
 ```powershell
 # v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 $env:AZUREAUTH_VERSION = 'v0.1.0'
-iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) }"
+$script = "${env:TEMP}\install.ps1"
+$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'
+irm $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
 ```
 
 **Note**: The script does not signal currently running processes to update their environments, so you'll need to

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ The CLI is designed for authenticating and returning an access token for public 
 | Ubuntu (linux)   | ❌ (not yet) | ✅ | ✅ | ✅ | ❌ (not yet) |
 <br/>
 
+# Installation
+
+## Windows
+
+On Windows we provide a PowerShell bootstrap script, which will download and extract the application to
+`%LOCALAPPDATA%\AzureAuth` and automatically add the `azureauth` binary to your `$PATH`. We don't currently provide a
+means of downloading the latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION`
+environment variable.
+
+To install the application, run
+
+```powershell
+# v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = 'v0.1.0'
+iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) }"
+```
+
+**Note**: The script does not signal currently running processes to update their environments, so you'll need to
+relaunch applications before the `$PATH` changes take effect.
+
 # Data Collection
 
 The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use

--- a/README.md
+++ b/README.md
@@ -22,14 +22,17 @@ On Windows we provide a PowerShell bootstrap script, which will download and ext
 means of downloading the latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION`
 environment variable.
 
-To install the application, run
+To install the application, set the environment variable (`v0.1.0` is an example. See
+[releases](https://github.com/AzureAD/microsoft-authentication-cli/releases) for the latest).
 
 ```powershell
-# v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 $env:AZUREAUTH_VERSION = 'v0.1.0'
-$script = "${env:TEMP}\install.ps1"
-$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'
-irm $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
+```
+
+Then execute the installation script (excuse the verbosity, we avoided using `Invoke-Expression`).
+
+```powershell
+$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'; $script = "${env:TEMP}\install.ps1"; irm $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
 ```
 
 **Note**: The script does not signal currently running processes to update their environments, so you'll need to
@@ -41,11 +44,15 @@ On macOS we provide a shell bootstrap script, which will download and extract th
 and automatically add the `azureauth` binary to your `$PATH`. We don't currently provide a means of downloading the
 latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION` environment variable.
 
-To install the application, run
+To install the application, set the environment variable (`v0.1.0` is an example. See
+[releases](https://github.com/AzureAD/microsoft-authentication-cli/releases) for the latest).
+```bash
+export AZUREAUTH_VERSION='v0.1.0'
+```
+
+Then execute the installation script.
 
 ```bash
-# v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-export AZUREAUTH_VERSION='v0.1.0'
 curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The CLI is designed for authenticating and returning an access token for public 
 ## Windows
 
 On Windows we provide a PowerShell bootstrap script, which will download and extract the application to
-`%LOCALAPPDATA%\AzureAuth` and automatically add the `azureauth` binary to your `$PATH`. We don't currently provide a
-means of downloading the latest release, so you **must** specify your desired version via the `$AZUREAUTH_VERSION`
-environment variable.
+`%LOCALAPPDATA%\Programs\AzureAuth` and automatically add the `azureauth` binary to your `$PATH`. We don't currently
+provide a means of downloading the latest release, so you **must** specify your desired version via the
+`$AZUREAUTH_VERSION` environment variable.
 
 To install the application, run
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To install the application, run
 ```bash
 # v0.1.0 is just an example here. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 export AZUREAUTH_VERSION='v0.1.0'
-curl https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
+curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
 ```
 
 **Note**: The script currently only updates the `$PATH` in `~/.bashrc` and `~/.zshrc`. It does not update the environment

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -33,12 +33,17 @@ Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
 $client = New-Object System.Net.WebClient
 $client.DownloadFile($releaseUrl, $zipFile)
 
+if (Test-Path -Path $extractedDirectory) {
+    Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"
+    Remove-Item -Force -Recurse $extractedDirectory
+}
+
 if (Test-Path -Path $targetDirectory) {
     Write-Verbose "Removing pre-existing target directory at ${targetDirectory}"
     Remove-Item -Force -Recurse $targetDirectory
 }
 
-Write-Verbose "Extracting ${zipFile} to ${targetDirectory}"
+Write-Verbose "Extracting ${zipFile} to ${extractedDirectory}"
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
 
@@ -46,6 +51,7 @@ Write-Verbose "Removing ${zipFile}"
 Remove-Item -Force $zipFile
 
 # The zip file is extracted to a directory with the same base name. Rename the extracted directory to match the version.
+Write-Verbose "Renaming ${extractedDirectory} to ${targetDirectory}"
 Rename-Item $extractedDirectory $targetDirectory
 
 # Symlink latest directory.

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,65 @@
+# Enable a default -Verbose flag for debug output.
+[CmdletBinding()]
+Param()
+
+# Halt script execution at the first failed command.
+$script:ErrorActionPreference='Stop'
+
+# We don't currently have good cross-platform options for determining the latest release version, so we require
+# knowledge of the specific target version, which the user should set as an environment variable.
+$version = $Env:AZUREAUTH_VERSION
+if ($null -eq $version) {
+    # Write-Error is terminal with ErrorActionPreference='Stop', so we continue to hit the exit
+    # and set an exit code.
+    Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release' -ErrorAction:Continue
+    exit 1
+}
+
+$repo = ($null -eq $Env:AZUREAUTH_REPO) ? 'AzureAD/microsoft-authentication-cli' : $Env:AZUREAUTH_REPO
+$releaseName = "azureauth-${version}-win10-x64"
+$releaseFile = "${releaseName}.zip"
+$releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
+
+$azureauthDirectory = ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "AzureAuth"))
+$extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
+$targetDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $version))
+$latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))
+$zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
+
+Write-Verbose "Creating ${azureauthDirectory}"
+$null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
+
+Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
+$client = New-Object System.Net.WebClient
+$client.DownloadFile($releaseUrl, $zipFile)
+
+if (Test-Path -Path $targetDirectory) {
+    Write-Verbose "Removing pre-existing target directory at ${targetDirectory}"
+    Remove-Item -Force -Recurse $targetDirectory
+}
+
+Write-Verbose "Extracting ${zipFile} to ${targetDirectory}"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
+
+Write-Verbose "Removing ${zipFile}"
+Remove-Item -Force $zipFile
+
+# The zip file is extracted to a directory with the same base name. Rename the extracted directory to match the version.
+Rename-Item $extractedDirectory $targetDirectory
+
+# Symlink latest directory.
+Write-Verbose "Linking ${latestDirectory} to ${targetDirectory}"
+$null = New-Item -ItemType SymbolicLink -Force -Path $latestDirectory -Target $targetDirectory
+
+# Permanently add the latest directory to the current user's $PATH (if it's not already there).
+# Note that this will only take effect when a new terminal is started.
+$registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
+$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH).Path
+if ($currentPath -NotMatch 'AzureAuth') {
+    Write-Verbose "Updating `$PATH to include ${latestDirectory}"
+    $newPath = "${currentPath};${latestDirectory}"
+    Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+}
+
+Write-Output "Installed azureauth $version!"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -9,10 +9,7 @@ $script:ErrorActionPreference='Stop'
 # knowledge of the specific target version, which the user should set as an environment variable.
 $version = $Env:AZUREAUTH_VERSION
 if ($null -eq $version) {
-    # Write-Error is terminal with ErrorActionPreference='Stop', so we continue to hit the exit
-    # and set an exit code.
-    Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release' -ErrorAction:Continue
-    exit 1
+    Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release'
 }
 
 $repo = if ($null -eq $Env:AZUREAUTH_REPO) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -8,16 +8,16 @@ $script:ErrorActionPreference='Stop'
 # We don't currently have good cross-platform options for determining the latest release version, so we require
 # knowledge of the specific target version, which the user should set as an environment variable.
 $version = $Env:AZUREAUTH_VERSION
-if ($null -eq $version) {
+if ([string]::IsNullOrEmpty($version)) {
     Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release'
 }
 
-$repo = if ($null -eq $Env:AZUREAUTH_REPO) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
+$repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
 $releaseName = "azureauth-${version}-win10-x64"
 $releaseFile = "${releaseName}.zip"
 $releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
 
-$azureauthDirectory = ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "AzureAuth"))
+$azureauthDirectory = ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "Programs", "AzureAuth"))
 $extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
 $targetDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $version))
 $latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -15,7 +15,7 @@ if ($null -eq $version) {
     exit 1
 }
 
-$repo = ($null -eq $Env:AZUREAUTH_REPO) ? 'AzureAD/microsoft-authentication-cli' : $Env:AZUREAUTH_REPO
+$repo = if ($null -eq $Env:AZUREAUTH_REPO) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
 $releaseName = "azureauth-${version}-win10-x64"
 $releaseFile = "${releaseName}.zip"
 $releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+set -e
+
+# We use an env var for this rather than --verbose because getopt is not reliably cross-platform.
+: ${AZUREAUTH_VERBOSE_INSTALL=""}
+verbose() {
+    if [ -n "${AZUREAUTH_VERBOSE_INSTALL}" ]; then
+        >&2 printf "\x1b[33m${1}\x1b[0m\n"
+    fi
+}
+error() { >&2 printf "\x1b[31m${1}\x1b[0m\n"; }
+
+version="${AZUREAUTH_VERSION}"
+if [ -z "${version}" ]; then
+    error 'No $AZUREAUTH_VERSION specified, unable to download a release'
+    exit 1
+fi
+
+# Parse the OS info from uname into a proper release artifact name.
+release_name() {
+    name="azureauth-${version}"
+    os_info="$(uname -a)"
+    os_name="$(echo $os_info | cut -d ' ' -f1)"
+
+    case "${os_name}" in
+        Darwin)
+            name="${name}-osx"
+            arch="$(echo $os_info | rev | cut -d ' ' -f1 | rev)"
+
+            case "${arch}" in
+                arm64)
+                    name="${name}-arm64"
+                    ;;
+                x86_64)
+                    name="${name}-x64"
+                    ;;
+                *)
+                    error "Unsupported architecture '${arch}', unable to download a release"
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            error "Unsupported OS '${os_name}', unable to download a release"
+            exit 1
+            ;;
+    esac
+
+    echo "${name}"
+}
+
+: ${AZUREAUTH_REPO='AzureAD/microsoft-authentication-cli'}
+repo="${AZUREAUTH_REPO}"
+release_file="$(release_name).tar.gz"
+release_url="https://github.com/${repo}/releases/download/${version}/${release_file}"
+
+azureauth_directory="${HOME}/.azureauth"
+target_directory="${azureauth_directory}/${version}"
+latest_directory="${azureauth_directory}/latest"
+tarball="${azureauth_directory}/${release_file}"
+
+verbose "Creating ${azureauth_directory}"
+mkdir -p $azureauth_directory
+
+verbose "Downloading ${release_url} to ${tarball}"
+curl -sL $release_url > $tarball
+
+if [ -d "${target_directory}" ]; then
+    verbose "Removing pre-existing target directory at ${target_directory}"
+    rm -rf $target_directory
+fi
+
+verbose "Extracting ${tarball} to ${target_directory}"
+mkdir -p $target_directory
+tar -xf $tarball -C $target_directory
+
+# The files extracted from the tarball are all executable, but only two need to be.
+chmod -x ${target_directory}/*
+chmod +x ${target_directory}/{azureauth,createdump}
+
+verbose "Removing ${tarball}"
+rm $tarball
+
+verbose "Linking ${latest_directory} to ${target_directory}"
+ln -sf $target_directory $latest_directory
+
+# We currently only support automatically appending $PATH modifications for the default
+# Bash and ZSH profiles as the syntax is identical.
+path_modification='export PATH="${PATH}:${HOME}/.azureauth/latest"'
+for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
+do
+    if ! grep "${path_modification}" "${shell_profile}" &>/dev/null; then
+        verbose "Updating \$PATH in ${shell_profile} to include ${latest_directory}"
+        echo "${path_modification}" >> $shell_profile
+    fi
+done
+
+echo "Installed azureauth ${version}!"

--- a/install/install.sh
+++ b/install/install.sh
@@ -64,7 +64,10 @@ verbose "Creating ${azureauth_directory}"
 mkdir -p $azureauth_directory
 
 verbose "Downloading ${release_url} to ${tarball}"
-curl -sL $release_url > $tarball
+if ! curl -sfL $release_url > $tarball; then
+    error "Failed to download azureauth ${version}"
+    exit 1
+fi
 
 if [ -d "${target_directory}" ]; then
     verbose "Removing pre-existing target directory at ${target_directory}"


### PR DESCRIPTION
## Windows

This adds a PowerShell bootstrap script which can be used to quickly install the application without the hassle of extracting the DLLs from a release `.zip`, adding the binary to the `$PATH`, etc.

You can test this for yourself by opening a PowerShell terminal and running the installation script from this branch. The `-Verbose` flag will provide extra debugging output so you can see what's going on.

```powershell
$env:AZUREAUTH_VERSION = 'v0.1.0'
iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/install-scripts/install/install.ps1) } -Verbose"
```

This script doesn't do a few things right now.

1. It doesn't allow downloading the latest release. We can get this information from the GitHub API in JSON form. PowerShell has JSON parsing capabilities baked in, but macOS does not and I'm focusing on the absolute minimum for having the same behavior across all supported platforms.
2. It doesn't clean up old versions. We can add this functionality later, but my lack of PowerShell knowledge is a hindrance and we want to ship this feature quickly.
4. It can't be used to uninstall the application. We will likely want a mechanism for that as well, but it might be best in a separate script.

## macOS

It also adds a shell script for Unix systems (currently only supporting macOS).

You can test this for yourself by opening a terminal and running the installation script from this branch. The `AZUREAUTH_VERBOSE_INSTALL` environment variable will provide extra debugging output so you can see what's going on.

```bash
export AZUREAUTH_VERSION='v0.1.0'
export AZUREAUTH_VERBOSE_INSTALL=1
curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/install-scripts/install/install.sh | sh
```

The limitations are currently the same as the Windows version.