### PR TITLE
Update to MSAL 4.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Rename the `--auth-mode` flag to `--mode`.
+- Update to MSAL 4.43.1.
 
 ### Removed
 - The `-t`, `-c`, `-d`, `-m`, and `-o` short flags.

--- a/examples/Demo.Console.NETFramework472/Demo.Console.NETFramework472.csproj
+++ b/examples/Demo.Console.NETFramework472/Demo.Console.NETFramework472.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.42.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.43.1" />
     <PackageReference Include="Microsoft.Office.Lasso" Version="2022.1.6.1" />
   </ItemGroup>
 

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -38,13 +38,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.42.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.43.1" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.6" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.16.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.42.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.43.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update to MSAL 4.43.1 which default to using WebView1 instead of WebView2. This re-enables proper broker integration so that embedded web view auth attempts are able to prove they are coming from a managed device. (This bug is causing over-prompting because the RT returned from this flow expires after 12 hours on machines suffering this issue). It's not 100% of customers hitting this because of the former shared cache. But the new cache, not warmed by Visual Studio will make this more prevalent.