### PR TITLE
Only write token output directly to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- Fix a bug that caused tokens to be written to log files.
+
 ### Added
 - Option `--prompt-hint` to support custom text to prompt caller in web and WAM mode.
 

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -337,10 +337,10 @@ Allowed values: [all, web, devicecode]";
                         this.logger.LogSuccess(tokenResult.ToString());
                         break;
                     case OutputMode.Token:
-                        this.logger.LogInformation(tokenResult.Token);
+                        Console.Write(tokenResult.Token);
                         break;
                     case OutputMode.Json:
-                        this.logger.LogInformation(tokenResult.ToJson());
+                        Console.Write(tokenResult.ToJson());
                         break;
                     case OutputMode.None:
                         break;


### PR DESCRIPTION
Only write token output to `stdout` directly to prevent writing the token to the auto-written log file that Lasso configures.