### PR TITLE
Use local machine certificates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,11 +110,11 @@ jobs:
           ESRP_REQ_CERT_VERSION: ${{ secrets.AZURE_VAULT_ESRP_REQ_CERT_VERSION }}
         run: |
           az keyvault secret download --subscription "$env:AZURE_SUBSCRIPTION" --vault-name "$env:AZURE_VAULT" --name "$env:ESRP_AAD_CERT_NAME" --version "$env:ESRP_AAD_CERT_VERSION" -f cert.pfx
-          certutil -f -user -importpfx cert.pfx
+          certutil -f -importpfx cert.pfx
           Remove-Item cert.pfx
 
           az keyvault secret download --subscription "$env:AZURE_SUBSCRIPTION" --vault-name "$env:AZURE_VAULT" --name "$env:ESRP_REQ_CERT_NAME" --version "$env:ESRP_REQ_CERT_VERSION" -f cert.pfx
-          certutil -f -user -importpfx cert.pfx
+          certutil -f -importpfx cert.pfx
           Remove-Item cert.pfx
       # We download all artifacts and overwrite them with signed files, but only upload ones which we can properly sign.
       - name: Download all artifacts

--- a/bin/sign.py
+++ b/bin/sign.py
@@ -158,12 +158,12 @@ def auth(tenant_id: str, client_id: str) -> JSON:
         "ClientId": client_id,
         "AuthCert": {
             "SubjectName": f"CN={client_id}.microsoft.com",
-            "StoreLocation": "CurrentUser",
+            "StoreLocation": "LocalMachine",
             "StoreName": "My",
         },
         "RequestSigningCert": {
             "SubjectName": f"CN={client_id}",
-            "StoreLocation": "CurrentUser",
+            "StoreLocation": "LocalMachine",
             "StoreName": "My",
         },
     }


### PR DESCRIPTION
Once more, with feeling! 🎉 Apparently we can just use the `LocalMachine` store instead of the `CurrentUser` store. This is what the [`git-credential-manager` does](https://github.com/GitCredentialManager/git-credential-manager/blob/dc689621356f70ab40664e73560b42747b727d9c/.github/run_esrp_signing.py#L33-L48).