### PR TITLE
Make AddErrors not static

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task SingleAuthFlow_Returns_Null_TokenResult()
         {
-            var authFlowResult = new AuthFlowResult(null, null);
+            var authFlowResult = new AuthFlowResult();
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
@@ -181,7 +181,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
         {
-            var authFlowResult1 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
             var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
@@ -237,7 +237,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
-            var authFlowResult = new AuthFlowResult(null, null);
+            var authFlowResult = new AuthFlowResult();
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -331,8 +331,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task HasThreeAuthFlows_Returns_Null_TokenResult()
         {
-            var authFlowResult1 = new AuthFlowResult(null, null);
-            var authFlowResult2 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
+            var authFlowResult2 = new AuthFlowResult();
             var authFlowResult3 = new AuthFlowResult(this.tokenResult, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
@@ -411,8 +411,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, null);
-            var authFlowResult2 = new AuthFlowResult(null, null);
+            var authFlowResult1 = new AuthFlowResult();
+            var authFlowResult2 = new AuthFlowResult();
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWithnullArgs()
         {
-            var subject = new AuthFlowResult(null, null);
+            var subject = new AuthFlowResult();
             subject.Success.Should().BeFalse();
             subject.TokenResult.Should().BeNull();
             subject.Errors.Should().BeEmpty();
@@ -36,6 +36,20 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.Success.Should().BeTrue();
             subject.TokenResult.Should().Be(tokenResult);
             subject.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddErrors()
+        {
+            var subject = new AuthFlowResult();
+            var errors = new List<Exception>
+            {
+                new ArgumentException("something can't be null"),
+                new NullReferenceException("you cannot get there from here"),
+            };
+
+            subject.AddErrors(errors);
+            subject.Errors.Should().BeEquivalentTo(errors);
         }
     }
 }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 }
                 else
                 {
-                    AuthFlowResult.AddErrorsToAuthFlowExecutorList(result, attempt);
+                    result.AddErrors(attempt.Errors);
 
                     if (attempt.Success)
                     {

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -12,10 +12,18 @@ namespace Microsoft.Authentication.MSALWrapper
     public class AuthFlowResult
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
+        /// </summary>
+        public AuthFlowResult()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class.
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
-        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result.</param>
+        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
         public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors)
         {
             this.TokenResult = tokenResult;
@@ -41,15 +49,14 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
-        /// Adds the errors from the attempted auth flows to the main error list on Auth flow executor.
+        /// Add the given errors to the <see cref="Errors"/> list.
         /// </summary>
-        /// <param name="authFlowResult">A <see cref="MSALWrapper.AuthFlowResult"/> that creates a main list of errors after attempting all the auth flows in the list.</param>
-        /// <param name="result">A <see cref="MSALWrapper.AuthFlowResult"/> that collects errors from the attempted auth flows at a time.</param>
-        internal static void AddErrorsToAuthFlowExecutorList(AuthFlowResult authFlowResult, AuthFlowResult result)
+        /// <param name="errors">The errors to add.</param>
+        public void AddErrors(IEnumerable<Exception> errors)
         {
-            foreach (var error in result.Errors)
+            foreach (var error in errors)
             {
-                authFlowResult.Errors.Add(error);
+                this.Errors.Add(error);
             }
         }
     }


### PR DESCRIPTION
This does 2 things:
* Add a default constructor which is equivalent to passing in nulls.
* Make the `AddErrors` method not static and take a more generic argument. 