### PR TITLE
Refactored common utilities into its own class

### DIFF
--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         /// The get http client.
         /// </summary>
         /// <returns>An instance of <see cref="HttpClient"/>.</returns>
-
         public HttpClient GetHttpClient()
         {
             // MSAL calls this method each time it wants to use an HTTP client.

--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The msal http client factory adaptor.
+    /// </summary>
+    internal class MsalHttpClientFactoryAdaptor : IMsalHttpClientFactory
+    {
+        /// <summary>
+        /// The get http client.
+        /// </summary>
+        /// <returns>The <see cref="HttpClient"/>.</returns>
+        public HttpClient GetHttpClient()
+        {
+            // MSAL calls this method each time it wants to use an HTTP client.
+            // We ensure we only create a single instance to avoid socket exhaustion.
+            HttpClientHandler handler = new HttpClientHandler();
+            var client = new HttpClient(handler);
+            client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true,
+            };
+
+            return client;
+        }
+    }
+}

--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         /// <summary>
         /// The get http client.
         /// </summary>
-        /// <returns>The <see cref="HttpClient"/>.</returns>
+        /// <returns>An instance of <see cref="HttpClient"/>.</returns>
+
         public HttpClient GetHttpClient()
         {
             // MSAL calls this method each time it wants to use an HTTP client.

--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
     internal class MsalHttpClientFactoryAdaptor : IMsalHttpClientFactory
     {
         /// <summary>
-        /// The get http client.
+        /// Gets the msal http client.
         /// </summary>
         /// <returns>An instance of <see cref="HttpClient"/>.</returns>
         public HttpClient GetHttpClient()

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// The task executor.
+    /// </summary>
+    internal class TaskExecutor
+    {
+        /// <summary>
+        /// The complete within.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="taskName">The task name.</param>
+        /// <param name="getTask">The get task.</param>
+        /// <param name="errorsList">The errors list.</param>
+        /// <param name="logger">The logger.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        internal static async Task<T> CompleteWithin<T>(TimeSpan timeout, string taskName, Func<CancellationToken, Task<T>> getTask, List<Exception> errorsList = null, ILogger logger = null)
+            where T : class
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            source.CancelAfter(timeout);
+            try
+            {
+                logger?.LogDebug($"{taskName} has {timeout.TotalMinutes} minutes to complete before timeout.");
+                return await getTask(source.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                var warningMessage = $"{taskName} timed out after {timeout.TotalMinutes} minutes.";
+                logger?.LogWarning(warningMessage);
+                errorsList?.Add(new AuthenticationTimeoutException(warningMessage));
+                return null;
+            }
+        }
+    }
+}

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -10,21 +10,21 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    /// The task executor.
+    /// The task executor class.
     /// </summary>
-    internal class TaskExecutor
+    internal static class TaskExecutor
     {
         /// <summary>
-        /// The complete within.
+        /// Completes a task within the timeout period.
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
+        /// <param name="logger">The logger.</param>
         /// <param name="timeout">The timeout.</param>
         /// <param name="taskName">The task name.</param>
         /// <param name="getTask">A function that return the task you want to complete within the given timeout.</param>
         /// <param name="errorsList">The errors list.</param>
-        /// <param name="logger">The logger.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        internal static async Task<T> CompleteWithin<T>(TimeSpan timeout, string taskName, Func<CancellationToken, Task<T>> getTask, List<Exception> errorsList = null, ILogger logger = null)
+        internal static async Task<T> CompleteWithin<T>(ILogger logger, TimeSpan timeout, string taskName, Func<CancellationToken, Task<T>> getTask, List<Exception> errorsList)
             where T : class
         {
             CancellationTokenSource source = new CancellationTokenSource();

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         /// <typeparam name="T">The type.</typeparam>
         /// <param name="timeout">The timeout.</param>
         /// <param name="taskName">The task name.</param>
-        /// <param name="getTask">The get task.</param>
+        /// <param name="getTask">A function that return the task you want to complete within the given timeout.</param>
+
         /// <param name="errorsList">The errors list.</param>
         /// <param name="logger">The logger.</param>
         /// <returns>The <see cref="Task"/>.</returns>

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         /// <param name="timeout">The timeout.</param>
         /// <param name="taskName">The task name.</param>
         /// <param name="getTask">A function that return the task you want to complete within the given timeout.</param>
-
         /// <param name="errorsList">The errors list.</param>
         /// <param name="logger">The logger.</param>
         /// <returns>The <see cref="Task"/>.</returns>

--- a/src/MSALWrapper/TokenResultExtensions.cs
+++ b/src/MSALWrapper/TokenResultExtensions.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Authentication.MSALWrapper.AuthFlows
 {
     /// <summary>
-    /// Extension methods to the <see cref="TokenResult"/> class.
+    /// Extension method to the <see cref="TokenResult"/> class.
     /// </summary>
     internal static class TokenResultExtensions
     {
         /// <summary>
-        /// Set the AuthType property to the given authType if the token result is not null.
+        /// Sets the AuthType property to the given authType if the token result is not null.
         /// </summary>
         /// <param name="result">The result.</param>
         /// <param name="authType">The auth type.</param>

--- a/src/MSALWrapper/TokenResultExtensions.cs
+++ b/src/MSALWrapper/TokenResultExtensions.cs
@@ -4,12 +4,14 @@
 namespace Microsoft.Authentication.MSALWrapper.AuthFlows
 {
     /// <summary>
-    /// The token result extensions.
+    /// Extension methods to the <see cref="TokenResult"/> class.
+
     /// </summary>
     internal static class TokenResultExtensions
     {
         /// <summary>
-        /// The set authentication type.
+        /// Set the AuthType property to the given authType if the token result is not null. 
+
         /// </summary>
         /// <param name="result">The result.</param>
         /// <param name="authType">The auth type.</param>

--- a/src/MSALWrapper/TokenResultExtensions.cs
+++ b/src/MSALWrapper/TokenResultExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+{
+    /// <summary>
+    /// The token result extensions.
+    /// </summary>
+    internal static class TokenResultExtensions
+    {
+        /// <summary>
+        /// The set authentication type.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="authType">The auth type.</param>
+        internal static void SetAuthenticationType(this TokenResult result, AuthType authType)
+        {
+            if (result != null)
+            {
+                result.AuthType = authType;
+            }
+        }
+    }
+}

--- a/src/MSALWrapper/TokenResultExtensions.cs
+++ b/src/MSALWrapper/TokenResultExtensions.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
 {
     /// <summary>
     /// Extension methods to the <see cref="TokenResult"/> class.
-
     /// </summary>
     internal static class TokenResultExtensions
     {
         /// <summary>
-        /// Set the AuthType property to the given authType if the token result is not null. 
-
+        /// Set the AuthType property to the given authType if the token result is not null.
         /// </summary>
         /// <param name="result">The result.</param>
         /// <param name="authType">The auth type.</param>


### PR DESCRIPTION
# What
Refactored (not 100% new code) utility code into its own classes - 
MsalHttpClientFactoryAdapter for providing MSAL httpclient.

TokenResultExtensions for augmenting tokenResult with auth type.

TaskExecutor to abstract timeout handling.

# Why
Each of these were individual methods in the `TokenFetcherPublicClient` class but used commonly between auth flows. Since we are separating auth flows into its own class, separating them them will enable us to use them commonly.

# Things to note
TaskExecutor - `CompleteWithin` method is used bythe `GetTokenNormalFlowAsync` method and during device code flow. Which means we use this method no matter which auth flow we try to execute. I moved it to its own class and gave it `logger` and `List<Exception> errorsList` as well so that we can match the usage just as before.

# Test
Nothing to test so far. This is just a refactor.

# Class diagram
The class diagram below gives a representation on how these classes are used. For brevity, I have only represented `AuthFlowBroker` but you could have any auth flow and the flow will look the same more or less.

```mermaid
classDiagram
      IAuthFlows <|-- AuthFlows
      IAuthFlows <|-- AuthFlowBroker
      AuthFlowBroker*-- PCACache
      AuthFlowBroker*-- AccountsProvider
      AuthFlowBroker*-- PCAWrapper
      AuthFlowBroker*-- TaskExecutor
     AuthFlowBroker*-- MsalHttpClientFactoryAdaptor
     AuthFlowBroker*-- TokenResultExtensions
      IAuthFlows : +Task<TokenResult> GetTokenAsync()
      PCAWrapper *-- IPublicClientApplication
      class AuthFlows{
          +ILogger logger
          +Guid resourceId
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
      class AuthFlowBroker{
          +ILogger logger
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false
      }
```