### PR TITLE
Enable customized header text for WAM prompts and web mode in Broker

### DIFF
--- a/src/MSALWrapper.Test/AuthFlowTest/AuthFlowBrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlowTest/AuthFlowBrokerTest.cs
@@ -399,11 +399,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         /// <summary>
-        /// Ensure <see cref="IPCAWrapper.WithPromptHint"/> be invoked in <see cref="TokenFetcherPublicClient.GetTokenNormalFlowAsync"/>.
+        /// Ensure <see cref="IPCAWrapper.WithPromptHint"/> be invoked in <see cref="AuthFlowBroker.GetTokenAsync"/>.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
         [Test]
-        public async Task GetTokenNormalFlowAsync_GetTokenInteractive_WithPromptHint()
+        public async Task BrokerAuthFlow_GetTokenInteractiveAsync_WithPromptHint()
         {
             this.SilentAuthUIRequired();
             this.InteractiveAuthResult();


### PR DESCRIPTION
This PR incorporates changes Rick did for adding customized header text in WAM prompts and web mode.
PR reference - https://github.com/AzureAD/microsoft-authentication-cli/pull/11

Since this PR is already reviewed and has all the details, please check it out if you are missing any context.