### PR TITLE
Fix installation script when PATH not exists

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -63,7 +63,7 @@ Remove-Item -Force $zipFile
 # Permanently add the latest directory to the current user's $PATH (if it's not already there).
 # Note that this will only take effect when a new terminal is started.
 $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
-$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ea 0).Path
+$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
 if ($currentPath -NotMatch 'AzureAuth') {
     Write-Verbose "Updating `$PATH to include ${latestDirectory}"
     $newPath = if($currentPath -Match $null) {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -66,7 +66,7 @@ $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
 $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
 if ($currentPath -NotMatch 'AzureAuth') {
     Write-Verbose "Updating `$PATH to include ${latestDirectory}"
-    $newPath = if($currentPath -Match $null) {
+    $newPath = if ($currentPath -Match $null) {
         "${latestDirectory}"
     } else {
         "${currentPath};${latestDirectory}"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -66,7 +66,7 @@ $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
 $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ea 0).Path
 if ($currentPath -NotMatch 'AzureAuth') {
     Write-Verbose "Updating `$PATH to include ${latestDirectory}"
-    $newPath = if($currentPath -Match $null") {
+    $newPath = if($currentPath -Match $null) {
         ${latestDirectory}
     } else {
         ${currentPath};${latestDirectory}

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -67,9 +67,9 @@ $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ea 0).Path
 if ($currentPath -NotMatch 'AzureAuth') {
     Write-Verbose "Updating `$PATH to include ${latestDirectory}"
     $newPath = if($currentPath -Match $null) {
-        ${latestDirectory}
+        "${latestDirectory}"
     } else {
-        ${currentPath};${latestDirectory}
+        "${currentPath};${latestDirectory}"
     }
     Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
 }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -63,10 +63,14 @@ Remove-Item -Force $zipFile
 # Permanently add the latest directory to the current user's $PATH (if it's not already there).
 # Note that this will only take effect when a new terminal is started.
 $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
-$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH).Path
+$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ea 0).Path
 if ($currentPath -NotMatch 'AzureAuth') {
     Write-Verbose "Updating `$PATH to include ${latestDirectory}"
-    $newPath = "${currentPath};${latestDirectory}"
+    $newPath = if($currentPath -Match $null") {
+        ${latestDirectory}
+    } else {
+        ${currentPath};${latestDirectory}
+    }
     Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
 }
 


### PR DESCRIPTION
# Background
On Windows Server 2012, `PATH` does not exist in users' environment variables. The [installation](https://github.com/AzureAD/microsoft-authentication-cli/blob/17c1a58cdf1caba7c097418fbaea246f7b12285c/install/install.ps1#L66) will throw exception `Get-ItemProperty : Property PATH does not exist at path HKEY_CURRENT_USER\Environment.`
 and quit.
 
# Solution
Add `-ea 0` in the script, which equals `-ErrorAction SilentlyContinue`, as well as compare `$currentPath` with `$null`.

Tested on Windows 11 and Windows Server 2012.