### PR TITLE
Always add newlines around *nix $PATH updates

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -95,7 +95,7 @@ for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
 do
     if ! grep "${path_modification}" "${shell_profile}" &>/dev/null; then
         verbose "Updating \$PATH in ${shell_profile} to include ${latest_directory}"
-        echo "${path_modification}" >> $shell_profile
+        printf "\n${path_modification}\n" >> $shell_profile
     fi
 done
 


### PR DESCRIPTION
This resolves a small bug that @kyle-rader noticed where shell config files with no trailing newline would be incorrectly updated. Without this we could end up ruining someone's config. Here's the example @kyle-rader provided.

```bash
# enable pyenv shims and autocompletion
if command -v pyenv 1>/dev/null 2>&1
then
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
fiexport PATH="${PATH}:${HOME}/.azureauth/latest"
```