### PR TITLE
Support Win Server 2012/2016

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -184,10 +184,11 @@ namespace MSALWrapper.Test
         }
 
         [Test]
-        public void DefaultModes_Not_Win10Or11()
+        [Platform("MacOsx")]
+        public void DefaultModes_Not_Windows()
         {
-            this.MockIsWindows10Or11(false);
-
+            // On non-windows platforms the Default Authmode doesn't contain "Broker" as an option to start with.
+            // so we short circuit checking the platform and expect it to not be called.
             var subject = this.Subject(AuthMode.Default);
 
             this.platformUtilsMock.VerifyAll();

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -27,14 +27,14 @@ namespace MSALWrapper.Test
         private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
         private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
 
+        private Mock<IPCAWrapper> pcaWrapperMock;
+        private Mock<IPlatformUtils> platformUtilsMock;
         private MemoryTarget logTarget;
         private ServiceProvider serviceProvider;
-        private Mock<IPCAWrapper> pcaWrapperMock;
         private ILogger logger;
         private IEnumerable<string> scopes;
         private string osxKeyChainSuffix;
         private string preferredDomain;
-        private IPCAWrapper pcaWrapper;
         private string promptHint;
 
         [SetUp]
@@ -46,7 +46,6 @@ namespace MSALWrapper.Test
             loggingConfig.AddTarget(this.logTarget);
             loggingConfig.AddRuleForAllLevels(this.logTarget);
 
-            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
             this.serviceProvider = new ServiceCollection()
              .AddLogging(loggingBuilder =>
              {
@@ -58,13 +57,19 @@ namespace MSALWrapper.Test
              .BuildServiceProvider();
 
             this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
-
+            this.platformUtilsMock = new Mock<IPlatformUtils>(MockBehavior.Strict);
             this.logger = this.serviceProvider.GetService<ILogger<AuthFlowFactory>>();
             this.scopes = new[] { $"{ResourceId}/.default" };
             this.osxKeyChainSuffix = "azureauth";
             this.preferredDomain = "contoso.com";
-            this.pcaWrapper = this.pcaWrapperMock.Object;
             this.promptHint = "Log into Contoso!";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.pcaWrapperMock.VerifyAll();
+            this.platformUtilsMock.VerifyAll();
         }
 
         public IEnumerable<IAuthFlow> Subject(AuthMode mode) => AuthFlowFactory.Create(
@@ -76,14 +81,14 @@ namespace MSALWrapper.Test
                 this.preferredDomain,
                 this.promptHint,
                 this.osxKeyChainSuffix,
-                this.pcaWrapper);
+                pcaWrapper: this.pcaWrapperMock.Object,
+                platformUtils: this.platformUtilsMock.Object);
 
         [Test]
         public void Web_Only()
         {
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Web);
 
-            this.pcaWrapperMock.VerifyAll();
             subject.Should().HaveCount(1);
             subject.First().GetType().Name.Should().Be(typeof(Web).Name);
         }
@@ -92,11 +97,40 @@ namespace MSALWrapper.Test
         [Test]
         public void Broker_Only()
         {
+            this.MockIsWindows10Or11(true);
+
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Broker);
 
-            this.pcaWrapperMock.VerifyAll();
             subject.Should().HaveCount(1);
             subject.First().GetType().Name.Should().Be(typeof(Broker).Name);
+        }
+
+        [Test]
+        public void Windows10Or11_Defaults()
+        {
+            this.MockIsWindows10Or11(true);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
+
+            subject.Should().HaveCount(2);
+
+            // BeEquivalentTo doesn't assert order for a list :(
+            // so explicitly assert the first and second item names.
+            var names = subject.Select(a => a.GetType().Name).ToList();
+            names[0].Should().Be(typeof(Broker).Name);
+            names[1].Should().Be(typeof(Web).Name);
+        }
+
+        [Test]
+        public void Windows_Defaults()
+        {
+            this.MockIsWindows10Or11(false);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
+
+            subject.Should().HaveCount(1);
+            var names = subject.Select(a => a.GetType().Name).ToList();
+            names[0].Should().Be(typeof(Web).Name);
         }
 #endif
 
@@ -114,6 +148,8 @@ namespace MSALWrapper.Test
         [Platform("Win")]
         public void AllModes_Windows()
         {
+            this.MockIsWindows10Or11(true);
+
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
@@ -145,6 +181,25 @@ namespace MSALWrapper.Test
                     typeof(Web).Name,
                     typeof(DeviceCode).Name,
                 });
