### PR TITLE
Args in Demo do not match the number of needed arguments.

### DIFF
--- a/examples/Demo.Console.NET6/Program.cs
+++ b/examples/Demo.Console.NET6/Program.cs
@@ -31,15 +31,15 @@ namespace Demo.Console.NET6
 
             logger.LogInformation("I am ExampleCLI");
 
-            if (args.Length != 2)
+            if (args.Length != 3)
             {
-                logger.LogError("Usage: <resource> <client>");
+                logger.LogError("Usage: <resource> <client> <tenant>");
                 Environment.Exit(1);
             }
 
-            Guid resource = new Guid(args[1]);
-            Guid client = new Guid(args[2]);
-            Guid tenant = new Guid(args[3]);
+            Guid resource = new Guid(args[0]);
+            Guid client = new Guid(args[1]);
+            Guid tenant = new Guid(args[2]);
 
             // Create a token fetcher
             ITokenFetcher adoAuth = new TokenFetcherPublicClient(logger, resource, client, tenant);


### PR DESCRIPTION
The number of arguments in `Demo.Console.Net6` should be 3 instead of 2. The index has also been changed to 0-based.
Ref: [Main() and command-line arguments
](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/main-command-line)