### PR TITLE
Fix the installation issue on Windows Server 2012

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -44,6 +44,8 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 if (Test-Path -Path $latestDirectory) {
     Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
+    
+    # We use IO.Directory::Delete instead of Remove-Item because on Windows Server 2012 with PowerShell 4.0 the latter will not work.
     [IO.Directory]::Delete($latestDirectory)
 }
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -44,7 +44,7 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 if (Test-Path -Path $latestDirectory) {
     Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
-    Remove-Item -Force -Recurse $latestDirectory
+    [io.directory]::Delete($latestDirectory)
 }
 
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -44,7 +44,7 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 if (Test-Path -Path $latestDirectory) {
     Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
-    [io.directory]::Delete($latestDirectory)
+    [IO.Directory]::Delete($latestDirectory)
 }
 
 # We use a directory junction here because not all Windows users will have permissions to create a symlink.


### PR DESCRIPTION
PowerShell 4.0 does not recognize junctions correctly. Use [io.directory]::Delete will do the right thing.