### PR TITLE
Update CHANGELOG from recent set of refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed a bug where device code flow authentication would not use the file cache to first attempt to get a cached token silently, causing it to always prompt.
+
+### Removed
+- Removed sample projects that used the old `TokenFetcherPublicClient` api from the MSALWrapper project.
 
 ## [v0.2.0] - 2022-04-21
 ### Security


### PR DESCRIPTION
The recent set of refactors resulted in 2 changes worthy of mention in the CHANGELOG. A bug fix in device code auth and the removal of the demo projects.