### PR TITLE
Stop azureauth before install

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -33,6 +33,14 @@ Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
 $client = New-Object System.Net.WebClient
 $client.DownloadFile($releaseUrl, $zipFile)
 
+# A running instance of azureauth can cause installation to fail, so we try to kill any running instances first.
+# We suppress taskkill output here because this is a best effort attempt and we don't want the user to see its output.
+# This has to be in a try/catch block otherwise ErrorActionPreference='Stop' will cause this to fail in PowerShell 5.
+try {
+    Write-Verbose "Stopping any currently running azureauth instances"
+    taskkill /f /im azureauth.exe 2>&1 | Out-Null
+} catch {}
+
 if (Test-Path -Path $extractedDirectory) {
     Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"
     Remove-Item -Force -Recurse $extractedDirectory


### PR DESCRIPTION
Installation can fail if azureauth is running at the same time. This will attempt to stop azureauth first. We tried to add this in #93, but had to revert it in #95. Using a `try`/`catch` block now prevents this from triggering `$ErrorActionPreference='Stop'` in PowerShell 5.