### PR TITLE
Setup .NET 5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
On Windows it would seem that we also need .NET 5 available to build and test.