### PR TITLE
Integrated Windows Authentication implementation

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -102,6 +102,15 @@ namespace MSALWrapper.Test
 
 #if PlatformWindows
         [Test]
+        public void IntegratedWindowsAuthentication_Only()
+        {
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.IWA);
+
+            subject.Should().HaveCount(1);
+            subject.First().GetType().Name.Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+        }
+
+        [Test]
         public void Broker_Only()
         {
             this.MockIsWindows10Or11(true);
@@ -119,13 +128,14 @@ namespace MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
-            subject.Should().HaveCount(2);
+            subject.Should().HaveCount(3);
 
             // BeEquivalentTo doesn't assert order for a list :(
             // so explicitly assert the first and second item names.
             var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(Broker).Name);
-            names[1].Should().Be(typeof(Web).Name);
+            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+            names[1].Should().Be(typeof(Broker).Name);
+            names[2].Should().Be(typeof(Web).Name);
         }
 
         [Test]
@@ -135,9 +145,45 @@ namespace MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
-            subject.Should().HaveCount(1);
+            subject.Should().HaveCount(2);
             var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(Web).Name);
+            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+            names[1].Should().Be(typeof(Web).Name);
+        }
+
+        [Test]
+        public void Windows10Or11_All()
+        {
+            this.MockIsWindows10Or11(true);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
+
+            subject.Should().HaveCount(4);
+
+            // BeEquivalentTo doesn't assert order for a list :(
+            // so explicitly assert the first and second item names.
+            var names = subject.Select(a => a.GetType().Name).ToList();
+            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+            names[1].Should().Be(typeof(Broker).Name);
+            names[2].Should().Be(typeof(Web).Name);
+            names[3].Should().Be(typeof(DeviceCode).Name);
+        }
+
+        [Test]
+        public void Windows_All()
+        {
+            this.MockIsWindows10Or11(false);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
+
+            subject.Should().HaveCount(3);
+
+            // BeEquivalentTo doesn't assert order for a list :(
+            // so explicitly assert the first and second item names.
+            var names = subject.Select(a => a.GetType().Name).ToList();
+            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+            names[1].Should().Be(typeof(Web).Name);
+            names[2].Should().Be(typeof(DeviceCode).Name);
         }
 #endif
 
