### PR TITLE
Fix broken macOS symlinks

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -87,7 +87,8 @@ verbose "Removing ${tarball}"
 rm $tarball
 
 verbose "Linking ${latest_directory} to ${target_directory}"
-ln -sf $target_directory $latest_directory
+# It's very important we use -n and -f here or the symlink won't actually be overwritten during upgrades.
+ln -snf $target_directory $latest_directory
 
 # We currently only support automatically appending $PATH modifications for the default
 # Bash and ZSH profiles as the syntax is identical.


### PR DESCRIPTION
Without this, for reasons we don't yet fully understand, the `-f` argument to `ln` doesn't seem to be respected and symlinks on macOS are not overwritten. Just removing the symlink ahead of time and creating a new one will have the intended behavior.

**Edit:**

From [some sleuthing](https://superuser.com/a/938865/368775) and reading `ln(1)` a little more closely...

```
-h    If the target_file or target_dir is a symbolic link, do not follow it.  This is most useful
      with the -f option, to replace a symlink which may point to a directory.
```

and then

```
-n    Same as -h, for compatibility with other ln implementations.
```

, so if we use `-n` it will also work on Linux (I've tested it does).