### PR TITLE
Add "AzureAuth" as prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The installation scripts now extract to directories named after the release artifact from GitHub.
 - The `latest` directory is now a [directory junction](https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions) on Windows.
-- The Option `--prompt-hint` will have a prefix `AzureAuth` by default.
+- The Option `--prompt-hint` will have a prefix `AzureAuth`.
 
 ### Removed
 - Removed sample projects that used the old `TokenFetcherPublicClient` api from the MSALWrapper project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The installation scripts now extract to directories named after the release artifact from GitHub.
 - The `latest` directory is now a [directory junction](https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions) on Windows.
- 
+- The Option `--prompt-hint` will have a prefix `AzureAuth` by default.
+
 ### Removed
 - Removed sample projects that used the old `TokenFetcherPublicClient` api from the MSALWrapper project.
 

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -370,7 +370,7 @@ invalid_key = ""this is not a valid alias key""
         {
             string promptHintOption = "Test Prompt Hint";
 
-            CommandMain.GetActualPromptHint(promptHintOption)
+            CommandMain.PrefixedPromptHint(promptHintOption)
                 .Should().BeEquivalentTo($"{PromptHintPrefix}: {promptHintOption}");
         }
 
@@ -380,7 +380,7 @@ invalid_key = ""this is not a valid alias key""
         [Test]
         public void TestPromptHintPrefixWithoutOption()
         {
-            CommandMain.GetActualPromptHint(null)
+            CommandMain.PrefixedPromptHint(null)
                 .Should().BeEquivalentTo(PromptHintPrefix);
         }
 

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -51,6 +51,7 @@ invalid_key = ""this is not a valid alias key""
 
         private const string RootDriveWindows = @"Z:\";
         private const string RootDriveUnix = "/";
+        private const string PromptHintPrefix = "AzureAuth";
 
         private CommandExecuteEventData eventData;
         private IFileSystem fileSystem;
@@ -359,6 +360,28 @@ invalid_key = ""this is not a valid alias key""
 
             subject.EvaluateOptions().Should().BeTrue();
             subject.TokenFetcherOptions.Should().BeEquivalentTo(expected);
+        }
+
+        /// <summary>
+        /// The test to ensure the prompt hint text has a valid prefix with user's option.
+        /// </summary>
+        [Test]
+        public void TestPromptHintPrefix()
+        {
+            string promptHintOption = "Test Prompt Hint";
+
+            CommandMain.GetActualPromptHint(promptHintOption)
+                .Should().BeEquivalentTo($"{PromptHintPrefix}: {promptHintOption}");
+        }
+
+        /// <summary>
+        /// The test to ensure the prompt hint text has a valid prefix without user's option.
+        /// </summary>
+        [Test]
+        public void TestPromptHintPrefixWithoutOption()
+        {
+            CommandMain.GetActualPromptHint(null)
+                .Should().BeEquivalentTo(PromptHintPrefix);
         }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -380,9 +380,9 @@ Allowed values: [all, web, devicecode]";
                 var scopes = this.Scopes ?? new string[] { $"{this.authSettings.Resource}/.default" };
 
                 string promptHint = PromptHintPrefix;