@@ -155,7 +201,7 @@ namespace MSALWrapper.Test
         [Platform("Win")]
         public void AllModes_Windows()
         {
-            this.MockIsWindows10Or11(true);
+            this.MockIsWindows10Or11(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
@@ -166,6 +212,28 @@ namespace MSALWrapper.Test
                 .Should()
                 .BeEquivalentTo(new[]
                 {
+                    typeof(IntegratedWindowsAuthentication).Name,
+                    typeof(Web).Name,
+                    typeof(DeviceCode).Name,
+                });
+        }
+
+        [Test]
+        [Platform("Win")]
+        public void AllModes_Windows10Or11()
+        {
+            this.MockIsWindows10Or11(true);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
+
+            this.pcaWrapperMock.VerifyAll();
+            subject.Should().HaveCount(4);
+            subject
+                .Select(flow => flow.GetType().Name)
+                .Should()
+                .BeEquivalentTo(new[]
+                {
+                    typeof(IntegratedWindowsAuthentication).Name,
                     typeof(Broker).Name,
                     typeof(Web).Name,
                     typeof(DeviceCode).Name,

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -104,6 +104,8 @@ namespace MSALWrapper.Test
         [Test]
         public void IntegratedWindowsAuthentication_Only()
         {
+            this.MockIsWindows(true);
+
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.IWA);
 
             subject.Should().HaveCount(1);
@@ -124,6 +126,7 @@ namespace MSALWrapper.Test
         [Test]
         public void Windows10Or11_Defaults()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(true);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
@@ -141,6 +144,7 @@ namespace MSALWrapper.Test
         [Test]
         public void Windows_Defaults()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
@@ -154,6 +158,7 @@ namespace MSALWrapper.Test
         [Test]
         public void Windows10Or11_All()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(true);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
@@ -172,6 +177,7 @@ namespace MSALWrapper.Test
         [Test]
         public void Windows_All()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
@@ -201,6 +207,7 @@ namespace MSALWrapper.Test
         [Platform("Win")]
         public void AllModes_Windows()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
@@ -222,6 +229,7 @@ namespace MSALWrapper.Test
         [Platform("Win")]
         public void AllModes_Windows10Or11()
         {
+            this.MockIsWindows(true);
             this.MockIsWindows10Or11(true);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
@@ -276,6 +284,11 @@ namespace MSALWrapper.Test
         private void MockIsWindows10Or11(bool value)
         {
             this.platformUtilsMock.Setup(p => p.IsWindows10Or11()).Returns(value);
+        }
+
+        private void MockIsWindows(bool value)
+        {
+            this.platformUtilsMock.Setup(p => p.IsWindows()).Returns(value);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 0.1 minutes.");
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[0].Message.Should().Be("AADSTS50076 UI is required");
+            authFlowResult.Errors[0].Message.Should().Be("AADSTS50076 MSAL UI Required Exception!");
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[0].Message.Should().Be("AADSTS500083 UI is required");
+            authFlowResult.Errors[0].Message.Should().Be("MSAL UI Required Exception!");
         }
 
         [Test]
@@ -398,14 +398,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("1", "AADSTS50076 UI is required"));
+                .Throws(new MsalUiRequiredException("1", "AADSTS50076 MSAL UI Required Exception!"));
         }
 
         private void IntegratedWindowsAuthenticationUIRequiredForAADBrokeIWA()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("2", "AADSTS500083 UI is required"));
+                .Throws(new MsalUiRequiredException("2", "MSAL UI Required Exception!"));
         }
 
         private void IntegratedWindowsAuthenticationServiceException()

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -1,0 +1,439 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+    using Moq;
+    using NLog.Extensions.Logging;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    public class IntegratedWindowsAuthenticationTest
+    {
+        private const string MsalServiceExceptionErrorCode = "1";
+        private const string MsalServiceExceptionMessage = "MSAL Service Exception: Something bad has happened!";
+        private const string TestUser = "user@microsoft.com";
+
+        // These Guids were randomly generated and do not refer to a real resource or client
+        // as we don't need either for our testing.
+        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+
+        private IServiceProvider serviceProvider;
+        private MemoryTarget logTarget;
+
+        // MSAL Specific Mocks
+        private Mock<IPCAWrapper> pcaWrapperMock;
+        private Mock<IAccount> testAccount;
+        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
+        private TokenResult tokenResult;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new NLog.Config.LoggingConfiguration();
+            this.logTarget = new MemoryTarget("memory_target");
+            loggingConfig.AddTarget(this.logTarget);
+            loggingConfig.AddRuleForAllLevels(this.logTarget);
+
+            // MSAL Mocks
+            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
+            this.testAccount.Setup(a => a.Username).Returns(TestUser);
+
+            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
+
+            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
+            this.serviceProvider = new ServiceCollection()
+             .AddLogging(loggingBuilder =>
+             {
+                 // configure Logging with NLog
+                 loggingBuilder.ClearProviders();
+                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+                 loggingBuilder.AddNLog(loggingConfig);
+             })
+             .AddTransient<AuthFlow.IntegratedWindowsAuthentication>((provider) =>
+             {
+                 var logger = provider.GetService<ILogger<AuthFlow.IntegratedWindowsAuthentication>>();
+                 return new AuthFlow.IntegratedWindowsAuthentication(logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object);
+             })
+             .BuildServiceProvider();
+
+            // Mock successful token result
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+        }
+
+        public AuthFlow.IntegratedWindowsAuthentication Subject() => this.serviceProvider.GetService<AuthFlow.IntegratedWindowsAuthentication>();
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_HappyPath()
+        {
+            this.SilentAuthResult();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_ReturnsNull()
+        {
+            this.SilentAuthReturnsNull();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_MsalUIException()
+        {
+            this.SilentAuthUIRequired();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        }
+
+        [Test]
+        public void IntegratedWindowsAuthFlow_General_Exceptions_Are_ReThrown()
+        {
+            var message = "Something somwhere has gone terribly wrong!";
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new Exception(message));
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            Func<Task> subject = async () => await iwa.GetTokenAsync();
+
+            // Assert
+            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+
+            this.pcaWrapperMock.VerifyAll();
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_MsalServiceException()
+        {
+            this.SilentAuthServiceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_OperationCanceledException()
+        {
+            this.SilentAuthTimeout();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_MsalClientException()
+        {
+            this.SilentAuthClientException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_NullReferenceException()
+        {
+            this.SilentAuthNullReferenceException();
+
+            this.MockAccount();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA()
+        {
+            this.IntegratedWindowsAuthenticationResult();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.AuthType.Should().Be(AuthType.IntegratedWindowsAuthenticationFlow);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_ReturnsNull()
+        {
+            this.IntegratedWindowsAuthenticationReturnsNull();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalUIRequired_2FA()
+        {
+            this.IntegratedWindowsAuthenticationUIRequiredFor2FA();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[0].Message.Should().Be("AADSTS50076 UI is required");
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalUIRequired_AADBrokeIWA()
+        {
+            this.IntegratedWindowsAuthenticationUIRequiredForAADBrokeIWA();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[0].Message.Should().Be("AADSTS500083 UI is required");
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalServiceException()
+        {
+            this.IntegratedWindowsAuthenticationServiceException();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert - this method should not throw for known types of excpeptions, instead return null, so
+            // our caller can retry auth another way.
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+        }
+
+        [Test]
+        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalClientException()
+        {
+            this.IntegratedWindowsAuthenticationClientException();
+
+            this.MockAccountReturnsNull();
+
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            // Assert
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+        }
+
+        private void SilentAuthResult()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void SilentAuthReturnsNull()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((TokenResult)null);
+        }
+
+        private void SilentAuthUIRequired()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "UI is required"));
+        }
+
+        private void SilentAuthServiceException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void SilentAuthTimeout()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+        }
+
+        private void SilentAuthClientException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
+        }
+
+        private void SilentAuthNullReferenceException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
+        }
+
+        private void IntegratedWindowsAuthenticationResult()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.tokenResult);
+        }
+
+        private void IntegratedWindowsAuthenticationReturnsNull()
+        {
+            this.pcaWrapperMock
+               .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((TokenResult)null);
+        }
+
+        private void IntegratedWindowsAuthenticationUIRequiredFor2FA()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "AADSTS50076 UI is required"));
+        }
+
+        private void IntegratedWindowsAuthenticationUIRequiredForAADBrokeIWA()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("2", "AADSTS500083 UI is required"));
+        }
+
+        private void IntegratedWindowsAuthenticationServiceException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+        }
+
+        private void IntegratedWindowsAuthenticationClientException()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
+                .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
+        }
+
+        private void MockAccount()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync(this.testAccount.Object);
+        }
+
+        private void MockAccountReturnsNull()
+        {
+            this.pcaWrapperMock
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync((IAccount)null);
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // and tries to auth silently if it finds an account in the cache.
             if (authMode.IsIWA())
             {
-                flows.Add(new IntegratedWindowsAuthentication(logger, clientId, tenantId, scopes, osxKeyChainSuffix, preferredDomain, pcaWrapper));
+                flows.Add(new IntegratedWindowsAuthentication(logger, clientId, tenantId, scopes, preferredDomain, pcaWrapper));
             }
 
             // This check silently fails on winserver if broker has been requested.

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             List<IAuthFlow> flows = new List<IAuthFlow>();
 
             // We try IWA as the first auth flow as it works for any Windows version
-            // and tries to auth silently if it finds an account in the cache.
-            if (authMode.IsIWA())
+            // and tries to auth silently.
+            if (authMode.IsIWA() && platformUtils.IsWindows())
             {
                 flows.Add(new IntegratedWindowsAuthentication(logger, clientId, tenantId, scopes, preferredDomain, pcaWrapper));
             }

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // as it sets the order in which auth flows will be attempted.
             List<IAuthFlow> flows = new List<IAuthFlow>();
 
+            // We try IWA as the first auth flow as it works for any Windows version
+            // and tries to auth silently if it finds an account in the cache.
+            if (authMode.IsIWA())
+            {
+                flows.Add(new IntegratedWindowsAuthentication(logger, clientId, tenantId, scopes, osxKeyChainSuffix, preferredDomain, pcaWrapper));
+            }
+
             // This check silently fails on winserver if broker has been requested.
             // Future: Consider making AuthMode platform aware at Runtime.
             // https://github.com/AzureAD/microsoft-authentication-cli/issues/55

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
+{
+#if NET472
+    using Microsoft.Identity.Client.Desktop;
+#endif
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// The broker auth flow.
+    /// </summary>
+    public class IntegratedWindowsAuthentication : IAuthFlow
+    {
+        private readonly ILogger logger;
+        private readonly IEnumerable<string> scopes;
+        private readonly string preferredDomain;
+        private readonly IList<Exception> errors;
+        private IPCAWrapper pcaWrapper;
+
+        #region Public configurable properties
+
+        /// <summary>
+        /// The silent auth timeout.
+        /// </summary>
+        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// The intercative windows auth flow timeout.
+        /// </summary>
+        private TimeSpan interactiveWindowsAuthTimeout = TimeSpan.FromMinutes(15);
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntegratedWindowsAuthentication"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="clientId">The client id.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
+        public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
+        {
+            this.errors = new List<Exception>();
+            this.logger = logger;
+            this.scopes = scopes;
+            this.preferredDomain = preferredDomain;
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
+        }
+
+        /// <summary>
+        /// Get a jwt token for a resource.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
+        public async Task<AuthFlowResult> GetTokenAsync()
+        {
+            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
+
+            if (account != null)
+            {
+                this.logger.LogDebug($"Using cached account '{account.Username}'");
+                try
+                {
+                    try
+                    {
+                        var tokenResult = await TaskExecutor.CompleteWithin(
+                            this.logger,
+                            this.silentAuthTimeout,
+                            "Get Token Silent",
+                            (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
+                            this.errors)
+                            .ConfigureAwait(false);
+                        tokenResult.SetAuthenticationType(AuthType.Silent);
+
+                        return new AuthFlowResult(tokenResult, this.errors);
+                    }
+                    catch (MsalUiRequiredException ex)
+                    {
+                        this.errors.Add(ex);
+                        this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                    }
+                }
+                catch (MsalServiceException ex)
+                {
+                    this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
+                    this.errors.Add(ex);
+                }
+                catch (MsalClientException ex)
+                {
+                    this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
+                    this.errors.Add(ex);
+                }
+                catch (NullReferenceException ex)
+                {
+                    this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
+                    this.errors.Add(ex);
+                }
+            }
+            else
+            {
+                try
+                {
+                    var tokenResult = await TaskExecutor.CompleteWithin(
+                                    this.logger,
+                                    this.interactiveWindowsAuthTimeout,
+                                    "Get Token Interactive Windows Authentication",
+                                    (cancellationToken) => this.pcaWrapper.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, cancellationToken),
+                                    this.errors)
+                                    .ConfigureAwait(false);
+                    tokenResult.SetAuthenticationType(AuthType.IntegratedWindowsAuthenticationFlow);
+
+                    return new AuthFlowResult(tokenResult, this.errors);
+                }
+                catch (MsalUiRequiredException ex) when (
+                             ex.Classification == UiRequiredExceptionClassification.BasicAction
+                          && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.errors.Add(ex);
+                    this.logger.LogDebug($"IWA failed, 2FA is required.\n{ex.Message}");
+                }
+                catch (MsalUiRequiredException ex) when (
+                             ex.Classification == UiRequiredExceptionClassification.None
+                          && ex.Message.StartsWith("AADSTS500083", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.errors.Add(ex);
+                    this.logger.LogDebug($"IWA failed, unable to verify token signature with identifier 'urn:federation:MSFT'.\n{ex.Message}");
+                }
+                catch (MsalServiceException ex)
+                {
+                    this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
+                    this.errors.Add(ex);
+                }
+                catch (MsalClientException ex)
+                {
+                    this.logger.LogWarning($"Msal Client Exception! Could not identify logged in user.\n{ex.Message}");
+                    this.errors.Add(ex);
+                }
+            }
+
+            return new AuthFlowResult(null, this.errors);
+        }
+
+        private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)
+        {
+            var clientBuilder =
+                PublicClientApplicationBuilder
+                .Create($"{clientId}")
+                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true);
+
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix);
+        }
+
+        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
+        {
+            this.logger.LogTrace($"MSAL: {message}");
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -23,11 +23,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         #region Public configurable properties
 
         /// <summary>
-        /// The silent auth timeout.
-        /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(6);
-
-        /// <summary>
         /// The integrated windows auth flow timeout.
         /// </summary>
         private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromSeconds(6);
@@ -69,7 +64,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     {
                         var tokenResult = await TaskExecutor.CompleteWithin(
                             this.logger,
-                            this.silentAuthTimeout,
+                            this.integratedWindowsAuthTimeout,
                             "Get Token Silent",
                             (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
                             this.errors)

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The silent auth timeout.
         /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(6);
 
         /// <summary>
-        /// The intercative windows auth flow timeout.
+        /// The integrated windows auth flow timeout.
         /// </summary>
-        private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromMinutes(15);
+        private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromSeconds(6);
         #endregion
 
         /// <summary>

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -117,12 +117,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     this.logger.LogWarning($"IWA failed, 2FA is required.\n" +
                         $"IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.\n{ex.Message}");
                 }
-                catch (MsalUiRequiredException ex) when (
-                             ex.Classification == UiRequiredExceptionClassification.None
-                          && ex.Message.StartsWith("AADSTS500083", StringComparison.OrdinalIgnoreCase))
+                catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
-                    this.logger.LogDebug($"IWA failed, unable to verify token signature with identifier 'urn:federation:MSFT'.\n{ex.Message}");
+                    this.logger.LogDebug($"MSAL UI Required Exception.\n{ex.Message}");
                 }
                 catch (MsalServiceException ex)
                 {

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -3,9 +3,6 @@
 
 namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
-#if NET472
-    using Microsoft.Identity.Client.Desktop;
-#endif
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                           && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
                 {
                     this.errors.Add(ex);
-                    this.logger.LogDebug($"IWA failed, 2FA is required.\n{ex.Message}");
+                    this.logger.LogWarning($"IWA failed, 2FA is required.\n" +
+                        $"IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.\n{ex.Message}");
                 }
                 catch (MsalUiRequiredException ex) when (
                              ex.Classification == UiRequiredExceptionClassification.None

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The intercative windows auth flow timeout.
         /// </summary>
-        private TimeSpan interactiveWindowsAuthTimeout = TimeSpan.FromMinutes(15);
+        private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromMinutes(15);
         #endregion
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 {
                     var tokenResult = await TaskExecutor.CompleteWithin(
                                     this.logger,
-                                    this.interactiveWindowsAuthTimeout,
-                                    "Get Token Interactive Windows Authentication",
+                                    this.integratedWindowsAuthTimeout,
+                                    "Get Token Integrated Windows Authentication",
                                     (cancellationToken) => this.pcaWrapper.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, cancellationToken),
                                     this.errors)
                                     .ConfigureAwait(false);

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -35,16 +35,15 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="clientId">The client id.</param>
         /// <param name="tenantId">The tenant id.</param>
         /// <param name="scopes">The scopes.</param>
-        /// <param name="osxKeyChainSuffix">The osx key chain suffix.</param>
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
-        public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string osxKeyChainSuffix = null, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
+        public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
         {
             this.errors = new List<Exception>();
             this.logger = logger;
             this.scopes = scopes;
             this.preferredDomain = preferredDomain;
-            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, null);
         }
 
         /// <summary>
@@ -151,7 +150,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     enablePiiLogging: false,
                     enableDefaultPlatformLogging: true);
 
-            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix);
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, null);
         }
 
         private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)


### PR DESCRIPTION
This is the main PR that integrates and implements IWA as one of the auth flows.

1. Created a new class for IWA and added tests. 
- We check for accounts in cache and try to get token silently.
- If no accounts in cache, then we try IWA as the first auth flow as it works with any Windows version.
- The error handling is mostly inspired by Edge's codebase since if they shell out to AzureAuth in future, the experience should be seamless. I will put link in chat for the code link.
3. Added IWA to AuthFactory class and added tests.
- We try IWA as the first Auth flow since it works with any Windows version.