### PR TITLE
Fixing the namespace and usage from AuthFlowBroker to AuthFlow.Broker

### DIFF
--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
 #if NET472
     using Microsoft.Identity.Client.Desktop;
@@ -15,7 +15,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
     /// <summary>
     /// The broker auth flow.
     /// </summary>
-    public class AuthFlowBroker : IAuthFlow
+    public class Broker : IAuthFlow
     {
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
@@ -37,7 +37,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         #endregion
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthFlowBroker"/> class.
+        /// Initializes a new instance of the <see cref="Broker"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
         /// <param name="clientId">The client id.</param>
@@ -47,7 +47,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlows
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
-        public AuthFlowBroker(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
+        public Broker(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
         {
             this.ErrorsList = new List<Exception>();
             this.logger = logger;

--- a/src/MSALWrapper/AuthFlow/IAuthFlow.cs
+++ b/src/MSALWrapper/AuthFlow/IAuthFlow.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System.Threading.Tasks;
 
     /// <summary>
-    /// The IAuthFlows interface.
+    /// The IAuthFlow interface.
     /// </summary>
     public interface IAuthFlow
     {

--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System.Net.Http;
     using System.Net.Http.Headers;

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System;
     using System.Collections.Generic;

--- a/src/MSALWrapper/TokenResultExtensions.cs
+++ b/src/MSALWrapper/TokenResultExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Authentication.MSALWrapper.AuthFlows
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     /// <summary>
     /// Extension method to the <see cref="TokenResult"/> class.


### PR DESCRIPTION
1. Changed the namespace from AuthFlows to Authflow
2. Changed the usage of AuthFlowBroker to be AuthFlow.Broker for better readability
3. Further cleaned the variable name from `authFlowBroker` to `broker`