### PR TITLE
AuthFlowExecutor that orchestrates different auth flows to get token and collect errors

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private IServiceProvider serviceProvider;
         private MemoryTarget logTarget;
         private TokenResult tokenResult;
+        private IEnumerable<IAuthFlow> authFlows;
 
         /// <summary>
         /// The test setup.
@@ -40,6 +41,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.logTarget = new MemoryTarget("memory_target");
             loggingConfig.AddTarget(this.logTarget);
             loggingConfig.AddRuleForAllLevels(this.logTarget);
+            this.authFlows = new List<IAuthFlow>();
 
             // Setup Dependency Injection container to provide logger and out class under test (the "subject")
             this.serviceProvider = new ServiceCollection()
@@ -54,6 +56,44 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             // Mock successful token result
             this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        [Test]
+        public void ConstructorWith_BothNullArgs()
+        {
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, null);
+
+            // Assert
+            authFlowExecutor.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void ConstructorWith_Null_Logger()
+        {
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, this.authFlows);
+
+            // Assert
+            authFlowExecutor.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void ConstructorWith_Null_AuthFlows()
+        {
+            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
+            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null);
+
+            // Assert
+            authFlowExecutor.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void ConstructorWith_Valid_Arguments()
+        {
+            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
+            Action authFlowExecutor = () => new AuthFlowExecutor(logger, this.authFlows);
+
+            // Assert
+            authFlowExecutor.Should().NotThrow<ArgumentNullException>();
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Authentication.MSALWrapper.Test;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// The main auth flow test.
+    /// </summary>
+    public class AuthFlowExecutorTest
+    {
+        private const string TestUser = "user@microsoft.com";
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapperMock;
+        private Mock<IAccount> testAccount;
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The test setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        [Test]
+        public async Task SingleAuthFlow_Returns_TokenResult()
+        {
+            var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, null);
+            authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
+
+            // Act
+            var authFlow = this.Subject(new[] { authFlow1.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            authFlow1.VerifyAll();
+            result.Should().NotBeNull();
+            result.TokenResult.Should().Be(this.tokenResult);
+            result.Success.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task SingleAuthFlow_Returns_Null()
+        {
+            var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
+
+            // Act
+            var authFlow = this.Subject(new[] { authFlow1.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            authFlow1.VerifyAll();
+            result.Should().NotBeNull();
+            result.Success.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
+        {
+            var authFlowResult1 = new AuthFlowResult(null, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+
+            var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
+
+            var authFlow2 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow2.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult2);
+
+            // Act
+            var authFlow = this.Subject(new[] { authFlow1.Object, authFlow2.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            authFlow1.VerifyAll();
+            authFlow2.VerifyAll();
+            result.TokenResult.Should().Be(this.tokenResult);
+            result.Success.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task HasTwoAuthFlows_Returns_Null_TokenResult_With_Errors()
+        {
+            var errors1 = new[]
+            {
+                new Exception("Exception 1."),
+            };
+            var authFlowResult1 = new AuthFlowResult(null, errors1);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+
+            var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
+
+            var authFlow2 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow2.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult2);
+
+            // Act
+            var authFlow = this.Subject(new[] { authFlow1.Object, authFlow2.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            authFlow1.VerifyAll();
+            authFlow2.VerifyAll();
+            result.TokenResult.Should().Be(this.tokenResult);
+            result.Success.Should().BeTrue();
+            result.Errors.Should().BeEquivalentTo(errors1);
+        }
+
+        [Ignore("Not yet!")]
+        [Test]
+        public async Task AuthFlowExecutor_HasTwoAuthFlows_Returns_Null_AuthFlowResult()
+        {
+            var authFlowResult = new AuthFlowResult(this.tokenResult, null);
+
+            var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
+
+            var authFlow2 = new Mock<IAuthFlow>(MockBehavior.Strict);
+            authFlow2.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
+
+            // Act
+            var authFlow = this.Subject(new[] { authFlow1.Object, authFlow2.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            authFlow1.VerifyAll();
+            authFlow2.VerifyAll();
+            result.TokenResult.Should().Be(this.tokenResult);
+            result.Success.Should().BeTrue();
+
+            // result.Errors.Should().NotBeNullOrEmpty();
+        }
+
+        private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
+        {
+            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
+            return new AuthFlowExecutor(logger, authFlows);
+        }
+    }
+}

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task SingleAuthFlow_Returns_Null_TokenResult()
         {
-            var authFlowResult = new AuthFlowResult(null, null);
+            var authFlowResult = new AuthFlowResult();
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
@@ -181,7 +181,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
         {
-            var authFlowResult1 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
             var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
@@ -237,7 +237,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
-            var authFlowResult = new AuthFlowResult(null, null);
+            var authFlowResult = new AuthFlowResult();
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -331,8 +331,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task HasThreeAuthFlows_Returns_Null_TokenResult()
         {
-            var authFlowResult1 = new AuthFlowResult(null, null);
-            var authFlowResult2 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
+            var authFlowResult2 = new AuthFlowResult();
             var authFlowResult3 = new AuthFlowResult(this.tokenResult, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
@@ -411,8 +411,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, null);
-            var authFlowResult2 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
+            var authFlowResult2 = new AuthFlowResult();
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -25,14 +25,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     /// </summary>
     public class AuthFlowExecutorTest
     {
-        private const string TestUser = "user@microsoft.com";
-
         private IServiceProvider serviceProvider;
         private MemoryTarget logTarget;
-
-        // MSAL Specific Mocks
-        private Mock<IPCAWrapper> pcaWrapperMock;
-        private Mock<IAccount> testAccount;
         private TokenResult tokenResult;
 
         /// <summary>
@@ -46,12 +40,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.logTarget = new MemoryTarget("memory_target");
             loggingConfig.AddTarget(this.logTarget);
             loggingConfig.AddRuleForAllLevels(this.logTarget);
-
-            // MSAL Mocks
-            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
-            this.testAccount.Setup(a => a.Username).Returns(TestUser);
-
-            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
 
             // Setup Dependency Injection container to provide logger and out class under test (the "subject")
             this.serviceProvider = new ServiceCollection()
@@ -102,7 +90,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlow1.VerifyAll();
             result.Should().NotBeNull();
             result.Success.Should().BeFalse();
-            result.Errors.Should().BeNullOrEmpty();
+            result.Errors.Should().BeEmpty();
         }
 
         [Test]
@@ -262,9 +250,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().BeNull();
             result.Success.Should().BeFalse();
             result.Errors.Should().HaveCount(3);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors2[1]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors2[1] });
         }
 
         [Test]
@@ -299,9 +285,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().Be(this.tokenResult);
             result.Success.Should().BeTrue();
             result.Errors.Should().HaveCount(3);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors2[1]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors2[1] });
         }
 
         [Test]
@@ -376,20 +360,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().Be(this.tokenResult);
             result.Success.Should().BeTrue();
             result.Errors.Should().HaveCount(4);
-            result.Errors[0].Should().BeOfType(typeof(Exception));
-            result.Errors[1].Should().BeOfType(typeof(Exception));
-            result.Errors[2].Should().BeOfType(typeof(Exception));
-            result.Errors[3].Should().BeOfType(typeof(Exception));
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors3[0]);
-            result.Errors[3].Should().BeEquivalentTo(errors3[1]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors3[0], errors3[1] });
         }
 
         [Test]
         public async Task HasThreeAuthFlows_Returns_Null_AuthFlowResult()
         {
-            var errors1 = new[]
+            var expectedError = new[]
             {
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
@@ -417,7 +394,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().BeNull();
             result.Success.Should().BeFalse();
             result.Errors.Should().HaveCount(1);
-            result.Errors.Should().BeEquivalentTo(errors1);
+            result.Errors.Should().BeEquivalentTo(expectedError);
         }
 
         [Test]
@@ -461,9 +438,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().BeNull();
             result.Success.Should().BeFalse();
             result.Errors.Should().HaveCount(3);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors3[0]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors3[0] });
         }
 
         [Test]
@@ -507,9 +482,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().BeNull();
             result.Success.Should().BeFalse();
             result.Errors.Should().HaveCount(3);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors3[0]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors3[0] });
         }
 
         [Test]
