### PR TITLE
Fix windows archive errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,7 @@ jobs:
     - name: Install Zip
       run: sudo apt install -y zip
     - name: Create win10-x64 archive
-      run: |
-        cd azureauth-${{ github.event.inputs.version }}-win10-x64
-        zip ../azureauth-${{ github.event.inputs.version }}-win10-x64.zip *
+      run: zip -r azureauth-${{ github.event.inputs.version }}-win10-x64.zip azureauth-${{ github.event.inputs.version }}-win10-x64
     - name: Upload win10-x64 artifact
       uses: actions/upload-artifact@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.3.1] - 2022-06-06
+## [0.3.1] - 2022-06-07
 ### Fixed
 - Fixed a bug where the tenant and resource ids were swapped in the telemetry events.
 


### PR DESCRIPTION
Now we can _actually_ release `0.3.1`. 🎉 