### PR TITLE
Making signing runtime support win10-x64

### DIFF
--- a/bin/sign.py
+++ b/bin/sign.py
@@ -209,9 +209,9 @@ def parse_args() -> Namespace:
     )
     parser.add_argument(
         "--runtime",
-        choices=["win-x64", "osx-x64", "osx-arm64"],
+        choices=["win10-x64", "osx-x64", "osx-arm64"],
         help="the runtime of the build in source",
-        default="win-x64",
+        default="win10-x64",
     )
 
     return parser.parse_args()


### PR DESCRIPTION
Looks like I forgot to make sure the `--runtime` argument to `sign.py` took `win10-x64` rather than `win-x64`.