### PR TITLE
Collect auth settings and arg validation status in telemetry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the Windows installation script could encounter errors renaming the extracted directory.
 
 ### Changed
+- Telemetry: If enabled, collect the app registration ids being used and whether args were valid.
 - The installation scripts now extract to directories named after the release artifact from GitHub.
 - The `latest` directory is now a [directory junction](https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions) on Windows.
 - The Option `--prompt-hint` will have a prefix `AzureAuth`.

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -254,12 +254,17 @@ Allowed values: [all, web, devicecode]";
         {
             if (!this.EvaluateOptions())
             {
+                this.eventData.Add("validargs", false);
                 return 1;
             }
 
+            this.eventData.Add("validargs", true);
             this.eventData.Add("settings_client", this.authSettings.Client);
             this.eventData.Add("settings_tenant", this.authSettings.Resource);
             this.eventData.Add("settings_resource", this.authSettings.Tenant);
+            this.eventData.Add("settings_prompthint", this.authSettings.PromptHint);
+
+            // Small bug in Lasso - Add does not accept a null IEnumerable here.
             this.eventData.Add("settings_scopes", this.authSettings.Scopes ?? new List<string>());
 
             return this.ClearCache ? this.ClearLocalCache() : this.GetToken();

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -257,6 +257,11 @@ Allowed values: [all, web, devicecode]";
                 return 1;
             }
 
+            this.eventData.Add("settings_client", this.authSettings.Client);
+            this.eventData.Add("settings_tenant", this.authSettings.Resource);
+            this.eventData.Add("settings_resource", this.authSettings.Tenant);
+            this.eventData.Add("settings_scopes", this.authSettings.Scopes ?? new List<string>());
+
             return this.ClearCache ? this.ClearLocalCache() : this.GetToken();
         }
 


### PR DESCRIPTION
## Problem
Right now we only collect the client/resource/tenant if passed directly on the CLI. This makes calls using a config file all look the same. We want to be able to distinguish the applications being authenticated too. 

## Solution
1 step in the right direction is to ensure we collect the IDs used either from the CLI or config file (or both if different) and if the arg validation passed all up.

## Future work
Also we want to collect the correlation ID from each auth attempt made. WHich will be it's own feature.