+        }
+
+        [Test]
+        public void DefaultModes_Not_Win10Or11()
+        {
+            this.MockIsWindows10Or11(false);
+
+            var subject = this.Subject(AuthMode.Default);
+
+            this.platformUtilsMock.VerifyAll();
+            subject.Select(async => async.GetType().Name).Should().BeEquivalentTo(new[]
+            {
+                typeof(Web).Name,
+            });
+        }
+
+        private void MockIsWindows10Or11(bool value)
+        {
+            this.platformUtilsMock.Setup(p => p.IsWindows10Or11()).Returns(value);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -56,8 +56,12 @@ namespace MSALWrapper.Test
              })
              .BuildServiceProvider();
 
+            // Always setup Mock with behavior strict - which fails tests on first use of non-mocked behavior.
+            // Reminder: If adding a new Mock - also call VerifyAll() in the TearDown method below to assert that
+            // all mocked calls were called.
             this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
             this.platformUtilsMock = new Mock<IPlatformUtils>(MockBehavior.Strict);
+
             this.logger = this.serviceProvider.GetService<ILogger<AuthFlowFactory>>();
             this.scopes = new[] { $"{ResourceId}/.default" };
             this.osxKeyChainSuffix = "azureauth";
@@ -68,6 +72,9 @@ namespace MSALWrapper.Test
         [TearDown]
         public void TearDown()
         {
+            // Verify all mocks used by the test here to prevent any individual test from
+            // forgetting to do this.
+            // Reminder: Add a call to VerifyAll() for any new mocks used.
             this.pcaWrapperMock.VerifyAll();
             this.platformUtilsMock.VerifyAll();
         }

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -4,7 +4,9 @@
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
     using FluentAssertions;
+
     using Microsoft.Authentication.MSALWrapper;
+
     using NUnit.Framework;
 
     internal class AuthModeTest
@@ -86,7 +88,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.IsBroker().Should().Be(expected);
         }
 
