### PR TITLE
Redesigned BrokerPCATokenFetcher and refactored more code

### DIFF
--- a/src/MSALWrapper.Test/AuthFlowsTest/AccountsProviderTest.cs
+++ b/src/MSALWrapper.Test/AuthFlowsTest/AccountsProviderTest.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlows;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// The accounts provider test.
+    /// </summary>
+    public class AccountsProviderTest
+    {
+        private const string TestUser = "user@microsoft.com";
+
+        private readonly IAccount userLive = new MockAccount("first@live.com");
+        private readonly IAccount userMicrosoft1 = new MockAccount("second@microsoft.com");
+        private readonly IAccount userMicrosoft2 = new MockAccount("third@microsoft.com");
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapper;
+        private Mock<IPublicClientApplication> pcaClient;
+        private Mock<IAccount> testAccount;
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapper = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.pcaClient = new Mock<IPublicClientApplication>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<IAccountsProvider>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<AccountsProvider>>();
+                 return new AccountsProvider(this.pcaClient.Object, logger);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        /// <summary>
+        /// The test to get cached account when there are no accounts.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_NoAccounts()
+        {
+            this.GetAccountsMock(new List<IAccount>());
+
+            // Act
+            var accountsProvider = this.Subject();
+            IAccount result = await accountsProvider.TryGetAccountAsync();
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeNull();
+        }
+
+        /// <summary>
+        /// The test to get cached account when null.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_Null()
+        {
+            this.GetAccountsMock(null);
+
+            // Act
+            IAccount result = await this.Subject().TryGetAccountAsync();
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeNull();
+        }
+
+        /// <summary>
+        /// The test to get cached account when one account.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_OneAccount()
+        {
+            var joe = new MockAccount("joe@microsoft.com");
+            IList<IAccount> accounts = new List<IAccount>() { joe };
+            this.GetAccountsMock(accounts);
+
+            // Act
+            IAccount result = await this.Subject().TryGetAccountAsync();
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeSameAs(joe);
+        }
+
+        /// <summary>
+        /// The test to get cached account when two accounts.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_TwoAccounts()
+        {
+            var first = new MockAccount("first@live.com");
+            var second = new MockAccount("second@microsoft.com");
+            IList<IAccount> accounts = new List<IAccount>() { first, second };
+            this.GetAccountsMock(accounts);
+
+            // Act
+            IAccount result = await this.Subject().TryGetAccountAsync();
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeNull();
+        }
+
+        /// <summary>
+        /// The test to get cached account when two accounts with preferred domain.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_TwoAccounts_WithPreferredDomain()
+        {
+            IList<IAccount> accounts = new List<IAccount>() { this.userLive, this.userMicrosoft1 };
+            this.GetAccountsMock(accounts);
+
+            // Act
+            IAccount result = await this.Subject().TryGetAccountAsync("microsoft.com");
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeSameAs(this.userMicrosoft1);
+        }
+
+        /// <summary>
+        /// The test to get cached account when multiple accounts with preferred domain.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task TryToGetCachedAccountAsync_MultipleAccounts_WithPreferredDomain()
+        {
+            IList<IAccount> accounts = new List<IAccount>() { this.userLive, this.userMicrosoft1, this.userMicrosoft2 };
+            this.GetAccountsMock(accounts);
+
+            // Act
+            IAccount result = await this.Subject().TryGetAccountAsync();
+
+            // Assert
+            this.pcaClient.VerifyAll();
+            result.Should().BeNull();
+        }
+
+        private void GetAccountsMock(IEnumerable<IAccount> accounts)
+        {
+            this.pcaClient
+                .Setup(pca => pca.GetAccountsAsync())
+                .ReturnsAsync(accounts);
+        }
+
+        private IAccountsProvider Subject() => this.serviceProvider.GetService<IAccountsProvider>();
+    }
+}

