### PR TITLE
Add status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Microsoft Authentication CLI
 
+![Tests](https://shields.io/github/workflow/status/AzureAD/microsoft-authentication-cli/Build%20and%20Test/main?style=flat-square)
+![Release](https://shields.io/github/v/release/AzureAD/microsoft-authentication-cli?display_name=tag&include_prereleases&sort=semver&style=flat-square)
+![License](https://shields.io/badge/license-MIT-purple?style=flat-square)
+
+---
+
 `AzureAuth` is a CLI wrapper for performing AAD Authentication. It makes use of [MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) for authentication and [MSAL Extensions](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet) for caching.
 
 The CLI is designed for authenticating and returning an access token for public client AAD applications. This acts like a credential provider for Azure Devops and any other [public client app](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-client-applications).


### PR DESCRIPTION
This PR just adds some simple status badges using [shields.io](https://shields.io/). This is similar to what [GCM](https://github.com/GitCredentialManager/git-credential-manager) does, but with a little more flair for quick visual identifiers on things you might want to know when choosing a new tool (are tests passing, which version are they on, what's the license, etc.).

Note that the release badge uses SemVer and includes pre-releases, so we never need to update it.

## Before
<img width="680" alt="readme-before-badge" src="https://user-images.githubusercontent.com/3084059/171965836-1a980905-1391-4e91-9772-c610dba6d33b.png">

## After
<img width="680" alt="readme-after-badge" src="https://user-images.githubusercontent.com/3084059/171965838-5be05619-ad1f-4ea2-bb25-3208976632bb.png">

