### PR TITLE
Device Code Auth Flow

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    internal class DeviceCodeTest
+    {
+        private const string TestUser = "user@microsoft.com";
+
+        // These Guids were randomly generated and do not refer to a real resource or client
+        // as we don't need either for our testing.
+        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+
+        private string promptHint = "test prompt hint";
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapperMock;
+        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
+        private TokenResult tokenResult;
+
+        /// <summary>
+        /// The test setup.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<AuthFlow.DeviceCode>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<AuthFlow.DeviceCode>>();
+                 return new AuthFlow.DeviceCode(logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        /// <summary>
+        /// Get a new instance of the class under test.
+        /// </summary>
+        /// <returns>The <see cref="AuthFlow.DeviceCode"/> registered in the <see cref="Setup"/> method.</returns>
+        public AuthFlow.DeviceCode Subject() => this.serviceProvider.GetService<AuthFlow.DeviceCode>();
+
+        [Test]
+        public async Task DeviceCodeAuthFlow_HappyPath()
+        {
+            this.DeviceCodeAuthResult();
+
+            // Act
+            AuthFlow.DeviceCode deviceCode = this.Subject();
+            var authFlowResult = await deviceCode.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.DeviceCodeFlow);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task DeviceCodeAuthFlow_Returns_Null()
+        {
+            this.DeviceCodeAuthReturnsNull();
+
+            // Act
+            AuthFlow.DeviceCode deviceCode = this.Subject();
+            var authFlowResult = await deviceCode.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task DeviceCodeAuthFlow_MsalException()
+        {
+            this.DeviceCodeAuthMsalException();
+
+            // Act
+            AuthFlow.DeviceCode deviceCode = this.Subject();
+            var authFlowResult = await deviceCode.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalException));
+        }
+
+        private void DeviceCodeAuthResult()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenDeviceCodeAsync(this.scopes, It.IsAny<Func<DeviceCodeResult, Task>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.tokenResult);
+        }
+
+        private void DeviceCodeAuthReturnsNull()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenDeviceCodeAsync(this.scopes, It.IsAny<Func<DeviceCodeResult, Task>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
+        }
+
+        private void DeviceCodeAuthMsalException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenDeviceCodeAsync(this.scopes, It.IsAny<Func<DeviceCodeResult, Task>>(), It.IsAny<CancellationToken>()))
+                .Throws(new MsalException("1", "Msal Exception."));
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
+{
+#if NET472
+    using Microsoft.Identity.Client.Desktop;
+#endif
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The device code auth flow.
+    /// </summary>
+    public class DeviceCode : IAuthFlow
+    {
+        private readonly ILogger logger;
+        private readonly IEnumerable<string> scopes;
+        private readonly string preferredDomain;
+        private readonly string promptHint;
+        private readonly IList<Exception> errors;
+        private IPCAWrapper pcaWrapper;
+
+        #region Public configurable properties
+
+        /// <summary>
+        /// The device code flow timeout.
+        /// </summary>
+        private TimeSpan deviceCodeFlowTimeout = TimeSpan.FromMinutes(15);
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceCode"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="clientId">The client id.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
+        /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
+        public DeviceCode(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
+        {
+            this.errors = new List<Exception>();
+            this.logger = logger;
+            this.scopes = scopes;
+            this.preferredDomain = preferredDomain;
+            this.promptHint = promptHint;
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
+        }
+
+        /// <summary>
+        /// Gets the token for a resource.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
+        public async Task<AuthFlowResult> GetTokenAsync()
+        {
+            try
+            {
+                var tokenResult = await TaskExecutor.CompleteWithin(
+                            this.logger,
+                            this.deviceCodeFlowTimeout,
+                            "Get Token using Device Code",
+                            (cancellationToken) => this.pcaWrapper.GetTokenDeviceCodeAsync(
+                            this.scopes,
+                            this.ShowDeviceCodeInTty,
+                            cancellationToken),
+                            this.errors)
+                        .ConfigureAwait(false);
+                tokenResult.SetAuthenticationType(AuthType.DeviceCodeFlow);
+
+                return new AuthFlowResult(tokenResult, this.errors);
+            }
+            catch (MsalException ex)
+            {
+                this.errors.Add(ex);
+                this.logger.LogError(ex.Message);
+            }
+
+            return new AuthFlowResult(null, this.errors);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            HttpClientHandler handler = new HttpClientHandler();
+
+            var client = new HttpClient(handler);
+
+            // Add default headers
+            client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true,
+            };
+
+            return client;
+        }
+
+        private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)
+        {
+            var httpFactoryAdaptor = new MsalHttpClientFactoryAdaptor(CreateHttpClient());
+            var clientBuilder =
+                PublicClientApplicationBuilder
+                .Create($"{clientId}")
+                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true)
+                    .WithHttpClientFactory(httpFactoryAdaptor)
+                    .WithRedirectUri(Constants.AadRedirectUri.ToString());
+
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix);
+        }
+
+        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
+        {
+            this.logger.LogTrace($"MSAL: {message}");
+        }
+
+        private Task ShowDeviceCodeInTty(DeviceCodeResult dcr)
+        {
+            this.logger.LogWarning(dcr.Message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain)
                 ?? null;
-            this.logger.LogDebug($"GetTokenNormalFlowAsync: Using account '{account.Username}'");
+            this.logger.LogDebug($"Trying Silent Auth: Using account '{account.Username}'");
 
             try
             {


### PR DESCRIPTION
# What
Redesigned the `TokenFetcherPublicClient` into different auth flows. This PR includes an `DeviceCode` that implements `IAuthFlow`.

# Why
These changes are necessary to close out some open bugs and customer scenarios:
- Better unit testing
- Interactive auth timeout fails to cancel the MSAL embedded web view 
- Provide env var to disable all interaction
- Get rid of coupling auth flows into a massive if else loop

# Things to note
I resolved a bug in this PR which is we MUST try silent auth before trying device code. Kyle wanted me to add to the same PR. Here's more context from the bug:
When we use device code to get a Token result, we currently don’t check the cache before trying device code auth flow to get an access token. The fix would be to call silent auth flow (checking the cache) before trying device code auth flow.

# Test
Nothing to test so far. This is just a refactor. We can do some integration tests once I update the CLI in a follow up PR.
Unit tests were added.

# Class diagram

```mermaid
classDiagram
      IAuthFlow <|-- AuthFlow
      IAuthFlow <|-- DeviceCode
      DeviceCode*-- PCACache
      PCAWrapper*-- AccountsProvider
      DeviceCode*-- PCAWrapper
      DeviceCode*-- TaskExecutor
     DeviceCode*-- MsalHttpClientFactoryAdaptor
     DeviceCode*-- TokenResultExtensions
      IAuthFlow : +Task<TokenResult> GetTokenAsync()
      PCAWrapper *-- IPublicClientApplication
      class AuthFlow{
          +ILogger logger
          +IEnumerable<IAuthFlow> authFlows
      }
      class DeviceCode{
          +ILogger logger
          +Guid clientId
          +Guid tenantId
          +IEnumerable<string> scopes = null
          +string osxKeyChainSuffix = null
          +string preferredDomain = null, 
          +bool verifyPersistence = false,
          +string promptHint = null
      }
```