### PR TITLE
Use secrets to fetch internal packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+        source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Install dependencies
       run: dotnet restore --runtime ${{ matrix.runtime }}
     - name: Test


### PR DESCRIPTION
Without the appropriate NuGet auth token we can't fetch non-public packages like Lasso.