### PR TITLE
Adding Integrated Windows Auth to PCA Wrapper

### DIFF
--- a/src/MSALWrapper/IPCAWrapper.cs
+++ b/src/MSALWrapper/IPCAWrapper.cs
@@ -52,6 +52,14 @@ namespace Microsoft.Authentication.MSALWrapper
         Task<TokenResult> GetTokenDeviceCodeAsync(IEnumerable<string> scopes, Func<DeviceCodeResult, Task> callback, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Get token integrated windows authentication async.
+        /// </summary>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<TokenResult> GetTokenIntegratedWindowsAuthenticationAsync(IEnumerable<string> scopes, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Customize the title bar by prompt hint(Web mode only).
         /// </summary>
         /// <param name="promptHint">The prompt hint text.</param>

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -106,6 +106,13 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <inheritdoc/>
+        public async Task<TokenResult> GetTokenIntegratedWindowsAuthenticationAsync(IEnumerable<string> scopes, CancellationToken cancellationToken)
+        {
+            AuthenticationResult result = await this.pca.AcquireTokenByIntegratedWindowsAuth(scopes).ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            return this.TokenResultOrNull(result);
+        }
+
+        /// <inheritdoc/>
         public async Task<IAccount> TryToGetCachedAccountAsync(string preferredDomain = null)
         {
             var accounts = await this.TryToGetCachedAccountsAsync(preferredDomain);


### PR DESCRIPTION
Adding a method `GetTokenIntegratedWindowsAuthenticationAsync` to PCAWrapper class that utilizes the internal MSAL method `AcquireTokenByIntegratedWindowsAuth`.