-                [Test]
+        [Test]
         public void NonWindowsDefaultModes()
         {
             var subject = AuthMode.Default;

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -9,26 +9,20 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
     internal class AuthModeTest
     {
-#if !PlatformWindows
-        [Test]
-        public void AllIsAll()
-        {
-            (AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
-        }
-
-        [TestCase(AuthMode.All, false)]
-        [TestCase(AuthMode.Web, false)]
-        [TestCase(AuthMode.DeviceCode, false)]
-        public void BrokerIsExpected(AuthMode subject, bool expected)
-        {
-            subject.IsBroker().Should().Be(expected);
-        }
-#else
-
+#if PlatformWindows
         [Test]
         public void AllIsAll()
         {
             (AuthMode.Broker | AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
+        }
+
+        [Test]
+        public void WindowsDefaultModes()
+        {
+            var subject = AuthMode.Default;
+            subject.IsBroker().Should().BeTrue();
+            subject.IsWeb().Should().BeTrue();
+            subject.IsDeviceCode().Should().BeFalse();
         }
 
         [TestCase(AuthMode.All, true)]
@@ -76,6 +70,29 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             var subject = AuthMode.Web | AuthMode.DeviceCode;
 
             subject.IsBroker().Should().BeFalse();
+        }
+#else
+        [Test]
+        public void AllIsAll()
+        {
+            (AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
+        }
+
+        [TestCase(AuthMode.All, false)]
+        [TestCase(AuthMode.Web, false)]
+        [TestCase(AuthMode.DeviceCode, false)]
+        public void BrokerIsExpected(AuthMode subject, bool expected)
+        {
+            subject.IsBroker().Should().Be(expected);
+        }
+
+                [Test]
+        public void NonWindowsDefaultModes()
+        {
+            var subject = AuthMode.Default;
+            subject.IsBroker().Should().BeFalse();
+            subject.IsWeb().Should().BeTrue();
+            subject.IsDeviceCode().Should().BeFalse();
         }
 #endif
     }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
@@ -35,6 +36,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         public async Task<AuthFlowResult> GetTokenAsync()
         {
             AuthFlowResult result = new AuthFlowResult(null, new List<Exception>());
+
+            if (this.authflows.Count() == 0)
+            {
+                this.logger.LogWarning("Warning: There are 0 auth modes to execute!");
+            }
+
             foreach (var authFlow in this.authflows)
             {
                 var authFlowName = authFlow.GetType().Name;

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -36,6 +37,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             AuthFlowResult result = new AuthFlowResult(null, new List<Exception>());
             foreach (var authFlow in this.authflows)
             {
+                var authFlowName = authFlow.GetType().Name;
+                this.logger.LogDebug($"Starting {authFlowName}...");
+
                 var attempt = await authFlow.GetTokenAsync();
                 if (attempt == null)
                 {
@@ -47,6 +51,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 {
                     result.AddErrors(attempt.Errors);
 
+                    this.logger.LogDebug($"{authFlowName} success: {attempt.Success}.");
                     if (attempt.Success)
                     {
                         result.TokenResult = attempt.TokenResult;

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -40,8 +40,14 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         {
             logger = logger ?? throw new ArgumentNullException(nameof(logger));
             platformUtils = platformUtils ?? new PlatformUtils(logger);
+
+            // This is a list. The order in which flows get added is very important
+            // as it sets the order in which auth flows will be attempted.
             List<IAuthFlow> flows = new List<IAuthFlow>();
 
+            // This check silently fails on winserver if broker has been requested.
+            // Future: Consider making AuthMode platform aware at Runtime.
+            // https://github.com/AzureAD/microsoft-authentication-cli/issues/55
             if (authMode.IsBroker() && platformUtils.IsWindows10Or11())
             {
                 flows.Add(new Broker(logger, clientId, tenantId, scopes, osxKeyChainSuffix, preferredDomain, pcaWrapper, promptHint));

--- a/src/MSALWrapper/AuthMode.cs
+++ b/src/MSALWrapper/AuthMode.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <summary>
         /// The default.
         /// </summary>
-        Default = Broker,
+        Default = Broker | Web,
 #else
         /// <summary>
         /// The all mode.

--- a/src/MSALWrapper/IPlatformUtils.cs
+++ b/src/MSALWrapper/IPlatformUtils.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper
+{
+    /// <summary>
+    /// An interface for platform utility methods.
+    /// </summary>
+    public interface IPlatformUtils
+    {
+        /// <summary>
+        /// Check if running on Windows 10 or 11.
+        /// </summary>
+        /// <returns><see cref="bool"/> - true if running on Windows 10 or 11.</returns>
+        bool IsWindows10Or11();
+
+        /// <summary>
+        /// Check if running on any version of Windows.
+        /// </summary>
+        /// <returns><see cref="bool"/> - true if running on any version of Windows.</returns>
+        bool IsWindows();
+    }
+}

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Package Naming, Building, & Versioning -->
     <PackageId>Microsoft.Authentication.MSALWrapper</PackageId>
-    <TargetFrameworks>net472;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Microsoft.Authentication.MSALWrapper</RootNamespace>
 
     <PackageOutputPath>../</PackageOutputPath>

--- a/src/stylecop/GlobalSuppressions.cs
+++ b/src/stylecop/GlobalSuppressions.cs
@@ -8,5 +8,3 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "We might want to keep a few different classes in a single file if it's not length. Doing this specifically to by-pass Exceptions.cs file.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "This is just an unnescessary mandate.")]
 [assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Internal fields are needed for tests.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:Elements should be ordered by access", Justification = "Rule conflicts with regions at times.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Specific windows version code should stay together.", Scope = "member", Target = "~F:Microsoft.Authentication.MSALWrapper.PlatformUtils.logger")]

--- a/src/stylecop/GlobalSuppressions.cs
+++ b/src/stylecop/GlobalSuppressions.cs
@@ -9,3 +9,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "This is just an unnescessary mandate.")]
 [assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Internal fields are needed for tests.")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:Elements should be ordered by access", Justification = "Rule conflicts with regions at times.")]
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Specific windows version code should stay together.", Scope = "member", Target = "~F:Microsoft.Authentication.MSALWrapper.PlatformUtils.logger")]


### PR DESCRIPTION
# Problem
On WinServer 2012 / 2016 - brokered auth doesn't exist. By default, only using broker on windows makes the default experience on those OSs a broken experience.

# Solution
The default configuration should still provide a working auth experience on win server 2012/16. Change the default auth modes on Windows to use Broker first - if on win10/11, and always fallback to web.

# Testing
I've tested this on a WinServer2012 VM and confirmed that now running 
```
azureauth --alias myApp --copnfig ./myConfig.toml
```
Only tries to use Web flow, and successfully auths, and caches. 