### PR TITLE
Change version scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version'
         required: true
         type: string
-      # We use SemVer, anything before v1.0.0 is a pre-release, but this could also include versions like v1.1.0-beta.
+      # We use SemVer, anything before 1.0.0 is a pre-release, but this could also include versions like 1.1.0-beta.
       prerelease:
         description: 'Prerelease'
         required: true
@@ -66,7 +66,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts
-      run: dotnet publish src/AzureAuth/AzureAuth.csproj --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
+      run: dotnet publish src/AzureAuth/AzureAuth.csproj -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [v0.3.1] - 2022-06-06
+## [0.3.1] - 2022-06-06
 ### Fixed
 - Fixed a bug where the tenant and resource ids were swapped in the telemetry events.
+
+### Changed
+- The version schema no longer has a `v` prefix (e.g. `v0.3.1` is now expressed as `0.3.1`).
 
 ## [v0.3.0] - 2022-05-03
 ### Fixed
@@ -43,8 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.3.1...HEAD
-[v0.3.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.3.0...v0.3.1
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.3.0...0.3.1
 [v0.3.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ provide a means of downloading the latest release, so you **must** specify your 
 To install the application, run
 
 ```powershell
-# v0.3.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-$env:AZUREAUTH_VERSION = 'v0.3.0'
+# 0.3.1 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = '0.3.1'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1) } -Verbose"
 ```
@@ -41,8 +41,8 @@ iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authenticatio
 Or, if you want a method more resilient to failure than `Invoke-Expression`, run
 
 ```powershell
-# v0.3.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-$env:AZUREAUTH_VERSION = 'v0.3.0'
+# 0.3.1 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = '0.3.1'
 $script = "${env:TEMP}\install.ps1"
 $url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.ps1'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -62,8 +62,8 @@ release, so you **must** specify your desired version via the `$AZUREAUTH_VERSIO
 To install the application, run
 
 ```bash
-# v0.3.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-export AZUREAUTH_VERSION='v0.3.0'
+# 0.3.1 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+export AZUREAUTH_VERSION='0.3.1'
 curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/main/install/install.sh | sh
 ```
 

--- a/bin/version.py
+++ b/bin/version.py
@@ -1,20 +1,16 @@
-"""A script which validates strings as mostly SemVer compliant. We add a 'v'."""
+"""A script which validates strings as SemVer compliant."""
 
 import re
 import sys
 
-# Strictly speaking, this isn't exactly SemVer because we've added a 'v' to the
-# prefix, but everything else is taken from https://semver.org.
-#
-# See also:
-# - https://semver.org/#is-v123-a-semantic-version
+# See this link for more info:
 # - https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-MOSTLY_SEMVER = re.compile(r"^v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
+SEMVER = re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
 
 def main() -> None:
     """Validate user input."""
     version = input("Enter a version: ")
-    match MOSTLY_SEMVER.match(version):
+    match SEMVER.match(version):
         case None:
             sys.exit(f"Invalid version: {version}")
         case _:


### PR DESCRIPTION
It turns out when we attempted to release `v0.3.1` I forgot that we needed the `-p:Version=` flag to `dotnet publish`. Using a `v` prefix makes that more difficult, so we've just dropped that and decided to use `0.3.1` instead of `v0.3.1`.