### PR TITLE
Wait after killing a task before removing the directory

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -41,6 +41,11 @@ if ($ProcessCheck -ne $null)
 {
     Write-Verbose "Stopping any currently running azureauth instances"
     taskkill /f /im azureauth.exe 2>&1 | Out-Null
+
+    # After killing the process it is still possible for there there to be locks on the files it was using (including
+    # its own DLLs). The OS may take an indeterminate amount of time to clean those up, but so far we've observed 1
+    # second to be enough.
+    Start-Sleep -Seconds 1
 }
 
 if (Test-Path -Path $extractedDirectory) {


### PR DESCRIPTION
We've observed that there may be a concurrency issue where after running `taskkill` the OS still has locks open for the DLLs that it was using. This is definitely a band-aid fix, but for now if we sleep for about a second that appears to be enough time to let those locks close and allow the installer to proceed.