### PR TITLE
Stop renaming directories, use directory junctions on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed a bug where device code flow authentication would not use the file cache to first attempt to get a cached token silently, causing it to always prompt.
+- Fixed a bug where the Windows installation script could encounter errors renaming the extracted directory.
 
+### Changed
+- The installation scripts now extract to directories named after the release artifact from GitHub.
+- The `latest` directory is now a [directory junction](https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions) on Windows.
+ 
 ### Removed
 - Removed sample projects that used the old `TokenFetcherPublicClient` api from the MSALWrapper project.
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -23,7 +23,6 @@ $azureauthDirectory = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_INSTALL_DIRECTO
     $Env:AZUREAUTH_INSTALL_DIRECTORY
 }
 $extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
-$targetDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $version))
 $latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))
 $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
 
@@ -39,28 +38,18 @@ if (Test-Path -Path $extractedDirectory) {
     Remove-Item -Force -Recurse $extractedDirectory
 }
 
-if (Test-Path -Path $targetDirectory) {
-    Write-Verbose "Removing pre-existing target directory at ${targetDirectory}"
-    Remove-Item -Force -Recurse $targetDirectory
-}
-
-Write-Verbose "Extracting ${zipFile} to ${targetDirectory}"
+Write-Verbose "Extracting ${zipFile} to ${extractedDirectory}"
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
-# The zip file is extracted to a directory with the same base name. Rename the extracted directory to match the version.
-Rename-Item $extractedDirectory $targetDirectory
 
 if (Test-Path -Path $latestDirectory) {
     Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
     Remove-Item -Force -Recurse $latestDirectory
 }
 
-# We would use a symlink here except that not all Windows users will have permission to create them.
-Write-Verbose "Extracting ${zipFile} to ${latestDirectory}"
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-[System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
-# The zip file is extracted to a directory with the same base name. Rename the extracted directory to be "latest".
-Rename-Item $extractedDirectory $latestDirectory
+# We use a directory junction here because not all Windows users will have permissions to create a symlink.
+Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
+$null = New-Item -Path $latestDirectory -Target $extractedDirectory -ItemType Junction
 
 Write-Verbose "Removing ${zipFile}"
 Remove-Item -Force $zipFile

--- a/install/install.sh
+++ b/install/install.sh
@@ -57,7 +57,7 @@ release_url="https://github.com/${repo}/releases/download/${version}/${release_f
 
 : ${AZUREAUTH_INSTALL_DIRECTORY="${HOME}/.azureauth"}
 azureauth_directory="${AZUREAUTH_INSTALL_DIRECTORY}"
-target_directory="${azureauth_directory}/${version}"
+target_directory="${azureauth_directory}/$(release_name)"
 latest_directory="${azureauth_directory}/latest"
 tarball="${azureauth_directory}/${release_file}"
 


### PR DESCRIPTION
We've run into an issue where we get spurious `Access to the path ... is denied` errors like
```
 ❯ iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) } -Verbose"VERBOSE: Creating C:\Users\rsiemens\AppData\Local\Programs\AzureAuth
VERBOSE: Downloading https://github.com/AzureAD/microsoft-authentication-cli/releases/download/v0.2.0/azureauth-v0.2.0-win10-x64.zip to C:\Users\rsiemens\AppData\Local\Programs\AzureAuth\azureauth-v0.2.0-win10-x64.zip
VERBOSE: Extracting C:\Users\rsiemens\AppData\Local\Programs\AzureAuth\azureauth-v0.2.0-win10-x64.zip to C:\Users\rsiemens\AppData\Local\Programs\AzureAuth\v0.2.0
Rename-Item:
Line |
  47 |  Rename-Item $extractedDirectory $targetDirectory
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Access to the path 'C:\Users\rsiemens\AppData\Local\Programs\AzureAuth\azureauth-v0.2.0-win10-x64' is denied.
```

Since this is intermittent, our best understanding of the issue right now is that there might be some sort of file/directory lock that is held unnecessarily long between these lines.

https://github.com/AzureAD/microsoft-authentication-cli/blob/230463d93ed6482b76b5a57140d639fab3cb5eca/install/install.ps1#L49-L51

As we don't directly control any locking done by `System.IO.Compression.ZipFile.ExtractToDirectory` the easiest option to solve this seems to be just not renaming directories in the first place.

Instead of being extracted to a directory like `v0.2.0` the application will now be extracted to something like `azureauth-v0.2.0-win10-x64` (or the equivalent on other platforms).

This also resolves #47 by using a directory junction instead of copying the contents of the `.zip` file twice.