### PR TITLE
Web Auth Flow

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -1,0 +1,599 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    internal class WebTest
+    {
+        private const string MsalServiceExceptionErrorCode = "1";
+        private const string MsalServiceExceptionMessage = "MSAL Service Exception: Something bad has happened!";
+        private const string TestUser = "user@microsoft.com";
+
+        // These Guids were randomly generated and do not refer to a real resource or client
+        // as we don't need either for our testing.
+        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+
+        private string promptHint = "test prompt hint";
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapperMock;
+        private Mock<IAccount> testAccount;
+        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The test setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<AuthFlow.Web>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<AuthFlow.Web>>();
+                 return new AuthFlow.Web(logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        /// <summary>
+        /// Get a new instance of the class under test.
+        /// </summary>
+        /// <returns>The <see cref="AuthFlow.Web"/> registered in the <see cref="Setup"/> method.</returns>
+        public AuthFlow.Web Subject() => this.serviceProvider.GetService<AuthFlow.Web>();
+
+        /// <summary>
+        /// The web auth flow for the happy path.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_HappyPath()
+        {
+            this.SilentAuthResult();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The web auth flow get token silent returns null token result.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenSilent_ReturnsNull()
+        {
+            this.SilentAuthReturnsNull();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The web auth flow throws MSAL UI exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_MsalUIException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthResult();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The web auth flow throws MSAL UI exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithoutClaims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthResultReturnsNullWithoutClaims();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The web auth flow throws general exception.
+        /// </summary>
+        [Test]
+        public void WebAuthFlow_General_Exceptions_Are_ReThrown()
+        {
+            var message = "Something somwhere has gone terribly wrong!";
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new Exception(message));
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            Func<Task> subject = async () => await web.GetTokenAsync();
+
+            // Assert
+            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+
+            // This VerifyAll must come after the assert, since the assert is what execute the lambda
+            this.pcaWrapperMock.VerifyAll();
+        }
+
+        /// <summary>
+        /// The web auth flow throws MSAL Service exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenSilent_MsalServiceException()
+        {
+            this.SilentAuthServiceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert - this method should not throw for known types of excpeptions, instead return null, so
+            // our caller can retry auth another way.
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token silent throws operation canceled exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenSilent_OperationCanceledException()
+        {
+            this.SilentAuthTimeout();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+        }
+
+        /// <summary>
+        /// The web auth flow get token silent throws Msal Client exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenSilent_MsalClientException()
+        {
+            this.SilentAuthClientException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token silent throws null reference exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenSilent_NullReferenceException()
+        {
+            this.SilentAuthNullReferenceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token interactive throws MSAL UI exception for Claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsResult();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The web auth flow throws MSAL UI exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithClaims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthResultReturnsNullWithClaims();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token interactive throws MSAL service exception after using Claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsServiceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(3);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token interactive throws MSAL service exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthServiceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        /// <summary>
+        /// The web auth flow get token interactive throws operation canceled exception.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthTimeout();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+        }
+
+        /// <summary>
+        /// The web auth flow get token interactive throws operation canceled exception for claims.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
+        [Test]
+        public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
+        {
+            this.SilentAuthUIRequired();
+            this.InteractiveAuthExtraClaimsRequired();
+            this.InteractiveAuthWithClaimsTimeout();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(3);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+        }
+
+        private void SilentAuthResult()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void SilentAuthReturnsNull()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((TokenResult)null);
+        }
+
+        private void SilentAuthUIRequired()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "UI is required"));
+            this.SetupInteractiveAuthWithPromptHint();
+        }
+
+        private void SilentAuthServiceException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void SilentAuthTimeout()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void SilentAuthClientException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
+        }
+
+        private void SilentAuthNullReferenceException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
+        }
+
+        private void InteractiveAuthResult()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void InteractiveAuthResultReturnsNullWithoutClaims()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
+        }
+
+        private void InteractiveAuthWithClaimsResult()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.tokenResult);
+        }
+
+        private void InteractiveAuthResultReturnsNullWithClaims()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
+        }
+
+        private void InteractiveAuthTimeout()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void InteractiveAuthExtraClaimsRequired()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "Extra Claims are required."));
+        }
+
+        private void InteractiveAuthServiceException()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void InteractiveAuthWithClaimsServiceException()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void InteractiveAuthWithClaimsTimeout()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void MockAccount()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync(this.testAccount.Object);
+        }
+
+        private void SetupInteractiveAuthWithPromptHint()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.WithPromptHint(It.IsAny<string>()))
+                .Returns((string s) => this.pcaWrapperMock.Object);
+        }
+    }
+}

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -42,9 +42,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
         private TokenResult tokenResult;
 
-        /// <summary>
-        /// The test setup.
-        /// </summary>
         [SetUp]
         public void Setup()
         {
@@ -57,7 +54,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // MSAL Mocks
             this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
             this.testAccount.Setup(a => a.Username).Returns(TestUser);
-
             this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
 
             // Setup Dependency Injection container to provide logger and out class under test (the "subject")
@@ -80,20 +76,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
         }
 
-        /// <summary>
-        /// Get a new instance of the class under test.
-        /// </summary>
-        /// <returns>The <see cref="AuthFlow.Web"/> registered in the <see cref="Setup"/> method.</returns>
         public AuthFlow.Web Subject() => this.serviceProvider.GetService<AuthFlow.Web>();
 
