### PR TITLE
Adding Integrated Windows Authentication to auth mode and token result.

### DIFF
--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -15,19 +15,31 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void AllIsAll()
         {
-            (AuthMode.Broker | AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
+            (AuthMode.IWA | AuthMode.Broker | AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
         }
 
         [Test]
         public void WindowsDefaultModes()
         {
             var subject = AuthMode.Default;
+            subject.IsIWA().Should().BeTrue();
             subject.IsBroker().Should().BeTrue();
             subject.IsWeb().Should().BeTrue();
             subject.IsDeviceCode().Should().BeFalse();
         }
 
         [TestCase(AuthMode.All, true)]
+        [TestCase(AuthMode.IWA, true)]
+        [TestCase(AuthMode.Broker, false)]
+        [TestCase(AuthMode.Web, false)]
+        [TestCase(AuthMode.DeviceCode, false)]
+        public void IWAIsExpected(AuthMode subject, bool expected)
+        {
+            subject.IsIWA().Should().Be(expected);
+        }
+
+        [TestCase(AuthMode.All, true)]
+        [TestCase(AuthMode.IWA, false)]
         [TestCase(AuthMode.Broker, true)]
         [TestCase(AuthMode.Web, false)]
         [TestCase(AuthMode.DeviceCode, false)]
@@ -37,6 +49,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [TestCase(AuthMode.All, true)]
+        [TestCase(AuthMode.IWA, false)]
         [TestCase(AuthMode.Broker, false)]
         [TestCase(AuthMode.Web, true)]
         [TestCase(AuthMode.DeviceCode, false)]
@@ -46,6 +59,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [TestCase(AuthMode.All, true)]
+        [TestCase(AuthMode.IWA, false)]
         [TestCase(AuthMode.Broker, false)]
         [TestCase(AuthMode.Web, false)]
         [TestCase(AuthMode.DeviceCode, true)]
@@ -64,14 +78,19 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject = AuthMode.Broker | AuthMode.Web;
             subject.IsBroker().Should().BeTrue();
             subject.IsWeb().Should().BeTrue();
+
+            subject = AuthMode.IWA | AuthMode.Broker;
+            subject.IsIWA().Should().BeTrue();
+            subject.IsBroker().Should().BeTrue();
         }
 
         [Test]
-        public void WebOrDeviceCodeIsNotbroker()
+        public void WebOrDeviceCodeIsNotBrokerAndIWA()
         {
             var subject = AuthMode.Web | AuthMode.DeviceCode;
 
             subject.IsBroker().Should().BeFalse();
+            subject.IsIWA().Should().BeFalse();
         }
 #else
         [Test]
@@ -92,6 +111,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void NonWindowsDefaultModes()
         {
             var subject = AuthMode.Default;
+            subject.IsIWA().Should().BeFalse();
             subject.IsBroker().Should().BeFalse();
             subject.IsWeb().Should().BeTrue();
             subject.IsDeviceCode().Should().BeFalse();

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public void WebOrDeviceCodeIsNotBrokerAndIWA()
+        public void WebOrDeviceCodeIsNotBrokerOrIWA()
         {
             var subject = AuthMode.Web | AuthMode.DeviceCode;
 

--- a/src/MSALWrapper/AuthMode.cs
+++ b/src/MSALWrapper/AuthMode.cs
@@ -28,14 +28,19 @@ namespace Microsoft.Authentication.MSALWrapper
         Broker = 1 << 2,
 
         /// <summary>
+        /// Integrated Windows auth mode.
+        /// </summary>
+        IWA = 1 << 3,
+
+        /// <summary>
         /// All auth modes.
         /// </summary>
-        All = Broker | Web | DeviceCode,
+        All = IWA | Broker | Web | DeviceCode,
 
         /// <summary>
         /// Default auth mode.
         /// </summary>
-        Default = Broker | Web,
+        Default = IWA | Broker | Web,
 #else
         /// <summary>
         /// All auth modes.
@@ -86,6 +91,20 @@ namespace Microsoft.Authentication.MSALWrapper
         public static bool IsDeviceCode(this AuthMode authMode)
         {
             return (AuthMode.DeviceCode & authMode) == AuthMode.DeviceCode;
+        }
+
+        /// <summary>
+        /// Checks if authMode is IWA Enabled.
+        /// </summary>
+        /// <param name="authMode">The <see cref="AuthMode"/>.</param>
+        /// <returns>true or false.</returns>
+        public static bool IsIWA(this AuthMode authMode)
+        {
+#if PlatformWindows
+            return (AuthMode.IWA & authMode) == AuthMode.IWA;
+#else
+            return false;
+#endif
         }
     }
 }

--- a/src/MSALWrapper/TokenResult.cs
+++ b/src/MSALWrapper/TokenResult.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Authentication.MSALWrapper
 
         /// <summary>
         /// Integrated Windows auth flow auth type.
-
         /// </summary>
         IntegratedWindowsAuthenticationFlow,
     }

--- a/src/MSALWrapper/TokenResult.cs
+++ b/src/MSALWrapper/TokenResult.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Device code flow auth type.
         /// </summary>
         DeviceCodeFlow,
+
+        /// <summary>
+        /// Interactive Windows auth flow auth type.
+        /// </summary>
+        InteractiveWindowsAuthFlow,
     }
 
     /// <summary>

--- a/src/MSALWrapper/TokenResult.cs
+++ b/src/MSALWrapper/TokenResult.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <summary>
         /// Interactive Windows auth flow auth type.
         /// </summary>
-        InteractiveWindowsAuthFlow,
+        IntegratedWindowsAuthenticationFlow,
     }
 
     /// <summary>

--- a/src/MSALWrapper/TokenResult.cs
+++ b/src/MSALWrapper/TokenResult.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Authentication.MSALWrapper
         DeviceCodeFlow,
 
         /// <summary>
-        /// Interactive Windows auth flow auth type.
+        /// Integrated Windows auth flow auth type.
+
         /// </summary>
         IntegratedWindowsAuthenticationFlow,
     }


### PR DESCRIPTION
This is the first PR for integrating IWA and contains the following:
1. Add IWA to auth modes if platform is Windows.
2. Added tests to validate the changes.
3. Added Interactive Windows Auth to TokenResult to capture Auth type.