### PR TITLE
Correctly collect resource and tenant fields in telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed a bug where the tenant and resource ids were swapped in the telemetry events.
 
 ## [v0.3.0] - 2022-05-03
 ### Fixed

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -260,8 +260,8 @@ Allowed values: [all, web, devicecode]";
 
             this.eventData.Add("validargs", true);
             this.eventData.Add("settings_client", this.authSettings.Client);
-            this.eventData.Add("settings_tenant", this.authSettings.Resource);
-            this.eventData.Add("settings_resource", this.authSettings.Tenant);
+            this.eventData.Add("settings_resource", this.authSettings.Resource);
+            this.eventData.Add("settings_tenant", this.authSettings.Tenant);
             this.eventData.Add("settings_prompthint", this.authSettings.PromptHint);
 
             // Small bug in Lasso - Add does not accept a null IEnumerable here.


### PR DESCRIPTION
In our telemetry we have logged the tenant as the resource and vice versa. That was probably a copy-paste error (probably my fault). Let's fix that so in version 0.4.0 we have the right fields under the right names.