### PR TITLE
Avoid empty try-catch code block by using GetProcess

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -35,11 +35,13 @@ $client.DownloadFile($releaseUrl, $zipFile)
 
 # A running instance of azureauth can cause installation to fail, so we try to kill any running instances first.
 # We suppress taskkill output here because this is a best effort attempt and we don't want the user to see its output.
-# This has to be in a try/catch block otherwise ErrorActionPreference='Stop' will cause this to fail in PowerShell 5.
-try {
+# Here, Get-Process is used to first determine whether there is an existing azureauth process. If there is, kill the existing process first.
+$ProcessCheck = Get-Process -Name azureauth -ErrorAction SilentlyContinue -ErrorVariable ProcessError
+if ($ProcessCheck -ne $null)
+{
     Write-Verbose "Stopping any currently running azureauth instances"
     taskkill /f /im azureauth.exe 2>&1 | Out-Null
-} catch {}
+}
 
 if (Test-Path -Path $extractedDirectory) {
     Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"


### PR DESCRIPTION
#99 stopped `azureauth.exe` before extracting zip files. This PR is to avoid empty try-catch code block.

Reference: [checking-if-a-process-is-running-via-powershell](https://community.spiceworks.com/topic/2310944-checking-if-a-process-is-running-via-powershell)

Tested on Windows Server 2012 and Windows 11.