### PR TITLE
Print a warning message when opening a browser window for auth

### DIFF
--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         public const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";
 
+        private const string INTERACTIVE_AUTH_MESSAGE = "Opening a browser window for interactive auth...";
+
         /// <summary>
         /// The _errors.
         /// </summary>
@@ -314,8 +316,6 @@ namespace Microsoft.Authentication.MSALWrapper
 
             try
             {
-                const string interactiveAuthMessage = "Opening a browser window for interactive auth...";
-
                 try
                 {
                     try
@@ -333,7 +333,7 @@ namespace Microsoft.Authentication.MSALWrapper
                     {
                         this.ErrorsList.Add(ex);
                         this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
-                        this.logger.LogWarning(interactiveAuthMessage);
+                        this.logger.LogWarning(INTERACTIVE_AUTH_MESSAGE);
                         var tokenResult = await this.CompleteWithin(
                             this.interactiveAuthTimeout,
                             "Interactive Auth",
@@ -347,7 +347,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 {
                     this.ErrorsList.Add(ex);
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
-                    this.logger.LogWarning(interactiveAuthMessage);
+                    this.logger.LogWarning(INTERACTIVE_AUTH_MESSAGE);
                     var tokenResult = await this.CompleteWithin(
                         this.interactiveAuthTimeout,
                         "Interactive Auth (with extra claims)",

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -314,6 +314,8 @@ namespace Microsoft.Authentication.MSALWrapper
 
             try
             {
+                const string interactiveAuthMessage = "Opening a browser window for interactive auth...";
+
                 try
                 {
                     try
@@ -331,6 +333,7 @@ namespace Microsoft.Authentication.MSALWrapper
                     {
                         this.ErrorsList.Add(ex);
                         this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                        this.logger.LogWarning(interactiveAuthMessage);
                         var tokenResult = await this.CompleteWithin(
                             this.interactiveAuthTimeout,
                             "Interactive Auth",
@@ -344,6 +347,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 {
                     this.ErrorsList.Add(ex);
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                    this.logger.LogWarning(interactiveAuthMessage);
                     var tokenResult = await this.CompleteWithin(
                         this.interactiveAuthTimeout,
                         "Interactive Auth (with extra claims)",

--- a/src/MSALWrapper/TokenFetcherPublicClient.cs
+++ b/src/MSALWrapper/TokenFetcherPublicClient.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         public const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";
 
-        private const string INTERACTIVE_AUTH_MESSAGE = "Opening a browser window for interactive auth...";
+        private const string INTERACTIVE_AUTH_MESSAGE = "Opening a browser window for interactive auth.";
+
 
         /// <summary>
         /// The _errors.


### PR DESCRIPTION
Note that this will not pollute stdout since the access token is writted to stdout. Warning messages are written to stderr.