### PR TITLE
Mac ESRP script update

### DIFF
--- a/bin/mac_esrp_signing/dll_signing.py
+++ b/bin/mac_esrp_signing/dll_signing.py
@@ -21,7 +21,7 @@ DESTINATION = WORKSPACE
 files = []
 extensions = [".dll"]
 for path in Path(SOURCE).iterdir():
-     if (path.name == "azureauth" or path.suffix in extensions) and path.is_file():
+    if path.suffix in extensions and path.is_file():
         files.append(path)
 
 #empty list check

--- a/bin/mac_esrp_signing/dylibs_signing.py
+++ b/bin/mac_esrp_signing/dylibs_signing.py
@@ -134,10 +134,10 @@ else:
 with zipfile.ZipFile(signed_zip_file, 'r') as zipObj:
    zipObj.extractall(DESTINATION)
 
-signed_zip_file.unlink()
+Path(signed_zip_file).unlink()
 
 #list of signed files
-signed_binaries = [f for f in DESTINATION if os.path.isfile(f)]
+signed_binaries = [f for f in DESTINATION.iterdir() if os.path.isfile(f)]
 
 if not signed_binaries: 
 	sys.exit("Error: no signed files found")


### PR DESCRIPTION
Fixing an error in the dll signing.py that adds the azureauth executable to be signed. (Not required since it must be signed with a MAC keycode
Fixing an error in the dylib signing.py that lists the signed binaries after the signing process is complete.