### PR TITLE
Fix PowerShell Install script to work on WS2012 and 2016

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -54,7 +54,7 @@ if (Test-Path -Path $latestDirectory) {
 
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.
 Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
-cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory"
+cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory" > $null
 if (!$?) {
     Write-Error "Linking failed!"
 }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -49,7 +49,8 @@ if (Test-Path -Path $latestDirectory) {
 
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.
 # We create this junction with cmd.exe's mklink because it has a stable interface across all active versions of Windows and Windows Server,
-# while PowerShell's New-Item has breaking changes and doesn't have the -Target param in 4.0 (the default PowerSehll on Win Server 2012).
+# while PowerShell's New-Item has breaking changes and doesn't have the -Target param in 4.0 (the default PowerShell on Win Server 2012).
+
 Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
 cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory" > $null
 if (!$?) {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -55,6 +55,9 @@ if (Test-Path -Path $latestDirectory) {
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.
 Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
 cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory"
+if (!$?) {
+    Write-Error "Linking failed!"
+}
 
 Write-Verbose "Removing ${zipFile}"
 Remove-Item -Force $zipFile

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -31,7 +31,7 @@ $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
 
 # Without this, System.Net.WebClient.DownloadFile will fail on a client with TLS 1.0/1.1 disabled
 if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -notcontains 'Tls12') {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 | [Net.ServicePointManager]::SecurityProtocol
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
 }
 
 Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
@@ -54,10 +54,7 @@ if (Test-Path -Path $latestDirectory) {
 
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.
 Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
-$null = New-Item -Path $latestDirectory -Target $extractedDirectory -ItemType Junction
-
-Write-Verbose "Removing ${zipFile}"
-Remove-Item -Force $zipFile
+cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory"
 
 # Permanently add the latest directory to the current user's $PATH (if it's not already there).
 # Note that this will only take effect when a new terminal is started.
@@ -68,5 +65,8 @@ if ($currentPath -NotMatch 'AzureAuth') {
     $newPath = "${currentPath};${latestDirectory}"
     Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
 }
+
+Write-Verbose "Removing ${zipFile}"
+Remove-Item -Force $zipFile
 
 Write-Output "Installed azureauth $version!"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -31,7 +31,7 @@ $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
 
 # Without this, System.Net.WebClient.DownloadFile will fail on a client with TLS 1.0/1.1 disabled
 if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -notcontains 'Tls12') {
-    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 | [Net.ServicePointManager]::SecurityProtocol
 }
 
 Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -56,6 +56,9 @@ if (Test-Path -Path $latestDirectory) {
 Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
 cmd.exe /Q /C "mklink /J $latestDirectory $extractedDirectory"
 
+Write-Verbose "Removing ${zipFile}"
+Remove-Item -Force $zipFile
+
 # Permanently add the latest directory to the current user's $PATH (if it's not already there).
 # Note that this will only take effect when a new terminal is started.
 $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
@@ -65,8 +68,5 @@ if ($currentPath -NotMatch 'AzureAuth') {
     $newPath = "${currentPath};${latestDirectory}"
     Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
 }
-
-Write-Verbose "Removing ${zipFile}"
-Remove-Item -Force $zipFile
 
 Write-Output "Installed azureauth $version!"


### PR DESCRIPTION
# Support Installation on WinServer2012 and 2016
On Windows Server 2012/16 you have an older version of PowerShell by default. There are 2 incompatibilities right now with our install script and those versions.
* The configured encryption options for TLS doesn't have the `+=` operator.
   * The fix: remove it. In order to download the install script in the first place, you have to have already enabled TLS1.2. 
   
* `New-Item` doesn't take an argument called `'Target`.
   * Instead, shell out to cmd.exe which has the same interface on all OS's for creating directory junctions. 