--- a/src/MSALWrapper.Test/AuthFlowsTest/AuthFlowsTest.cs
+++ b/src/MSALWrapper.Test/AuthFlowsTest/AuthFlowsTest.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlows;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// The broker public client test.
+    /// </summary>
+    public class AuthFlowsTest
+    {
+        private const string TestUser = "user@microsoft.com";
+
+        // These Guids were randomly generated and do not refer to a real resource or client
+        // as we don't need either for our testing.
+        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapper;
+        private Mock<IPublicClientApplication> pcaClient;
+        private Mock<IAccount> testAccount;
+        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapper = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.pcaClient = new Mock<IPublicClientApplication>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<BrokerPCATokenFetcher>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<BrokerPCATokenFetcher>>();
+                 return new BrokerPCATokenFetcher(logger, ClientId, TenantId, this.scopes);
+             })
+             .AddTransient<AuthFlows>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<AuthFlows>>();
+                 return new AuthFlows(logger, ResourceId, ClientId, TenantId);
+             })
+             .AddTransient<IAccountsProvider>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<BrokerPCATokenFetcher>>();
+                 return new AccountsProvider(this.pcaClient.Object, logger);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        /// <summary>
+        /// The broker auth flow is expected.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Test]
+        public async Task BrokerAuthFlowIsExpected()
+        {
+            var brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            this.GetAccountsMock();
+
+            // Act
+            var authFlows = this.Subject();
+            authFlows.Authflows.Add(brokerPcaTokenFetcher);
+            var result = await authFlows.GetTokenAsync();
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().Be(this.tokenResult);
+        }
+
+        private AuthFlows Subject() => this.serviceProvider.GetService<AuthFlows>();
+
+        private BrokerPCATokenFetcher Subject1() => this.serviceProvider.GetService<BrokerPCATokenFetcher>();
+
+        private BrokerPCATokenFetcher GetBrokerPCATokenFetcherMock()
+        {
+            var brokerPcaTokenFetcher = this.Subject1();
+            brokerPcaTokenFetcher.PCAWrapper = this.pcaWrapper.Object;
+            brokerPcaTokenFetcher.PublicClientApplication = this.pcaClient.Object;
+            brokerPcaTokenFetcher.AccountsProvider = this.serviceProvider.GetService<IAccountsProvider>();
+
+            this.pcaWrapper
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+
+            return brokerPcaTokenFetcher;
+        }
+
+        private void GetAccountsMock()
+        {
+            this.pcaClient
+                .Setup(pca => pca.GetAccountsAsync())
+                .ReturnsAsync(new List<IAccount>() { this.testAccount.Object });
+        }
+    }
+}

