### PR TITLE
Enable TLS 1.2 by default

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -30,6 +30,11 @@ $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
 Write-Verbose "Creating ${azureauthDirectory}"
 $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
 
+# Without this, System.Net.WebClient.DownloadFile will fail on a client with TLS 1.0/1.1 disabled
+if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -notcontains 'Tls12') {
+    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+}
+
 Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
 $client = New-Object System.Net.WebClient
 $client.DownloadFile($releaseUrl, $zipFile)


### PR DESCRIPTION
This directly copies from the corresponding [Azure Artifacts Credential Provider install script](https://github.com/microsoft/artifacts-credprovider/blob/53d48954c3117bd6f3a8e8267f7c7b3d62a46fbb/helpers/installcredprovider.ps1#L24-L27). This should allow the installer to work on previously unsupported platforms like Windows Server 2012.