### PR TITLE
Filter PR build and test workflow on files that impact build

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
+      - '.github/**'
       - 'src/**'
       - '**.sln'
       - 'nuget.config'


### PR DESCRIPTION
# Summary
Right now we unconditionally run the build and test workflow for all PRs. This is wasteful for changes only updating docs, or configuration that does not impact build itself.

# Solution
Filter the trigger for that pipeline to paths that do impact the build.

# Notes
We also have PR required to be up-tp-date. This means they must either be rebased on main, or have merged main before they merge, so we can safely remove the trigger to run the same workflow on pushes to main - because any PR is required to have already run against the merge commit for that branch.