--- a/src/MSALWrapper.Test/AuthFlowsTest/BrokerPCATokenFetcherTest.cs
+++ b/src/MSALWrapper.Test/AuthFlowsTest/BrokerPCATokenFetcherTest.cs
@@ -1,0 +1,509 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlows;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// The broker public client test.
+    /// </summary>
+    public class BrokerPCATokenFetcherTest
+    {
+        private const string MsalServiceExceptionErrorCode = "1";
+        private const string MsalServiceExceptionMessage = "MSAL Service Exception: Something bad has happened!";
+        private const string TestUser = "user@microsoft.com";
+
+        // These Guids were randomly generated and do not refer to a real resource or client
+        // as we don't need either for our testing.
+        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapper;
+        private Mock<IPublicClientApplication> pcaClient;
+        private Mock<IAccount> testAccount;
+        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapper = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.pcaClient = new Mock<IPublicClientApplication>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<BrokerPCATokenFetcher>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<BrokerPCATokenFetcher>>();
+                 return new BrokerPCATokenFetcher(logger, ClientId, TenantId, this.scopes);
+             })
+             .AddTransient<IAccountsProvider>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<BrokerPCATokenFetcher>>();
+                 return new AccountsProvider(this.pcaClient.Object, logger);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        /// <summary>
+        /// The broker auth flow happy path.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_HappyPath()
+        {
+            this.SilentAuthResult();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(this.tokenResult);
+            result.AuthType.Should().Be(AuthType.Silent);
+            brokerPcaTokenFetcher.ErrorsList.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The broker auth flow throws MSAL UI exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_MsalUIException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthResult();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(this.tokenResult);
+            result.AuthType.Should().Be(AuthType.Interactive);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(1);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The broker auth flow throws general exception.
+        /// </summary>
+        [Test]
+        public void BrokerAuthFlow_General_Exceptions_Are_ReThrown()
+        {
+            var message = "Something somwhere has gone terribly wrong!";
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new Exception(message));
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            Func<Task> subject = async () => await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+
+            // This VerifyAll must come after the assert, since the assert is what execute the lambda
+            this.pcaWrapper.VerifyAll();
+        }
+
+        /// <summary>
+        /// The broker auth flow throws MSAL Service exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenSilent_MsalServiceException()
+        {
+            this.SilentAuthServiceException();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert - this method should not throw for known types of excpeptions, instead return null, so
+            // our caller can retry auth another way.
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(1);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token silent throws operation canceled exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenSilent_OperationCanceledException()
+        {
+            this.SilentAuthTimeout();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(1);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            brokerPcaTokenFetcher.ErrorsList[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+        }
+
+        /// <summary>
+        /// The broker auth flow get token silent throws Msal Client exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenSilent_MsalClientException()
+        {
+            this.SilentAuthClientException();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(1);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalClientException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token silent throws null reference exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenSilent_NullReferenceException()
+        {
+            this.SilentAuthNullReferenceException();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(1);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(NullReferenceException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token interactive throws MSAL UI exception for Claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsResult();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(this.tokenResult);
+            result.AuthType.Should().Be(AuthType.Interactive);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(2);
+            brokerPcaTokenFetcher.ErrorsList.Should().AllBeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token interactive throws MSAL service exception after using Claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsServiceException();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(3);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[2].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token interactive throws MSAL service exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenInteractive_MsalServiceException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthServiceException();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(2);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[1].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The broker auth flow get token interactive throws operation canceled exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenInteractive_OperationCanceledException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthTimeout();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(2);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            brokerPcaTokenFetcher.ErrorsList[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+        }
+
+        /// <summary>
+        /// The broker auth flow get token interactive throws operation canceled exception for claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task BrokerAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsTimeout();
+
+            this.GetAccountsMock();
+
+            // Act
+            BrokerPCATokenFetcher brokerPcaTokenFetcher = this.GetBrokerPCATokenFetcherMock();
+            var result = await brokerPcaTokenFetcher.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapper.VerifyAll();
+            result.Should().Be(null);
+            brokerPcaTokenFetcher.ErrorsList.Should().HaveCount(3);
+            brokerPcaTokenFetcher.ErrorsList[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            brokerPcaTokenFetcher.ErrorsList[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            brokerPcaTokenFetcher.ErrorsList[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+        }
+
+        private void GetAccountsMock()
+        {
+            this.pcaClient
+                .Setup(pca => pca.GetAccountsAsync())
+                .ReturnsAsync(new List<IAccount>() { this.testAccount.Object });
+        }
+
+        private void SilentAuthResult()
+        {
+            this.pcaWrapper
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void SilentAuthUIRequired()
+        {
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "UI is required"));
+        }
+
+        private void SilentAuthServiceException()
+        {
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void SilentAuthTimeout()
+        {
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void SilentAuthClientException()
+        {
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
+        }
+
+        private void SilentAuthNullReferenceException()
+        {
+            this.pcaWrapper
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
+        }
+
+        private void InteractiveAuthResult()
+        {
+            this.pcaWrapper
+               .Setup((pca) => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void InteractiveAuthWithClaimsResult()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.tokenResult);
+        }
+
+        private void InteractiveAuthTimeout()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void InteractiveAuthExtraClaimsRequired()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "Extra Claims are required."));
+        }
+
+        private void InteractiveAuthServiceException()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void InteractiveAuthWithClaimsServiceException()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void InteractiveAuthWithClaimsTimeout()
+        {
+            this.pcaWrapper
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private BrokerPCATokenFetcher Subject() => this.serviceProvider.GetService<BrokerPCATokenFetcher>();
+
+        private BrokerPCATokenFetcher GetBrokerPCATokenFetcherMock()
+        {
+            var brokerPcaTokenFetcher = this.Subject();
+            brokerPcaTokenFetcher.PCAWrapper = this.pcaWrapper.Object;
+            brokerPcaTokenFetcher.PublicClientApplication = this.pcaClient.Object;
+            brokerPcaTokenFetcher.AccountsProvider = this.serviceProvider.GetService<IAccountsProvider>();
+            return brokerPcaTokenFetcher;
+        }
+    }
+}

--- a/src/MSALWrapper.Test/MSALWrapper.Test.csproj
+++ b/src/MSALWrapper.Test/MSALWrapper.Test.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
-        <SupportedOSPlatformVersion>7</SupportedOSPlatformVersion>
-        <DefineConstants>PlatformWindows</DefineConstants>
-        <IsPackable>false</IsPackable>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+    <SupportedOSPlatformVersion>7</SupportedOSPlatformVersion>
+    <DefineConstants>PlatformWindows</DefineConstants>
+    <IsPackable>false</IsPackable>
 
-        <!-- Stylecop warnings as errors flag for build to fail -->
-        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    </PropertyGroup>
+    <!-- Stylecop warnings as errors flag for build to fail -->
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
         <TargetFramework>net6.0</TargetFramework>
@@ -19,31 +19,31 @@
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
-    <ItemGroup>
-        <!-- Stylecop required items -->
-        <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />
-        <Compile Include="..\..\stylecop\GlobalSupressions.cs" Link="GlobalSupressions.cs" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <!-- Stylecop required items -->
+    <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />
+    <Compile Include="..\..\stylecop\GlobalSupressions.cs" Link="GlobalSupressions.cs" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
-        <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
-        <PackageReference Include="nunit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="Moq" Version="4.17.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+  </ItemGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <DefineConstants>PlatformWindows</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <DefineConstants>PlatformWindows</DefineConstants>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/MSALWrapper.Test/MSALWrapper.Test.csproj
+++ b/src/MSALWrapper.Test/MSALWrapper.Test.csproj
@@ -1,40 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+        <SupportedOSPlatformVersion>7</SupportedOSPlatformVersion>
+        <DefineConstants>PlatformWindows</DefineConstants>
+        <IsPackable>false</IsPackable>
 
-    <IsPackable>false</IsPackable>
+        <!-- Stylecop warnings as errors flag for build to fail -->
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    </PropertyGroup>
 
-    <!-- Stylecop warnings as errors flag for build to fail -->
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Stylecop required items -->
-    <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />
-    <Compile Include="..\..\stylecop\GlobalSupressions.cs" Link="GlobalSupressions.cs" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-  </ItemGroup>
-    
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <DefineConstants>PlatformWindows</DefineConstants>
-  </PropertyGroup>
-    
-  <ItemGroup>
-    <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <!-- Stylecop required items -->
+        <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />
+        <Compile Include="..\..\stylecop\GlobalSupressions.cs" Link="GlobalSupressions.cs" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
+        <PackageReference Include="nunit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="Moq" Version="4.17.2" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <DefineConstants>PlatformWindows</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/MSALWrapper/AuthFlows/AccountsProvider/AccountsProvider.cs
+++ b/src/MSALWrapper/AuthFlows/AccountsProvider/AccountsProvider.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The accounts provider.
+    /// </summary>
+    internal class AccountsProvider : IAccountsProvider
+    {
+        private readonly IPublicClientApplication publicClientApplication;
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccountsProvider"/> class.
+        /// </summary>
+        /// <param name="publicClientApplication">The public client application.</param>
+        /// <param name="logger">The logger.</param>
+        internal AccountsProvider(IPublicClientApplication publicClientApplication, ILogger logger)
+        {
+            this.publicClientApplication = publicClientApplication;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// The try get account async.
+        /// </summary>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<IAccount> TryGetAccountAsync(string preferredDomain = null)
+        {
+            var accounts = await this.TryGetAccountsAsync(preferredDomain);
+            var account = (accounts == null || accounts.Count() > 1) ? null : accounts.FirstOrDefault();
+            return account;
+        }
+
+        /// <summary>
+        /// The try get accounts async.
+        /// </summary>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<IList<IAccount>> TryGetAccountsAsync(string preferredDomain = null)
+        {
+            IEnumerable<IAccount> accounts = await this.publicClientApplication.GetAccountsAsync().ConfigureAwait(false);
+            if (accounts == null)
+            {
+                return null;
+            }
+
+            this.logger.LogDebug($"Accounts found in cache: ({accounts.Count()}):");
+            this.logger.LogDebug(string.Join("\n", accounts.Select(a => a.Username)));
+
+            if (!string.IsNullOrWhiteSpace(preferredDomain))
+            {
+                this.logger.LogDebug($"Filtering cached accounts with preferred domain '{preferredDomain}'");
+                accounts = accounts.Where(eachAccount => eachAccount.Username.EndsWith(preferredDomain, StringComparison.OrdinalIgnoreCase));
+
+                this.logger.LogDebug($"Accounts found in cache after filtering: ({accounts.Count()}):");
+                this.logger.LogDebug(string.Join("\n", accounts.Select(a => a.Username)));
+            }
+
+            return accounts.ToList();
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/AccountsProvider/IAccountsProvider.cs
+++ b/src/MSALWrapper/AuthFlows/AccountsProvider/IAccountsProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The AccountsProvider interface.
+    /// </summary>
+    internal interface IAccountsProvider
+    {
+        /// <summary>
+        /// The try get account async.
+        /// </summary>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<IAccount> TryGetAccountAsync(string preferredDomain = null);
+
+        /// <summary>
+        /// The try get accounts async.
+        /// </summary>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<IList<IAccount>> TryGetAccountsAsync(string preferredDomain = null);
+    }
+}

--- a/src/MSALWrapper/AuthFlows/AuthFlows.cs
+++ b/src/MSALWrapper/AuthFlows/AuthFlows.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The auth flows class.
+    /// </summary>
+    public class AuthFlows : IAuthFlows
+    {
+        /// <summary>
+        /// The list of Auth flows to try.
+        /// </summary>
+        internal readonly List<IAuthFlows> Authflows;
+
+        private readonly ILogger logger;
+        private readonly Guid resourceId;
+        private readonly Guid clientId;
+        private readonly Guid tenantId;
+        private readonly string osxKeyChainSuffix;
+        private readonly bool verifyPersistence;
+        private readonly string preferredDomain;
+        private IEnumerable<string> scopes;
+
+        #region Public configurable properties
+
+        /// <summary>
+        /// The global auth timeout.
+        /// </summary>
+        private TimeSpan globalAuthTimeout = TimeSpan.FromMinutes(15);
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthFlows"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="resourceId">The resource id.</param>
+        /// <param name="clientId">The client id.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <param name="verifyPersistence">The verify persistence.</param>
+        public AuthFlows(ILogger logger, Guid resourceId, Guid clientId, Guid tenantId, IEnumerable<string> scopes = null, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false)
+        {
+            this.Authflows = new List<IAuthFlows>();
+            this.logger = logger;
+            this.resourceId = resourceId;
+            this.clientId = clientId;
+            this.tenantId = tenantId;
+            this.osxKeyChainSuffix = osxKeyChainSuffix;
+            this.preferredDomain = preferredDomain;
+            this.verifyPersistence = verifyPersistence;
+            this.scopes = scopes ?? new string[] { $"{this.resourceId}/.default" };
+
+            this.BuildRequiredAuthFlows();
+        }
+
+        /// <summary>
+        /// The get token async.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<TokenResult> GetTokenAsync()
+        {
+            var token = await TaskExecutor.CompleteWithin(
+                    this.globalAuthTimeout,
+                    "Try auth flows",
+                    (cancellationToken) => this.TryGetToken());
+            return token;
+        }
+
+        private async Task<TokenResult> TryGetToken()
+        {
+            TokenResult token = null;
+            foreach (var authFlow in this.Authflows)
+            {
+                try
+                {
+                    token = await authFlow.GetTokenAsync();
+                    if (token != null)
+                    {
+                        return token;
+                    }
+                }
+                catch (MsalException ex)
+                {
+                    this.logger.LogError(ex.Message);
+                }
+            }
+
+            return token;
+        }
+
+        private void BuildRequiredAuthFlows()
+        {
+            if (PlatformUtils.IsWindows10(this.logger))
+            {
+                this.Authflows.Add(new BrokerPCATokenFetcher(this.logger, this.clientId, this.tenantId, this.scopes, this.osxKeyChainSuffix, this.preferredDomain, this.verifyPersistence));
+            }
+
+            // COMING SOON
+            // this.authFlows.Add(new WebPCATokenFetcher(this.logger, this.clientId, this.tenantId, this.scopes, this.osxKeyChainSuffix, this.preferredDomain, this.verifyPersistence));
+            // this.authFlows.Add(new DeviceCodePCATokenFetcher(this.logger, this.clientId, this.tenantId, this.scopes, this.osxKeyChainSuffix, this.verifyPersistence));
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/BrokerPCATokenFetcher.cs
+++ b/src/MSALWrapper/AuthFlows/BrokerPCATokenFetcher.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+#if NET472
+    using Microsoft.Identity.Client.Desktop;
+#endif
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The broker pca token fetcher.
+    /// </summary>
+    public class BrokerPCATokenFetcher : IAuthFlows
+    {
+        private readonly ILogger logger;
+        private readonly IEnumerable<string> scopes;
+        private readonly string preferredDomain;
+
+        /// <summary>
+        /// The pca wrapper.
+        /// </summary>
+        internal IPCAWrapper PCAWrapper;
+
+        /// <summary>
+        /// The public client application.
+        /// </summary>
+        internal IPublicClientApplication PublicClientApplication;
+
+        /// <summary>
+        /// The accounts provider.
+        /// </summary>
+        internal IAccountsProvider AccountsProvider;
+
+        #region Public configurable properties
+
+        /// <summary>
+        /// The silent auth timeout.
+        /// </summary>
+        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// The interactive auth timeout.
+        /// </summary>
+        private TimeSpan interactiveAuthTimeout = TimeSpan.FromMinutes(15);
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrokerPCATokenFetcher"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="clientId">The client id.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <param name="verifyPersistence">The verify persistence.</param>
+        public BrokerPCATokenFetcher(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, bool verifyPersistence = false)
+        {
+            this.logger = logger;
+            this.scopes = scopes;
+            this.preferredDomain = preferredDomain;
+            this.ErrorsList = new List<Exception>();
+
+            this.SetupPCAWrapper(clientId, tenantId);
+            new PCACache(this.PublicClientApplication, logger, tenantId, osxKeyChainSuffix, verifyPersistence).SetupTokenCache();
+            this.AccountsProvider = new AccountsProvider(this.PublicClientApplication, this.logger);
+        }
+
+        /// <summary>
+        /// Gets the errors list.
+        /// </summary>
+        public List<Exception> ErrorsList { get; }
+
+        /// <summary>
+        /// The get token async.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<TokenResult> GetTokenAsync()
+        {
+            IAccount account = await this.AccountsProvider.TryGetAccountAsync(this.preferredDomain)
+                ?? Identity.Client.PublicClientApplication.OperatingSystemAccount;
+            this.logger.LogDebug($"GetTokenNormalFlowAsync: Using account '{account.Username}'");
+
+            try
+            {
+                try
+                {
+                    try
+                    {
+                        var tokenResult = await TaskExecutor.CompleteWithin(
+                            this.silentAuthTimeout,
+                            "Get Token Silent",
+                            (cancellationToken) => this.PCAWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
+                            this.ErrorsList,
+                            this.logger)
+                            .ConfigureAwait(false);
+                        tokenResult.SetAuthenticationType(AuthType.Silent);
+
+                        return tokenResult;
+                    }
+                    catch (MsalUiRequiredException ex)
+                    {
+                        this.ErrorsList.Add(ex);
+                        this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                        var tokenResult = await TaskExecutor.CompleteWithin(
+                            this.interactiveAuthTimeout,
+                            "Interactive Auth",
+                            (cancellationToken) => this.PCAWrapper.GetTokenInteractiveAsync(this.scopes, account, cancellationToken),
+                            this.ErrorsList,
+                            this.logger)
+                            .ConfigureAwait(false);
+                        tokenResult.SetAuthenticationType(AuthType.Interactive);
+                        return tokenResult;
+                    }
+                }
+                catch (MsalUiRequiredException ex)
+                {
+                    this.ErrorsList.Add(ex);
+                    this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                    var tokenResult = await TaskExecutor.CompleteWithin(
+                        this.interactiveAuthTimeout,
+                        "Interactive Auth (with extra claims)",
+                        (cancellationToken) => this.PCAWrapper.GetTokenInteractiveAsync(this.scopes, ex.Claims, cancellationToken),
+                        this.ErrorsList,
+                        this.logger)
+                        .ConfigureAwait(false);
+                    tokenResult.SetAuthenticationType(AuthType.Interactive);
+                    return tokenResult;
+                }
+            }
+            catch (MsalServiceException ex)
+            {
+                this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
+                this.ErrorsList.Add(ex);
+                return null;
+            }
+            catch (MsalClientException ex)
+            {
+                this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
+                this.ErrorsList.Add(ex);
+                return null;
+            }
+            catch (NullReferenceException ex)
+            {
+                this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
+                this.ErrorsList.Add(ex);
+                return null;
+            }
+        }
+
+        private void SetupPCAWrapper(Guid clientId, Guid tenantId)
+        {
+            var clientBuilder =
+                PublicClientApplicationBuilder
+                .Create($"{clientId}")
+                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true);
+
+#if NETFRAMEWORK
+            clientBuilder.WithWindowsBroker();
+#else
+            clientBuilder.WithBroker();
+#endif
+            this.PublicClientApplication = clientBuilder.Build();
+            this.PCAWrapper = new PCAWrapper(this.PublicClientApplication);
+        }
+
+        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
+        {
+            this.logger.LogTrace($"MSAL: {message}");
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/IAuthFlow.cs
+++ b/src/MSALWrapper/AuthFlows/IAuthFlow.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The IAuthFlows interface.
+    /// </summary>
+    public interface IAuthFlows
+    {
+        /// <summary>
+        /// The get token async.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<TokenResult> GetTokenAsync();
+    }
+}

--- a/src/MSALWrapper/AuthFlows/PCACache/IPCACache.cs
+++ b/src/MSALWrapper/AuthFlows/PCACache/IPCACache.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.Identity.Client.Extensions.Msal;
+
+    /// <summary>
+    /// The PCACache interface.
+    /// </summary>
+    internal interface IPCACache
+    {
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        void SetupTokenCache();
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        /// <param name="errorsList">The errors list.</param>
+        void SetupTokenCache(List<Exception> errorsList);
+    }
+}

--- a/src/MSALWrapper/AuthFlows/PCACache/PCACache.cs
+++ b/src/MSALWrapper/AuthFlows/PCACache/PCACache.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.Identity.Client.Extensions.Msal;
+
+    /// <summary>
+    /// The pca cache.
+    /// </summary>
+    internal class PCACache : IPCACache
+    {
+        // OSX
+        private const string MacOSAccountName = "MSALCache";
+        private const string MacOSServiceName = "Microsoft.Developer.IdentityService";
+
+        // Linux
+        private const string LinuxKeyRingSchema = "com.microsoft.identity.tokencache";
+        private const string LinuxKeyRingCollection = "default";
+        private const string LinuxKeyRingLabel = "MSAL token cache";
+        private static KeyValuePair<string, string> linuxKeyRingAttr1 = new KeyValuePair<string, string>("Version", "1");
+        private static KeyValuePair<string, string> linuxKeyRingAttr2 = new KeyValuePair<string, string>("ProductGroup", "Microsoft Develoepr Tools");
+
+        private readonly IPublicClientApplication publicClientApplication;
+        private readonly ILogger logger;
+        private readonly string osxKeyChainSuffix;
+        private readonly bool verifyPersistence;
+
+        private readonly string cacheDir;
+        private readonly string cacheFileName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PCACache"/> class.
+        /// </summary>
+        /// <param name="publicClientApplication">The public client application.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="verifyPersistence">The verify persistence.</param>
+        internal PCACache(IPublicClientApplication publicClientApplication, ILogger logger, Guid tenantId, string osxKeyChainSuffix = null, bool verifyPersistence = false)
+        {
+            this.publicClientApplication = publicClientApplication;
+            this.logger = logger;
+
+            this.osxKeyChainSuffix = string.IsNullOrWhiteSpace(osxKeyChainSuffix) ? $"{tenantId}" : $"{osxKeyChainSuffix}.{tenantId}";
+            this.verifyPersistence = verifyPersistence;
+
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            this.cacheDir = Path.Combine(appData, ".IdentityService");
+            this.cacheFileName = $"msal_{tenantId}.cache";
+        }
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        /// <param name="errorsList">The errors list.</param>
+        public void SetupTokenCache(List<Exception> errorsList)
+        {
+            var cacheDisabled = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.OEAUTH_MSAL_DISABLE_CACHE));
+            if (cacheDisabled)
+            {
+                return;
+            }
+
+            var osxKeychainItem = MacOSServiceName + (string.IsNullOrWhiteSpace(this.osxKeyChainSuffix) ? string.Empty : $".{this.osxKeyChainSuffix}");
+            var storageProperties = new StorageCreationPropertiesBuilder(this.cacheFileName, this.cacheDir)
+            .WithLinuxKeyring(LinuxKeyRingSchema, LinuxKeyRingCollection, LinuxKeyRingLabel, linuxKeyRingAttr1, linuxKeyRingAttr2)
+            .WithMacKeyChain(osxKeychainItem, MacOSAccountName)
+            .Build();
+
+            try
+            {
+                MsalCacheHelper cacher = MsalCacheHelper.CreateAsync(storageProperties).Result;
+                if (this.verifyPersistence)
+                {
+                    cacher.VerifyPersistence();
+                }
+
+                cacher.RegisterCache(this.publicClientApplication.UserTokenCache);
+            }
+            catch (MsalCachePersistenceException ex)
+            {
+                this.logger.LogWarning($"MSAL token cache verification failed.\n{ex.Message}\n");
+                errorsList.Add(ex);
+            }
+            catch (AggregateException ex) when (ex.InnerException.Message.Contains("Could not get access to the shared lock file"))
+            {
+                var exceptionMessage = ex.ToFormattedString();
+                errorsList.Add(ex);
+
+                this.logger.LogError("An unexpected error occured creating the cache.");
+                throw new Exception(exceptionMessage);
+            }
+        }
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        public void SetupTokenCache()
+        {
+            this.SetupTokenCache(new List<Exception>());
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/Utils/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/AuthFlows/Utils/MsalHttpClientFactoryAdaptor.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The msal http client factory adaptor.
+    /// </summary>
+    internal class MsalHttpClientFactoryAdaptor : IMsalHttpClientFactory
+    {
+        /// <summary>
+        /// The get http client.
+        /// </summary>
+        /// <returns>The <see cref="HttpClient"/>.</returns>
+        public HttpClient GetHttpClient()
+        {
+            // MSAL calls this method each time it wants to use an HTTP client.
+            // We ensure we only create a single instance to avoid socket exhaustion.
+            HttpClientHandler handler = new HttpClientHandler();
+            var client = new HttpClient(handler);
+            client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true,
+            };
+
+            return client;
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/Utils/TaskExecutor.cs
+++ b/src/MSALWrapper/AuthFlows/Utils/TaskExecutor.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// The task executor.
+    /// </summary>
+    internal class TaskExecutor
+    {
+        /// <summary>
+        /// The complete within.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="taskName">The task name.</param>
+        /// <param name="getTask">The get task.</param>
+        /// <param name="errorsList">The errors list.</param>
+        /// <param name="logger">The logger.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        internal static async Task<T> CompleteWithin<T>(TimeSpan timeout, string taskName, Func<CancellationToken, Task<T>> getTask, List<Exception> errorsList = null, ILogger logger = null)
+            where T : class
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            source.CancelAfter(timeout);
+            try
+            {
+                logger?.LogDebug($"{taskName} has {timeout.TotalMinutes} minutes to complete before timeout.");
+                return await getTask(source.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                var warningMessage = $"{taskName} timed out after {timeout.TotalMinutes} minutes.";
+                logger?.LogWarning(warningMessage);
+                errorsList?.Add(new AuthenticationTimeoutException(warningMessage));
+                return null;
+            }
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlows/Utils/TokenResultExtensions.cs
+++ b/src/MSALWrapper/AuthFlows/Utils/TokenResultExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    /// <summary>
+    /// The token result extensions.
+    /// </summary>
+    internal static class TokenResultExtensions
+    {
+        /// <summary>
+        /// The set authentication type.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="authType">The auth type.</param>
+        internal static void SetAuthenticationType(this TokenResult result, AuthType authType)
+        {
+            if (result != null)
+            {
+                result.AuthType = authType;
+            }
+        }
+    }
+}

--- a/src/MSALWrapper/Constants.cs
+++ b/src/MSALWrapper/Constants.cs
@@ -26,5 +26,10 @@ namespace Microsoft.Authentication.MSALWrapper
         /// The aad redirect uri.
         /// </summary>
         public static readonly Uri AadRedirectUri = new Uri("http://localhost");
+
+        /// <summary>
+        /// The msal disabled cache.
+        /// </summary>
+        internal const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";
     }
 }

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
-    
+ 
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
-
+    
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />
@@ -46,5 +46,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.42.0" />
   </ItemGroup>
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>$(AssemblyName).Test</_Parameter1>
+            <!-- We use the value of AssemblyName to declare the value of the attribute -->
+        </AssemblyAttribute>
+    </ItemGroup>
 
 </Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
- 
+
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\..\stylecop\stylecop.json" Link="stylecop.json" />


### PR DESCRIPTION
Used composition and polymorphism to refactor and redesign the TokenFetcherPublicClient class.
Created an interface IAuthFlow that implements a GetTokenAsync method.
Each of the current AuthFlows - Broker, Web, DeviceCode are moved into their own class and they implement the IAuthFlow interface.
AuthFlows class creates a list of Auth flows to execute one by one.
Created an interface for AccountsProvider and PCACache to help separate responsibilities for providing an account and cache set respectively.
Refactored utility code into its own classes - MsalHttpClientFactoryAdapter for providing httpclient, TokenResultExtensions for augmenting tokenResult with auth type, and TaskExecutor to abstract timeout handling.

This PR specifically focuses on the Broker auth flow. Web and DeviceCode auth flow will be part of the next PR.

Please click Preview to check out the class diagram below:

```mermaid
classDiagram
      IAuthFlows <|-- AuthFlows
      IAuthFlows <|-- BrokerPCATokenFetcher 
      BrokerPCATokenFetcher *-- PCACache
      BrokerPCATokenFetcher *-- AccountsProvider
      BrokerPCATokenFetcher *-- PCAWrapper
      BrokerPCATokenFetcher *-- TaskExecutor           
      IAuthFlows : +Task<TokenResult> GetTokenAsync()
      PCAWrapper *-- IPublicClientApplication
      class AuthFlows{
          +ILogger logger
          +Guid resourceId
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
      class BrokerPCATokenFetcher {
          +ILogger logger
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
```