### PR TITLE
Created an interface for PCACache to help separate responsibilities for caching logic.

### DIFF
--- a/examples/Demo.Console.NET6/Program.cs
+++ b/examples/Demo.Console.NET6/Program.cs
@@ -31,15 +31,15 @@ namespace Demo.Console.NET6
 
             logger.LogInformation("I am ExampleCLI");
 
-            if (args.Length != 2)
+            if (args.Length != 3)
             {
-                logger.LogError("Usage: <resource> <client>");
+                logger.LogError("Usage: <resource> <client> <tenant>");
                 Environment.Exit(1);
             }
 
-            Guid resource = new Guid(args[1]);
-            Guid client = new Guid(args[2]);
-            Guid tenant = new Guid(args[3]);
+            Guid resource = new Guid(args[0]);
+            Guid client = new Guid(args[1]);
+            Guid tenant = new Guid(args[2]);
 
             // Create a token fetcher
             ITokenFetcher adoAuth = new TokenFetcherPublicClient(logger, resource, client, tenant);

--- a/src/MSALWrapper/Constants.cs
+++ b/src/MSALWrapper/Constants.cs
@@ -26,5 +26,10 @@ namespace Microsoft.Authentication.MSALWrapper
         /// The aad redirect uri.
         /// </summary>
         public static readonly Uri AadRedirectUri = new Uri("http://localhost");
+
+        /// <summary>
+        /// The msal disabled cache.
+        /// </summary>
+        internal const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";
     }
 }

--- a/src/MSALWrapper/Constants.cs
+++ b/src/MSALWrapper/Constants.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Authentication.MSALWrapper
 
         /// <summary>
         /// The name of an environment variable used to disable file cache configuration.
-
         /// </summary>
         internal const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";
     }

--- a/src/MSALWrapper/PCACache/IPCACache.cs
+++ b/src/MSALWrapper/PCACache/IPCACache.cs
@@ -12,12 +12,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
     internal interface IPCACache
     {
         /// <summary>
-        /// The setup token cache.
-        /// </summary>
-        void SetupTokenCache();
-
-        /// <summary>
-        /// The setup token cache.
+        /// Sets up the token cache.
         /// </summary>
         /// <param name="errorsList">The errors list.</param>
         void SetupTokenCache(List<Exception> errorsList);

--- a/src/MSALWrapper/PCACache/IPCACache.cs
+++ b/src/MSALWrapper/PCACache/IPCACache.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The PCACache interface.
+    /// </summary>
+    internal interface IPCACache
+    {
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        void SetupTokenCache();
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        /// <param name="errorsList">The errors list.</param>
+        void SetupTokenCache(List<Exception> errorsList);
+    }
+}

--- a/src/MSALWrapper/PCACache/PCACache.cs
+++ b/src/MSALWrapper/PCACache/PCACache.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
     using Microsoft.Identity.Client.Extensions.Msal;
 
     /// <summary>
-    /// The pca cache.
+    /// The PCA cache class.
     /// </summary>
     internal class PCACache : IPCACache
     {
@@ -56,7 +56,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         }
 
         /// <summary>
-        /// The setup token cache.
+        /// Sets up the token cache.
         /// </summary>
         /// <param name="errorsList">The errors list.</param>
         public void SetupTokenCache(List<Exception> errorsList)
@@ -96,14 +96,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
                 this.logger.LogError("An unexpected error occured creating the cache.");
                 throw new Exception(exceptionMessage);
             }
-        }
-
-        /// <summary>
-        /// The setup token cache.
-        /// </summary>
-        public void SetupTokenCache()
-        {
-            this.SetupTokenCache(new List<Exception>());
         }
     }
 }

