### PR TITLE
Use assignment instead of add-assign.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install the application, run
 ```powershell
 # v0.3.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 $env:AZUREAUTH_VERSION = 'v0.3.0'
-[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) } -Verbose"
 ```
 
@@ -39,7 +39,7 @@ Or, if you want a method more resilient to failure than `Invoke-Expression`, run
 $env:AZUREAUTH_VERSION = 'v0.3.0'
 $script = "${env:TEMP}\install.ps1"
 $url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'
-[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
 ```
 


### PR DESCRIPTION
The `+=` operator doesn't exist in early versions of PowerShell used by default on win server 2012, and 2016. The install block should #JustWork on those systems so instead let's assign (`=`) the current TLS to 1.2 for the current shell session.