### PR TITLE
Actually make signing runtime support win10-x64

### DIFF
--- a/bin/sign.py
+++ b/bin/sign.py
@@ -247,7 +247,7 @@ def main() -> None:
 
     # 3. Determine runtime & create a batchmaker.
     match args.runtime.lower():
-        case "win-x64":
+        case "win10-x64":
             batchmaker = windows_batches(
                 source=source_path,
                 key_codes=key_codes,


### PR DESCRIPTION
Wow. I cannot believe I forgot this one when I submitted #78. This should _actually_ make `win10-x64` a valid runtime for the `sign.py` script.