@@ -554,10 +527,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().Be(this.tokenResult);
             result.Success.Should().BeTrue();
             result.Errors.Should().HaveCount(4);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors3[0]);
-            result.Errors[3].Should().BeEquivalentTo(errors3[1]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors3[0], errors3[1] });
         }
 
         [Test]
@@ -601,9 +571,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().Be(this.tokenResult);
             result.Success.Should().BeTrue();
             result.Errors.Should().HaveCount(3);
-            result.Errors[0].Should().BeEquivalentTo(errors1[0]);
-            result.Errors[1].Should().BeEquivalentTo(errors2[0]);
-            result.Errors[2].Should().BeEquivalentTo(errors2[1]);
+            result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors2[1] });
         }
 
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     /// </summary>
     public class AuthFlowExecutorTest
     {
+        private const string NullAuthFlowResultExceptionMessage = "Auth flow 'IAuthFlowProxy' returned a null AuthFlowResult.";
+
         private IServiceProvider serviceProvider;
         private MemoryTarget logTarget;
         private TokenResult tokenResult;
@@ -161,7 +163,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -235,7 +237,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
             var authFlowResult = new AuthFlowResult();
 
@@ -263,7 +265,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -298,7 +300,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -408,7 +410,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var expectedError = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult();
@@ -452,7 +454,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors3 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult(null, errors1);
@@ -491,7 +493,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]
@@ -535,7 +537,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new Exception("This is a catastrophic failure. AuthFlow result is null!"),
+                new Exception(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWithnullArgs()
         {
-            var subject = new AuthFlowResult(null, null);
+            var subject = new AuthFlowResult();
             subject.Success.Should().BeFalse();
             subject.TokenResult.Should().BeNull();
             subject.Errors.Should().BeEmpty();
@@ -36,6 +36,20 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.Success.Should().BeTrue();
             subject.TokenResult.Should().Be(tokenResult);
             subject.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddErrors()
+        {
+            var subject = new AuthFlowResult();
+            var errors = new List<Exception>
+            {
+                new ArgumentException("something can't be null"),
+                new NullReferenceException("you cannot get there from here"),
+            };
+
+            subject.AddErrors(errors);
+            subject.Errors.Should().BeEquivalentTo(errors);
         }
     }
 }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -39,8 +39,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 var attempt = await authFlow.GetTokenAsync();
                 if (attempt == null)
                 {
-                    result.Errors.Add(new Exception("This is a catastrophic failure. AuthFlow result is null!"));
-                    this.logger.LogDebug($"This is a catastrophic failure. AuthFlow result is null!");
+                    var oopsMessage = $"Auth flow '{authFlow.GetType().Name}' returned a null AuthFlowResult.";
+                    result.Errors.Add(new Exception(oopsMessage));
+                    this.logger.LogDebug(oopsMessage);
                 }
                 else
                 {

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="authFlows">The list of auth flows.</param>
         public AuthFlowExecutor(ILogger logger, IEnumerable<IAuthFlow> authFlows)
         {
-            this.logger = logger;
-            this.authflows = authFlows;
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.authflows = authFlows ?? throw new ArgumentNullException(nameof(authFlows));
         }
 
         /// <summary>

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 if (attempt == null)
                 {
                     result.Errors.Add(new Exception("This is a catastrophic failure. AuthFlow result is null!"));
-                    this.logger.LogError($"This is a catastrophic failure. AuthFlow result is null!");
+                    this.logger.LogDebug($"This is a catastrophic failure. AuthFlow result is null!");
                 }
                 else
                 {

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 var result = await authFlow.GetTokenAsync();
                 if (result == null)
                 {
-                    authFlowResult.Errors.Add(new Exception());
+                    authFlowResult.Errors.Add(new Exception("This is a catastrophic failure. AuthFlow result is null!"));
                 }
                 else
                 {

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// The auth flows class.
+    /// </summary>
+    public class AuthFlowExecutor : IAuthFlow
+    {
+        private readonly IEnumerable<IAuthFlow> authflows;
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthFlowExecutor"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="authFlows">The list of auth flows.</param>
+        public AuthFlowExecutor(ILogger logger, IEnumerable<IAuthFlow> authFlows)
+        {
+            this.logger = logger;
+            this.authflows = authFlows;
+        }
+
+        /// <summary>
+        /// Gets the auth flow result.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<AuthFlowResult> GetTokenAsync()
+        {
+            AuthFlowResult authFlowResult = new AuthFlowResult(null, new List<Exception>());
+            foreach (var authFlow in this.authflows)
+            {
+                var result = await authFlow.GetTokenAsync();
+                if (result == null)
+                {
+                    authFlowResult.Errors.Add(new Exception());
+                }
+                else
+                {
+                    foreach (var error in result.Errors)
+                    {
+                        authFlowResult.Errors.Add(error);
+                    }
+
+                    if (result.Success)
+                    {
+                        authFlowResult.TokenResult = result.TokenResult;
+                        break;
+                    }
+                }
+            }
+
+            return authFlowResult;
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 }
                 else
                 {
-                    AuthFlowResult.AddErrorsToAuthFlowExecutorList(result, attempt);
+                    result.AddErrors(attempt.Errors);
 
                     if (attempt.Success)
                     {

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -39,5 +39,18 @@ namespace Microsoft.Authentication.MSALWrapper
         {
             get { return this.TokenResult != null; }
         }
+
+        /// <summary>
+        /// Adds the errors from the attempted auth flows to the main error list on Auth flow executor.
+        /// </summary>
+        /// <param name="authFlowResult">A <see cref="MSALWrapper.AuthFlowResult"/> that creates a main list of errors after attempting all the auth flows in the list.</param>
+        /// <param name="result">A <see cref="MSALWrapper.AuthFlowResult"/> that collects errors from the attempted auth flows at a time.</param>
+        internal static void AddErrorsToAuthFlowExecutorList(AuthFlowResult authFlowResult, AuthFlowResult result)
+        {
+            foreach (var error in result.Errors)
+            {
+                authFlowResult.Errors.Add(error);
+            }
+        }
     }
 }

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -12,10 +12,18 @@ namespace Microsoft.Authentication.MSALWrapper
     public class AuthFlowResult
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
+        /// </summary>
+        public AuthFlowResult()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class.
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
-        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result.</param>
+        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
         public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors)
         {
             this.TokenResult = tokenResult;
@@ -41,15 +49,14 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
-        /// Adds the errors from the attempted auth flows to the main error list on Auth flow executor.
+        /// Add the given errors to the <see cref="Errors"/> list.
         /// </summary>
-        /// <param name="authFlowResult">A <see cref="MSALWrapper.AuthFlowResult"/> that creates a main list of errors after attempting all the auth flows in the list.</param>
-        /// <param name="result">A <see cref="MSALWrapper.AuthFlowResult"/> that collects errors from the attempted auth flows at a time.</param>
-        internal static void AddErrorsToAuthFlowExecutorList(AuthFlowResult authFlowResult, AuthFlowResult result)
+        /// <param name="errors">The errors to add.</param>
+        public void AddErrors(IEnumerable<Exception> errors)
         {
-            foreach (var error in result.Errors)
+            foreach (var error in errors)
             {
-                authFlowResult.Errors.Add(error);
+                this.Errors.Add(error);
             }
         }
     }


### PR DESCRIPTION
# What
Added `AuthFlowExecutor` class and its test.

# Why
This is a top level class that runs through a list of auth flows and mainly does 2 things
1. Gets a token
2. Collects error

If the auth flow result or token result is null, we still collect the errors. If the auth flow result is success, we assign the token and break.

# Test
Units tests were added for cases as the following:
1. Single auth flow returns token result.
2. Single auth flow returns null token result.
3. Single auth flow returns null auth flow result.
4. Single auth flow returns null token result with errors.
5. Single auth flow returns null auth flow result with errors.
6. Similar tests were added for two and three auth flows respectively to check the behavior.