-                if (string.IsNullOrEmpty(promptHint))
+                if (!string.IsNullOrEmpty(this.authSettings.PromptHint))
                 {
-                    promptHint = $"{PromptHintPrefix}: {promptHint}";
+                    promptHint = $"{PromptHintPrefix}: {this.authSettings.PromptHint}";
                 }
 
                 var authFlows = AuthFlowFactory.Create(

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Authentication.AzureAuth
         private const string AliasOption = "--alias";
         private const string ConfigOption = "--config";
 
+        private const string PromptHintPrefix = "AzureAuth";
+
 #if PlatformWindows
         private const string AuthModeHelperText = @"Authentication mode. Default: broker.
 You can use any combination of modes with multiple instances of the -m flag.
@@ -110,6 +112,7 @@ Allowed values: [all, web, devicecode]";
 
         /// <summary>
         /// Gets or sets the customized prompt hint text for WAM prompts and web mode.
+        /// By default there is "AzureAuth" as prefix.
         /// </summary>
         [Option(PromptHintOption, "The prompt hint text for WAM prompts and web mode.", CommandOptionType.SingleValue)]
         public string PromptHint { get; set; }
@@ -376,6 +379,12 @@ Allowed values: [all, web, devicecode]";
                 // TODO: Really we need to get rid of Resource
                 var scopes = this.Scopes ?? new string[] { $"{this.authSettings.Resource}/.default" };
 
+                string promptHint = PromptHintPrefix;
+                if (string.IsNullOrEmpty(promptHint))
+                {
+                    promptHint = $"{PromptHintPrefix}: {promptHint}";
+                }
+
                 var authFlows = AuthFlowFactory.Create(
                     this.logger,
                     this.CombinedAuthMode,
@@ -383,7 +392,7 @@ Allowed values: [all, web, devicecode]";
                     new Guid(this.authSettings.Tenant),
                     scopes,
                     this.PreferredDomain,
-                    this.authSettings.PromptHint,
+                    promptHint,
                     Constants.AuthOSXKeyChainSuffix);
 
                 this.authFlow = new AuthFlowExecutor(this.logger, authFlows);

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -170,20 +170,21 @@ Allowed values: [all, web, devicecode]";
         private AuthMode CombinedAuthMode => this.AuthModes.Aggregate((a1, a2) => a1 | a2);
 
         /// <summary>
-        /// Get the combination of the prefix <see cref="PromptHintPrefix"/> with user-supplied option.
-        /// By default "AzureAuth" is the prefix.
-        /// </summary>
-        /// <param name="promptHintOption">The prompt hint provided by users.</param>
-        /// <returns>the combined value.</returns>
-        public static string GetActualPromptHint(string promptHintOption)
-        {
-            string promptHint = PromptHintPrefix;
-            if (!string.IsNullOrEmpty(promptHintOption))
-            {
-                promptHint = $"{PromptHintPrefix}: {promptHintOption}";
-            }
+        /// Combine the <see cref="PromptHintPrefix"/> with the caller provided prompt hint.
 
-            return promptHint;
+        /// </summary>
+        /// <param name="promptHintOption">The provided prompt hint.</param>
+
+        /// <returns>The combined prefix and prompt hint or just the prefix if no prompt hint was given.</returns>
+
+        public static string PrefixedPromptHint(string promptHint)
+
+        {
+            if (string.IsNullOrEmpty(promptHintOption))
+            {
+                return PromptHintPrefix;
+            }
+            return $"{PromptHintPrefix}: {promptHintOption}";
         }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -171,20 +171,17 @@ Allowed values: [all, web, devicecode]";
 
         /// <summary>
         /// Combine the <see cref="PromptHintPrefix"/> with the caller provided prompt hint.
-
         /// </summary>
-        /// <param name="promptHintOption">The provided prompt hint.</param>
-
+        /// <param name="promptHint">The provided prompt hint.</param>
         /// <returns>The combined prefix and prompt hint or just the prefix if no prompt hint was given.</returns>
-
         public static string PrefixedPromptHint(string promptHint)
-
         {
-            if (string.IsNullOrEmpty(promptHintOption))
+            if (string.IsNullOrEmpty(promptHint))
             {
                 return PromptHintPrefix;
             }
-            return $"{PromptHintPrefix}: {promptHintOption}";
+
+            return $"{PromptHintPrefix}: {promptHint}";
         }
 
         /// <summary>
@@ -403,7 +400,7 @@ Allowed values: [all, web, devicecode]";
                     new Guid(this.authSettings.Tenant),
                     scopes,
                     this.PreferredDomain,
-                    GetActualPromptHint(this.authSettings.PromptHint),
+                    PrefixedPromptHint(this.authSettings.PromptHint),
                     Constants.AuthOSXKeyChainSuffix);
 
                 this.authFlow = new AuthFlowExecutor(this.logger, authFlows);


### PR DESCRIPTION
Added `AzureAuth` as the prefix.
By default, the title bar will show `AzureAuth`.
If option `--prompt-hint` is set as "sample", the title bar will show `AzureAuth: sample`

Related issue: #24 