-        /// <summary>
-        /// The web auth flow for the happy path.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
-        public async Task WebAuthFlow_HappyPath()
+        public async Task WebAuthFlow_CachedToken()
         {
             this.SilentAuthResult();
 
@@ -110,12 +96,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().BeEmpty();
         }
 
-        /// <summary>
-        /// The web auth flow get token silent returns null token result.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenSilent_ReturnsNull()
         {
@@ -133,12 +113,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().BeEmpty();
         }
 
-        /// <summary>
-        /// The web auth flow throws MSAL UI exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_MsalUIException()
         {
@@ -159,12 +133,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
         }
 
-        /// <summary>
-        /// The web auth flow throws MSAL UI exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithoutClaims()
         {
@@ -184,9 +152,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
         }
 
-        /// <summary>
-        /// The web auth flow throws general exception.
-        /// </summary>
         [Test]
         public void WebAuthFlow_General_Exceptions_Are_ReThrown()
         {
@@ -208,12 +173,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
         }
 
-        /// <summary>
-        /// The web auth flow throws MSAL Service exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenSilent_MsalServiceException()
         {
@@ -233,12 +192,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
         }
 
-        /// <summary>
-        /// The web auth flow get token silent throws operation canceled exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenSilent_OperationCanceledException()
         {
@@ -258,12 +211,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
         }
 
-        /// <summary>
-        /// The web auth flow get token silent throws Msal Client exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenSilent_MsalClientException()
         {
@@ -282,12 +229,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
         }
 
-        /// <summary>
-        /// The web auth flow get token silent throws null reference exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenSilent_NullReferenceException()
         {
@@ -306,12 +247,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
         }
 
-        /// <summary>
-        /// The web auth flow get token interactive throws MSAL UI exception for Claims.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
         {
@@ -333,12 +268,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
         }
 
-        /// <summary>
-        /// The web auth flow throws MSAL UI exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithClaims()
         {
@@ -359,12 +288,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
         }
 
-        /// <summary>
-        /// The web auth flow get token interactive throws MSAL service exception after using Claims.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
         {
@@ -387,12 +310,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
         }
 
-        /// <summary>
-        /// The web auth flow get token interactive throws MSAL service exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException()
         {
@@ -413,12 +330,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
         }
 
-        /// <summary>
-        /// The web auth flow get token interactive throws operation canceled exception.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException()
         {
@@ -440,12 +351,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
         }
 
-        /// <summary>
-        /// The web auth flow get token interactive throws operation canceled exception for claims.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
         [Test]
         public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
         {

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (MsalClientException ex)
             {
-                this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
+                this.logger.LogWarning($"MSAL Client Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
             }
             catch (NullReferenceException ex)
             {
-                this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
+                this.logger.LogWarning($"MSAL unexpected null reference! (Not Expected)\n{ex.Message}");
                 this.errors.Add(ex);
             }
 

--- a/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
+++ b/src/MSALWrapper/MsalHttpClientFactoryAdaptor.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
+    using System;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using Microsoft.Identity.Client;
@@ -12,11 +13,36 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     internal class MsalHttpClientFactoryAdaptor : IMsalHttpClientFactory
     {
+        private HttpClient instance;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MsalHttpClientFactoryAdaptor"/> class.
+        /// Creates an instance of msal http client factory adaptor.
+        /// </summary>
+        /// <param name="instance">A http client.</param>
+        public MsalHttpClientFactoryAdaptor(HttpClient instance)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            this.instance = instance;
+        }
+
+        /// <inheritdoc/>
+        public HttpClient GetHttpClient()
+        {
+            // MSAL calls this method each time it wants to use an HTTP client.
+            // We ensure we only create a single instance to avoid socket exhaustion.
+            return this.instance;
+        }
+
         /// <summary>
         /// Gets the msal http client.
         /// </summary>
         /// <returns>An instance of <see cref="HttpClient"/>.</returns>
-        public HttpClient GetHttpClient()
+        public HttpClient CreateHttpClient()
         {
             // MSAL calls this method each time it wants to use an HTTP client.
             // We ensure we only create a single instance to avoid socket exhaustion.


### PR DESCRIPTION
# What
Redesigned the `TokenFetcherPublicClient` into different auth flows. This PR includes an `Web` that implements `IAuthFlow`.

# Why
These changes are necessary to close out some open bugs and customer scenarios:
- Better unit testing
- Interactive auth timeout fails to cancel the MSAL embedded web view 
- Provide env var to disable all interaction
- Get rid of coupling auth flows into a massive if else loop

# Things to note
Updated `MsalHttpClientFactoryAdaptor` to create a new http client instance required to create PCAWrapper for web mode.

Honestly, the setup is very similar to Broker except building PCAWrapper is a bit different.

# Test
Nothing to test so far. This is just a refactor. We can do some integration tests once I update the CLI in a follow up PR.
Unit tests were added.

# Class diagram

```mermaid
classDiagram
      IAuthFlow <|-- AuthFlow
      IAuthFlow <|-- Web
      Web*-- PCACache
      PCAWrapper*-- AccountsProvider
      Web*-- PCAWrapper
      Web*-- TaskExecutor
     Web*-- MsalHttpClientFactoryAdaptor
     Web*-- TokenResultExtensions
      IAuthFlow : +Task<TokenResult> GetTokenAsync()
      PCAWrapper *-- IPublicClientApplication
      class AuthFlow{
          +ILogger logger
          +IEnumerable<IAuthFlow> authFlows
      }
      class Web{
          +ILogger logger
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false,
          +string promptHint - null
      }
```