### PR TITLE
Return NullTokenResultException when the authflow returns null.

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -163,7 +164,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -237,7 +238,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
             var authFlowResult = new AuthFlowResult();
 
@@ -265,7 +266,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -300,7 +301,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -410,7 +411,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var expectedError = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult();
@@ -454,7 +455,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors3 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult(null, errors1);
@@ -493,7 +494,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]
@@ -537,7 +538,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new Exception(NullAuthFlowResultExceptionMessage),
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]
@@ -614,6 +615,29 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.Success.Should().BeTrue();
             result.Errors.Should().HaveCount(3);
             result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors2[1] });
+        }
+
+        [Test]
+        public async Task HasBadAuthFlow_Returns_With_BadImplementationException()
+        {
+            // Setup
+            var badAuthflow = new Mock<IAuthFlow>(MockBehavior.Strict);
+            badAuthflow.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
+
+            var errors = new[]
+            {
+                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+            };
+
+            // Act
+            var authFlow = this.Subject(new[] { badAuthflow.Object });
+            var result = await authFlow.GetTokenAsync();
+
+            // Assert
+            badAuthflow.VerifyAll();
+            result.Success.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.Should().BeEquivalentTo(errors);
         }
 
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -237,7 +237,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
             var authFlowResult = new AuthFlowResult();
 
@@ -265,7 +265,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -300,7 +300,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var errors1 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors2 = new[]
@@ -410,7 +410,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var expectedError = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult();
@@ -454,7 +454,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors3 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var authFlowResult1 = new AuthFlowResult(null, errors1);
@@ -493,7 +493,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]
@@ -537,7 +537,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             var errors2 = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             var errors3 = new[]
@@ -617,23 +617,23 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task HasBadAuthFlow_Returns_With_BadImplementationException()
+        public async Task HasNullResultAuthFlow_Returns_With_BadImplementationException()
         {
             // Setup
-            var badAuthflow = new Mock<IAuthFlow>(MockBehavior.Strict);
-            badAuthflow.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
+            var nullTokenResultAuthflow = new Mock<IAuthFlow>(MockBehavior.Strict);
+            nullTokenResultAuthflow.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
 
             var errors = new[]
             {
-                new BadAuthFlowImplementException(NullAuthFlowResultExceptionMessage),
+                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
             // Act
-            var authFlow = this.Subject(new[] { badAuthflow.Object });
+            var authFlow = this.Subject(new[] { nullTokenResultAuthflow.Object });
             var result = await authFlow.GetTokenAsync();
 
             // Assert
-            badAuthflow.VerifyAll();
+            nullTokenResultAuthflow.VerifyAll();
             result.Success.Should().BeFalse();
             result.Errors.Should().HaveCount(1);
             result.Errors.Should().BeEquivalentTo(errors);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentAssertions;

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -616,29 +616,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.Errors.Should().BeEquivalentTo(new[] { errors1[0], errors2[0], errors2[1] });
         }
 
-        [Test]
-        public async Task HasNullResultAuthFlow_Returns_With_BadImplementationException()
-        {
-            // Setup
-            var nullTokenResultAuthflow = new Mock<IAuthFlow>(MockBehavior.Strict);
-            nullTokenResultAuthflow.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
-
-            var errors = new[]
-            {
-                new NullTokenResultException(NullAuthFlowResultExceptionMessage),
-            };
-
-            // Act
-            var authFlow = this.Subject(new[] { nullTokenResultAuthflow.Object });
-            var result = await authFlow.GetTokenAsync();
-
-            // Assert
-            nullTokenResultAuthflow.VerifyAll();
-            result.Success.Should().BeFalse();
-            result.Errors.Should().HaveCount(1);
-            result.Errors.Should().BeEquivalentTo(errors);
-        }
-
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 if (attempt == null)
                 {
                     var oopsMessage = $"Auth flow '{authFlow.GetType().Name}' returned a null AuthFlowResult.";
-                    result.Errors.Add(new BadAuthFlowImplementException(oopsMessage));
+                    result.Errors.Add(new NullTokenResultException(oopsMessage));
                     this.logger.LogDebug(oopsMessage);
                 }
                 else

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 if (attempt == null)
                 {
                     var oopsMessage = $"Auth flow '{authFlow.GetType().Name}' returned a null AuthFlowResult.";
-                    result.Errors.Add(new Exception(oopsMessage));
+                    result.Errors.Add(new BadAuthFlowImplementException(oopsMessage));
                     this.logger.LogDebug(oopsMessage);
                 }
                 else

--- a/src/MSALWrapper/AuthFlow/BadAuthFlowImplementException.cs
+++ b/src/MSALWrapper/AuthFlow/BadAuthFlowImplementException.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
+{
+    using System;
+
+    /// <summary>
+    /// The bad authflow implementation exception.
+    /// </summary>
+    public class BadAuthFlowImplementException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BadAuthFlowImplementException"/> class.
+        /// </summary>
+        /// <param name="message">
+        /// The message.
+        /// </param>
+        public BadAuthFlowImplementException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/NullTokenResultException.cs
+++ b/src/MSALWrapper/AuthFlow/NullTokenResultException.cs
@@ -6,17 +6,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System;
 
     /// <summary>
-    /// The bad authflow implementation exception.
+    /// The null token result exception, which should be thrown when an <see cref="IAuthFlow"/> returns a null <see cref="TokenResult"/>.
     /// </summary>
-    public class BadAuthFlowImplementException : Exception
+    public class NullTokenResultException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BadAuthFlowImplementException"/> class.
+        /// Initializes a new instance of the <see cref="NullTokenResultException"/> class.
         /// </summary>
         /// <param name="message">
         /// The message.
         /// </param>
-        public BadAuthFlowImplementException(string message)
+        public NullTokenResultException(string message)
             : base(message)
         {
         }


### PR DESCRIPTION
# Description
Currently in the `AuthFlowExecutor` we just return a generic exception when the `AuthFlowResult` is `null` -> this is a catastrophic and very edge case for which we could create a custom Exception class. 
# Change
Added a new exception type `NullTokenResultException`. If an auth flow returns `null`, this exception will be returned.