--- a/src/MSALWrapper/PCACache/PCACache.cs
+++ b/src/MSALWrapper/PCACache/PCACache.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.Identity.Client.Extensions.Msal;
+
+    /// <summary>
+    /// The pca cache.
+    /// </summary>
+    internal class PCACache : IPCACache
+    {
+        // OSX
+        private const string MacOSAccountName = "MSALCache";
+        private const string MacOSServiceName = "Microsoft.Developer.IdentityService";
+
+        // Linux
+        private const string LinuxKeyRingSchema = "com.microsoft.identity.tokencache";
+        private const string LinuxKeyRingCollection = "default";
+        private const string LinuxKeyRingLabel = "MSAL token cache";
+        private static KeyValuePair<string, string> linuxKeyRingAttr1 = new KeyValuePair<string, string>("Version", "1");
+        private static KeyValuePair<string, string> linuxKeyRingAttr2 = new KeyValuePair<string, string>("ProductGroup", "Microsoft Develoepr Tools");
+
+        private readonly IPublicClientApplication publicClientApplication;
+        private readonly ILogger logger;
+        private readonly string osxKeyChainSuffix;
+        private readonly bool verifyPersistence;
+
+        private readonly string cacheDir;
+        private readonly string cacheFileName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PCACache"/> class.
+        /// </summary>
+        /// <param name="publicClientApplication">The public client application.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="verifyPersistence">The verify persistence.</param>
+        internal PCACache(IPublicClientApplication publicClientApplication, ILogger logger, Guid tenantId, string osxKeyChainSuffix = null, bool verifyPersistence = false)
+        {
+            this.publicClientApplication = publicClientApplication;
+            this.logger = logger;
+
+            this.osxKeyChainSuffix = string.IsNullOrWhiteSpace(osxKeyChainSuffix) ? $"{tenantId}" : $"{osxKeyChainSuffix}.{tenantId}";
+            this.verifyPersistence = verifyPersistence;
+
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            this.cacheDir = Path.Combine(appData, ".IdentityService");
+            this.cacheFileName = $"msal_{tenantId}.cache";
+        }
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        /// <param name="errorsList">The errors list.</param>
+        public void SetupTokenCache(List<Exception> errorsList)
+        {
+            var cacheDisabled = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.OEAUTH_MSAL_DISABLE_CACHE));
+            if (cacheDisabled)
+            {
+                return;
+            }
+
+            var osxKeychainItem = MacOSServiceName + (string.IsNullOrWhiteSpace(this.osxKeyChainSuffix) ? string.Empty : $".{this.osxKeyChainSuffix}");
+            var storageProperties = new StorageCreationPropertiesBuilder(this.cacheFileName, this.cacheDir)
+            .WithLinuxKeyring(LinuxKeyRingSchema, LinuxKeyRingCollection, LinuxKeyRingLabel, linuxKeyRingAttr1, linuxKeyRingAttr2)
+            .WithMacKeyChain(osxKeychainItem, MacOSAccountName)
+            .Build();
+
+            try
+            {
+                MsalCacheHelper cacher = MsalCacheHelper.CreateAsync(storageProperties).Result;
+                if (this.verifyPersistence)
+                {
+                    cacher.VerifyPersistence();
+                }
+
+                cacher.RegisterCache(this.publicClientApplication.UserTokenCache);
+            }
+            catch (MsalCachePersistenceException ex)
+            {
+                this.logger.LogWarning($"MSAL token cache verification failed.\n{ex.Message}\n");
+                errorsList.Add(ex);
+            }
+            catch (AggregateException ex) when (ex.InnerException.Message.Contains("Could not get access to the shared lock file"))
+            {
+                var exceptionMessage = ex.ToFormattedString();
+                errorsList.Add(ex);
+
+                this.logger.LogError("An unexpected error occured creating the cache.");
+                throw new Exception(exceptionMessage);
+            }
+        }
+
+        /// <summary>
+        /// The setup token cache.
+        /// </summary>
+        public void SetupTokenCache()
+        {
+            this.SetupTokenCache(new List<Exception>());
+        }
+    }
+}


### PR DESCRIPTION
# What and Why
This PR contains an `IPCACache` that implements `SetupTokenCache`. This class will be shared across Broker, Web and DeviceCode auth flow and so I separated the responsibilities.

# Things to note
Moved `msal disable cache` flag into Constants file.
Created a `IPCACache` that implements `SetupTokenCache` and expects an errorList as an input. Currently this method is part of the `TokenFetcherPublicClient` class.

# Test
Nothing to test so far. This is just a refactor.

# Class diagram
The class diagram below gives a representation on how these classes are used. For brevity, I have only represented `AuthFlowBroker` but you could have any auth flow and the flow will look the same more or less.

```mermaid
classDiagram
      IAuthFlows <|-- AuthFlows
      IAuthFlows <|-- AuthFlowBroker
      AuthFlowBroker*-- PCACache
      AuthFlowBroker*-- AccountsProvider
      AuthFlowBroker*-- PCAWrapper
      AuthFlowBroker*-- TaskExecutor
     AuthFlowBroker*-- MsalHttpClientFactoryAdaptor
     AuthFlowBroker*-- TokenResultExtensions
      IAuthFlows : +Task<TokenResult> GetTokenAsync()
      PCAWrapper *-- IPublicClientApplication
      class AuthFlows{
          +ILogger logger
          +Guid resourceId
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
      class AuthFlowBroker{
          +ILogger logger
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
```