### PR TITLE
Send AuthFlow telemetry events to the App Insights

### DIFF
--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -59,6 +59,7 @@ invalid_key = ""this is not a valid alias key""
         private MemoryTarget logTarget;
         private Mock<ITokenFetcher> tokenFetcherMock;
         private Mock<IEnv> envMock;
+        private Mock<ITelemetryService> telemetryServiceMock;
 
         /// <summary>
         /// The setup.
@@ -84,6 +85,7 @@ invalid_key = ""this is not a valid alias key""
             this.tokenFetcherMock = new Mock<ITokenFetcher>(MockBehavior.Strict);
 
             this.envMock = new Mock<IEnv>(MockBehavior.Strict);
+            this.telemetryServiceMock = new Mock<ITelemetryService>(MockBehavior.Strict);
 
             // Setup Dependency Injection container to provide logger and out class under test (the "subject").
             this.serviceProvider = new ServiceCollection()
@@ -97,6 +99,7 @@ invalid_key = ""this is not a valid alias key""
                 .AddSingleton(this.fileSystem)
                 .AddSingleton<ITokenFetcher>(this.tokenFetcherMock.Object)
                 .AddSingleton<IEnv>(this.envMock.Object)
+                .AddSingleton<ITelemetryService>(this.telemetryServiceMock.Object)
                 .AddTransient<CommandMain>()
                 .BuildServiceProvider();
         }

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -57,6 +57,7 @@ Allowed values: [all, web, devicecode]";
         private readonly IEnv env;
         private Alias authSettings;
         private IAuthFlow authFlow;
+        private ITelemetryService telemetryService;
 
         /// <summary>
         /// The maximum time we will wait to acquire a mutex around prompting the user.
@@ -67,12 +68,14 @@ Allowed values: [all, web, devicecode]";
         /// Initializes a new instance of the <see cref="CommandMain"/> class.
         /// </summary>
         /// <param name="eventData">The event data.</param>
+        /// <param name="telemetryService">Instance of <see cref="ITelemetryService"/> class to send customEvents to the App Insights.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="env">The environment interface.</param>
-        public CommandMain(CommandExecuteEventData eventData, ILogger<CommandMain> logger, IFileSystem fileSystem, IEnv env)
+        public CommandMain(CommandExecuteEventData eventData, ITelemetryService telemetryService, ILogger<CommandMain> logger, IFileSystem fileSystem, IEnv env)
         {
             this.eventData = eventData;
+            this.telemetryService = telemetryService;
             this.logger = logger;
             this.fileSystem = fileSystem;
             this.env = env;
@@ -82,12 +85,13 @@ Allowed values: [all, web, devicecode]";
         /// Initializes a new instance of the <see cref="CommandMain"/> class.
         /// </summary>
         /// <param name="eventData">The event data.</param>
+        /// <param name="telemetryService">Instance of <see cref="ITelemetryService"/> class to send customEvents to App Insights.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="env">The environment interface.</param>
         /// <param name="authFlow">An injected <see cref="IAuthFlow"/> (defined for testability).</param>
-        public CommandMain(CommandExecuteEventData eventData, ILogger<CommandMain> logger, IFileSystem fileSystem, IEnv env, IAuthFlow authFlow)
-            : this(eventData, logger, fileSystem, env)
+        public CommandMain(CommandExecuteEventData eventData, ITelemetryService telemetryService, ILogger<CommandMain> logger, IFileSystem fileSystem, IEnv env, IAuthFlow authFlow)
+            : this(eventData, telemetryService, logger, fileSystem, env)
         {
             this.authFlow = authFlow;
         }
@@ -413,7 +417,7 @@ Allowed values: [all, web, devicecode]";
                     PrefixedPromptHint(this.authSettings.PromptHint),
                     Constants.AuthOSXKeyChainSuffix);
 
-                this.authFlow = new AuthFlowExecutor(this.logger, authFlows);
+                this.authFlow = new AuthFlowExecutor(this.logger, this.telemetryService, authFlows);
             }
 
             return this.authFlow;

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -365,7 +365,7 @@ Allowed values: [all, web, devicecode]";
                 }
 
                 // But what if result is null? The compiler cannot ensure it won't be (yet).
-                this.eventData.Add("error_list", ExceptionListToStringConverter.Execute(result.Errors));
+                this.eventData.Add("error_list", ExceptionListToStringConverter.SerializeExceptions(result.Errors));
 
                 if (!result.Success)
                 {

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.TokenResult.Should().Be(this.tokenResult);
             result.Success.Should().BeTrue();
             result.Errors.Should().BeEmpty();
+            result.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -144,6 +145,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             result.Should().NotBeNull();
             result.Success.Should().BeFalse();
             result.Errors.Should().BeEmpty();
+            result.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void ConstructorWith_Null_AuthFlows()
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null, null);
+            var telemetryService = this.serviceProvider.GetService<ITelemetryService>();
+            Action authFlowExecutor = () => new AuthFlowExecutor(logger, telemetryService, null);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();
@@ -628,7 +629,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            return new AuthFlowExecutor(logger, null, authFlows);
+            return new AuthFlowExecutor(logger, this.telemetryServiceMock, authFlows);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .BuildServiceProvider();
 
             // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public void ConstructorWith_BothNullArgs()
+        public void ConstructorWith_AllNullArgs()
         {
-            Action authFlowExecutor = () => new AuthFlowExecutor(null, null);
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, null, null);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();
@@ -66,7 +66,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWith_Null_Logger()
         {
-            Action authFlowExecutor = () => new AuthFlowExecutor(null, this.authFlows);
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, null, this.authFlows);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();
@@ -76,7 +76,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void ConstructorWith_Null_AuthFlows()
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null);
+            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null, null);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();
@@ -86,7 +86,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void ConstructorWith_Valid_Arguments()
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            Action authFlowExecutor = () => new AuthFlowExecutor(logger, this.authFlows);
+            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null, this.authFlows);
 
             // Assert
             authFlowExecutor.Should().NotThrow<ArgumentNullException>();
@@ -613,7 +613,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            return new AuthFlowExecutor(logger, authFlows);
+            return new AuthFlowExecutor(logger, null, authFlows);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task SingleAuthFlow_Returns_TokenResult()
         {
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
-            var authFlowResult = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, null, 0);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
             // Act
@@ -153,7 +153,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult = new AuthFlowResult(null, errors1);
+            var authFlowResult = new AuthFlowResult(null, errors1, 0);
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
@@ -195,7 +195,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
         {
             var authFlowResult1 = new AuthFlowResult();
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -222,8 +222,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -285,7 +285,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(null, errors2);
+            var authFlowResult = new AuthFlowResult(null, errors2, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -320,7 +320,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -346,7 +346,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var authFlowResult1 = new AuthFlowResult();
             var authFlowResult2 = new AuthFlowResult();
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -389,9 +389,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 4."),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(null, errors2);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, 0);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -468,8 +468,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(null, errors2);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -512,8 +512,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult3 = new AuthFlowResult(null, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult3 = new AuthFlowResult(null, errors3, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -557,8 +557,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 3"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -602,8 +602,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, 0);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2, 0);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -630,7 +630,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
         {
             var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            return new AuthFlowExecutor(logger, this.telemetryServiceMock, authFlows);
+            var telemetryService = this.serviceProvider.GetService<ITelemetryService>();
+
+            return new AuthFlowExecutor(logger, telemetryService, authFlows);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWith_Null_Logger()
         {
-            Action authFlowExecutor = () => new AuthFlowExecutor(null, null, this.authFlows);
+            var telemetryService = this.serviceProvider.GetService<ITelemetryService>();
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, telemetryService, this.authFlows);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWithNonNullArgs()
         {
-            var tokenResult = new TokenResult(new JsonWebToken(FakeToken));
+            var tokenResult = new TokenResult(new JsonWebToken(FakeToken), Guid.NewGuid());
             var errors = new List<Exception>();
-            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors);
+            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors, 0);
 
             subject.Success.Should().BeTrue();
             subject.TokenResult.Should().Be(tokenResult);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.Success.Should().BeFalse();
             subject.TokenResult.Should().BeNull();
             subject.Errors.Should().BeEmpty();
+            subject.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -31,11 +32,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var tokenResult = new TokenResult(new JsonWebToken(FakeToken), Guid.NewGuid());
             var errors = new List<Exception>();
-            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors, 0);
+            var interactivePromptsCount = 2;
+            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors, interactivePromptsCount);
 
             subject.Success.Should().BeTrue();
             subject.TokenResult.Should().Be(tokenResult);
             subject.Errors.Should().BeEmpty();
+            subject.InteractivePromptsCount.Should().Be(interactivePromptsCount);
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .BuildServiceProvider();
 
             // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
         public AuthFlow.Broker Subject() => this.serviceProvider.GetService<AuthFlow.Broker>();

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -151,6 +152,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -267,6 +269,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -287,6 +290,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -309,6 +313,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -329,6 +334,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -350,6 +356,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -373,6 +380,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -114,6 +115,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.DeviceCodeFlow);
             authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -131,6 +133,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -170,6 +173,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.DeviceCodeFlow);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -189,6 +193,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -209,6 +214,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .BuildServiceProvider();
 
             // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
         public AuthFlow.DeviceCode Subject() => this.serviceProvider.GetService<AuthFlow.DeviceCode>();

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -112,6 +113,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -129,6 +131,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -149,6 +152,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -168,6 +172,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -208,6 +213,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -227,6 +233,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -245,6 +252,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -263,6 +271,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(0);
         }
 
         [Test]
@@ -284,6 +293,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -304,6 +314,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -326,6 +337,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         [Test]
@@ -346,6 +358,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -367,6 +380,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.InteractivePromptsCount.Should().Be(1);
         }
 
         [Test]
@@ -390,6 +404,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.InteractivePromptsCount.Should().Be(2);
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .BuildServiceProvider();
 
             // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
         public AuthFlow.Web Subject() => this.serviceProvider.GetService<AuthFlow.Web>();

--- a/src/MSALWrapper.Test/ExceptionListToStringConverterTest.cs
+++ b/src/MSALWrapper.Test/ExceptionListToStringConverterTest.cs
@@ -131,5 +131,23 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 "System.Exception: This is the second exception\n" +
                 "System.Exception: This is the third exception");
         }
+
+        [Test]
+        public void SerializeExceptions_Test()
+        {
+            List<Exception> exceptions = new List<Exception>();
+            string result = ExceptionListToStringConverter.SerializeExceptions(exceptions);
+            string expected = "[]";
+            result.Should().Be(expected);
+
+            exceptions.Add(null);
+            result = ExceptionListToStringConverter.SerializeExceptions(exceptions);
+            expected = "[null]";
+            result.Should().Be(expected);
+
+            exceptions.Add(new Exception("Random Exception"));
+            result = ExceptionListToStringConverter.SerializeExceptions(exceptions);
+            result.Should().Contain("\"Message\":\"Random Exception\"");
+        }
     }
 }

--- a/src/MSALWrapper.Test/PCAWrapperTest.cs
+++ b/src/MSALWrapper.Test/PCAWrapperTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
              .BuildServiceProvider();
 
             // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken));
+            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
         [Test]

--- a/src/MSALWrapper.Test/TokenResultTest.cs
+++ b/src/MSALWrapper.Test/TokenResultTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     public class TokenResultTest
     {
         public const string FakeToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsInJoIjoieHh4IiwieDV0IjoieHh4Iiwia2lkIjoieHh4In0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXVkIjoiMTExMTExMTEtMTExMS0xMTExLTExMTEtMTExMTExMTExMTExIiwiaWF0IjoxNjE3NjY0Mjc2LCJuYmYiOjE2MTc2NjQyNzYsImV4cCI6MTYxNzY2ODE3NiwiYWNyIjoiMSIsImFpbyI6IllTQjBiM1JoYkd4NUlHWmhhMlVnYTJWNUlDTWtKVjQ9Iiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwidW5pcXVlX25hbWUiOiJreXJhZGVyQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJreXJhZGVyQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bNc3QlL4zIClzFqH68A4hxsR7K-jabQvzB2EodgujQqc0RND_VLVkk2h3iDy8so3azN-964c2z5AiBGY6PVtWKYB-h0Z_VnzbebhDjzPLspEsANyQxaDX_ugOrf7BerQOtILWT5Vqs-A3745Bh0eTDFZpobmeENpANNhRE-yKwScjU8BDY9RimdrA2Z00V0lSliUQwnovWmtfdlbEpWObSFQAK7wCcNnUesV-jNZAUMrDkmTItPA9Z1Ks3NUbqdqMP3D6n99sy8DxQeFmbNQGYocYqI7QH24oNXODq0XB-2zpvCqy4T2jiBLgN_XEaZ5zTzEOzztpgMIWH1AUvEIyw";
+        public Guid FakeCorrelationID = Guid.NewGuid();
 
         private JsonWebToken jwt;
         private TokenResult subject;
@@ -20,7 +21,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void Setup()
         {
             this.jwt = new JsonWebToken(FakeToken);
-            this.subject = new TokenResult(this.jwt, Guid.NewGuid());
+            this.subject = new TokenResult(this.jwt, this.FakeCorrelationID);
         }
 
         [Test]
@@ -30,6 +31,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.subject.Token.Should().Be(FakeToken);
             this.subject.User.Should().Be("kyrader@microsoft.com");
             this.subject.ValidFor.Should().NotBeCloseTo(new System.TimeSpan(0, 0, 0), new System.TimeSpan(0, 1, 0));
+            this.subject.CorrelationID.Should().Be(this.FakeCorrelationID);
         }
 
         [Test]

--- a/src/MSALWrapper.Test/TokenResultTest.cs
+++ b/src/MSALWrapper.Test/TokenResultTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
+    using System;
     using FluentAssertions;
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.IdentityModel.JsonWebTokens;
@@ -19,7 +20,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void Setup()
         {
             this.jwt = new JsonWebToken(FakeToken);
-            this.subject = new TokenResult(this.jwt);
+            this.subject = new TokenResult(this.jwt, Guid.NewGuid());
         }
 
         [Test]

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
+    using Microsoft.Office.Lasso.Interfaces;
+    using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
     /// The auth flows class.
@@ -17,15 +19,18 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     {
         private readonly IEnumerable<IAuthFlow> authflows;
         private readonly ILogger logger;
+        private readonly ITelemetryService telemetryService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthFlowExecutor"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
+        /// <param name="telemetryService">The telemetry service.</param>
         /// <param name="authFlows">The list of auth flows.</param>
-        public AuthFlowExecutor(ILogger logger, IEnumerable<IAuthFlow> authFlows)
+        public AuthFlowExecutor(ILogger logger, ITelemetryService telemetryService, IEnumerable<IAuthFlow> authFlows)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.telemetryService = telemetryService;
             this.authflows = authFlows ?? throw new ArgumentNullException(nameof(authFlows));
         }
 
@@ -48,9 +53,11 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.logger.LogDebug($"Starting {authFlowName}...");
 
                 var attempt = await authFlow.GetTokenAsync();
+                this.SendTelemetryEvent(attempt, authFlowName);
+
                 if (attempt == null)
                 {
-                    var oopsMessage = $"Auth flow '{authFlow.GetType().Name}' returned a null AuthFlowResult.";
+                    var oopsMessage = $"Auth flow '{authFlowName}' returned a null AuthFlowResult.";
                     result.Errors.Add(new NullTokenResultException(oopsMessage));
                     this.logger.LogDebug(oopsMessage);
                 }
@@ -68,6 +75,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
 
             return result;
+        }
+
+        private void SendTelemetryEvent(AuthFlowResult attempt, string authFlowName)
+        {
+            // will be implemented in the next PR
+            return;
         }
     }
 }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.logger.LogDebug($"Starting {authFlowName}...");
 
                 var attempt = await authFlow.GetTokenAsync();
-                this.SendTelemetryEvent(attempt, authFlowName);
 
                 if (attempt == null)
                 {
@@ -65,6 +64,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 else
                 {
                     result.AddErrors(attempt.Errors);
+                    this.SendTelemetryEvent(attempt, authFlowName);
 
                     this.logger.LogDebug($"{authFlowName} success: {attempt.Success}.");
                     if (attempt.Success)

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
     using Microsoft.Office.Lasso.Interfaces;
     using Microsoft.Office.Lasso.Telemetry;
 
@@ -40,7 +41,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            AuthFlowResult result = new AuthFlowResult(null, new List<Exception>());
+            AuthFlowResult result = new AuthFlowResult(null, new List<Exception>(), 0);
 
             if (this.authflows.Count() == 0)
             {
@@ -79,16 +80,21 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
         private void SendTelemetryEvent(AuthFlowResult attempt, string authFlowName)
         {
-            var eventData = attempt.EventData;
+            var eventData = new EventData();
+            eventData.Add("auth_mode", authFlowName);
             eventData.Add("success", attempt.Success);
             eventData.Add("errors", ExceptionListToStringConverter.SerializeExceptions(attempt.Errors));
+            eventData.Add("no_of_interactive_prompts", attempt.InteractivePromptCount);
+            List<string> correlationIDs = ExceptionsExtensions.ExtractCorrelationIDsFromException(attempt.Errors);
 
             if (attempt.Success)
             {
+                correlationIDs.Add(attempt.TokenResult.CorrelationID.ToString());
                 eventData.Add("token_validity_hours", attempt.TokenResult.ValidFor.Hours);
                 eventData.Add("is_silent", attempt.TokenResult.AuthType == AuthType.Silent);
             }
 
+            eventData.Add("msal_correlation_ids", correlationIDs);
             this.telemetryService.SendEvent($"authflow_{authFlowName}", eventData);
         }
     }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         public AuthFlowExecutor(ILogger logger, ITelemetryService telemetryService, IEnumerable<IAuthFlow> authFlows)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.telemetryService = telemetryService;
+            this.telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(logger));
             this.authflows = authFlows ?? throw new ArgumentNullException(nameof(authFlows));
         }
 

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -79,8 +79,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
         private void SendTelemetryEvent(AuthFlowResult attempt, string authFlowName)
         {
-            // will be implemented in the next PR
-            return;
+            var eventData = attempt.EventData;
+            eventData.Add("success", attempt.Success);
+            eventData.Add("errors", ExceptionListToStringConverter.SerializeExceptions(attempt.Errors));
+
+            if (attempt.Success)
+            {
+                eventData.Add("token_validity_hours", attempt.TokenResult.ValidFor.Hours);
+                eventData.Add("is_silent", attempt.TokenResult.AuthType == AuthType.Silent);
+            }
+
+            this.telemetryService.SendEvent($"authflow_{authFlowName}", eventData);
         }
     }
 }

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             eventData.Add("auth_mode", authFlowName);
             eventData.Add("success", attempt.Success);
             eventData.Add("errors", ExceptionListToStringConverter.SerializeExceptions(attempt.Errors));
-            eventData.Add("no_of_interactive_prompts", attempt.InteractivePromptCount);
+            eventData.Add("no_of_interactive_prompts", attempt.InteractivePromptsCount);
             List<string> correlationIDs = ExceptionsExtensions.ExtractCorrelationIDsFromException(attempt.Errors);
 
             if (attempt.Success)

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -44,11 +44,6 @@ namespace Microsoft.Authentication.MSALWrapper
         public IList<Exception> Errors { get; internal set; }
 
         /// <summary>
-        /// Gets the telemetry event data.
-        /// </summary>
-        public EventData EventData { get; internal set; }
-
-        /// <summary>
         /// Gets the interactive prompt count.
         /// </summary>
         public int InteractivePromptCount { get; internal set; }

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
         /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
-        /// <param name="interactivePromptCount">No. of interactive auth prompts occured while getting (or failing to get) the given token result.</param>
-        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, int interactivePromptCount)
+        /// <param name="interactivePromptsCount">No. of interactive auth prompts occured while getting (or failing to get) the given token result.</param>
+        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, int interactivePromptsCount)
         {
             this.TokenResult = tokenResult;
             this.Errors = errors ?? new List<Exception>();
-            this.InteractivePromptCount = interactivePromptCount;
+            this.InteractivePromptsCount = interactivePromptsCount;
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <summary>
         /// Gets the interactive prompt count.
         /// </summary>
-        public int InteractivePromptCount { get; internal set; }
+        public int InteractivePromptsCount { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether the TokenResult represents a non-null <see cref="MSALWrapper.TokenResult"/>.

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.MSALWrapper
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
     /// The Auth Flow result.
@@ -15,7 +16,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
         /// </summary>
         public AuthFlowResult()
-            : this(null, null)
+        : this(null, null)
         {
         }
 
@@ -31,6 +32,19 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AuthFlowResult"/> class.
+        /// </summary>
+        /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
+        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
+        /// <param name="eventData">An instance of <see cref="EventData"/>.</param>
+        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, EventData eventData)
+        {
+            this.TokenResult = tokenResult;
+            this.Errors = errors ?? new List<Exception>();
+            this.EventData = eventData ?? new EventData();
+        }
+
+        /// <summary>
         /// Gets a token result.
         /// </summary>
         public TokenResult TokenResult { get; internal set; }
@@ -39,6 +53,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Gets a list of errors.
         /// </summary>
         public IList<Exception> Errors { get; internal set; }
+
+        /// <summary>
+        /// Gets the telemetry event data.
+        /// </summary>
+        public EventData EventData { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether the TokenResult represents a non-null <see cref="MSALWrapper.TokenResult"/>.

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
         /// </summary>
         public AuthFlowResult()
-        : this(null, null)
+        : this(null, null, 0)
         {
         }
 
@@ -25,23 +25,12 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
         /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
-        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors)
+        /// <param name="interactivePromptCount">No. of interactive auth prompts occured while getting (or failing to get) the given token result.</param>
+        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, int interactivePromptCount)
         {
             this.TokenResult = tokenResult;
             this.Errors = errors ?? new List<Exception>();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthFlowResult"/> class.
-        /// </summary>
-        /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
-        /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
-        /// <param name="eventData">An instance of <see cref="EventData"/>.</param>
-        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, EventData eventData)
-        {
-            this.TokenResult = tokenResult;
-            this.Errors = errors ?? new List<Exception>();
-            this.EventData = eventData ?? new EventData();
+            this.InteractivePromptCount = interactivePromptCount;
         }
 
         /// <summary>
@@ -58,6 +47,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Gets the telemetry event data.
         /// </summary>
         public EventData EventData { get; internal set; }
+
+        /// <summary>
+        /// Gets the interactive prompt count.
+        /// </summary>
+        public int InteractivePromptCount { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether the TokenResult represents a non-null <see cref="MSALWrapper.TokenResult"/>.

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IList<Exception> errors;
-        private readonly EventData eventData;
-        private readonly IList<string> correlationIDs;
         private IPCAWrapper pcaWrapper;
         private int interactivePromptsCount;
 
@@ -60,8 +58,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
-            this.eventData = new EventData();
-            this.correlationIDs = new List<string>();
         }
 
         /// <summary>
@@ -70,7 +66,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            this.eventData.Add("auth_mode", "Broker");
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain)
                 ?? Identity.Client.PublicClientApplication.OperatingSystemAccount;
             this.logger.LogDebug($"Using cached account '{account.Username}'");
@@ -89,14 +84,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             this.errors)
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Silent);
-                        this.correlationIDs.Add(tokenResult.CorrelationID.ToString());
-                        this.PopulateEventData();
-                        return new AuthFlowResult(tokenResult, this.errors, this.eventData);
+
+                        return new AuthFlowResult(tokenResult, this.errors, this.interactivePromptsCount);
                     }
                     catch (MsalUiRequiredException ex)
                     {
                         this.errors.Add(ex);
-                        this.correlationIDs.Add(ex.CorrelationId?.ToString());
                         this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
                         this.interactivePromptsCount += 1;
                         var tokenResult = await TaskExecutor.CompleteWithin(
@@ -108,16 +101,14 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .GetTokenInteractiveAsync(this.scopes, account, cancellationToken),
                             this.errors)
                             .ConfigureAwait(false);
-                        tokenResult.SetAuthenticationType(AuthType.Interactive); // confirm this.
-                        this.PopulateEventData();
+                        tokenResult.SetAuthenticationType(AuthType.Interactive);
 
-                        return new AuthFlowResult(tokenResult, this.errors, this.eventData);
+                        return new AuthFlowResult(tokenResult, this.errors, this.interactivePromptsCount);
                     }
                 }
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
-                    this.correlationIDs.Add(ex.CorrelationId?.ToString());
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
                     this.interactivePromptsCount += 1;
                     var tokenResult = await TaskExecutor.CompleteWithin(
@@ -130,37 +121,27 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Interactive);
-                    this.PopulateEventData();
 
-                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
+                    return new AuthFlowResult(tokenResult, this.errors, this.interactivePromptsCount);
                 }
             }
             catch (MsalServiceException ex)
             {
                 this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
-                this.PopulateEventData();
             }
             catch (MsalClientException ex)
             {
                 this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
-                this.PopulateEventData();
             }
             catch (NullReferenceException ex)
             {
                 this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
                 this.errors.Add(ex);
-                this.PopulateEventData();
             }
 
-            return new AuthFlowResult(null, this.errors, this.eventData);
-        }
-
-        private void PopulateEventData()
-        {
-            this.eventData.Add("msal_correlation_ids", this.correlationIDs);
-            this.eventData.Measures.Add("no_of_interactive_prompts", this.interactivePromptsCount);
+            return new AuthFlowResult(null, this.errors, this.interactivePromptsCount);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IList<Exception> errors;
-        private readonly EventData eventData;
-        private readonly IList<string> correlationIDs;
         private IPCAWrapper pcaWrapper;
         private int interactivePromptsCount;
 
@@ -62,8 +60,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
-            this.eventData = new EventData();
-            this.correlationIDs = new List<string>();
         }
 
         /// <summary>
@@ -72,7 +68,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            this.eventData.Add("auth_mode", "DeviceCode");
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
 
             if (account != null)
@@ -95,14 +90,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Silent);
-                    this.correlationIDs.Add(tokenResult.CorrelationID.ToString());
-                    this.PopulateEventData();
-                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
+
+                    return new AuthFlowResult(tokenResult, this.errors, this.interactivePromptsCount);
                 }
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
-                    this.correlationIDs.Add(ex.CorrelationId?.ToString());
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
                     this.interactivePromptsCount += 1;
                     var tokenResult = await TaskExecutor.CompleteWithin(
@@ -116,18 +109,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.DeviceCodeFlow);
-                    this.PopulateEventData();
-                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
+
+                    return new AuthFlowResult(tokenResult, this.errors, this.interactivePromptsCount);
                 }
             }
             catch (MsalException ex)
             {
                 this.errors.Add(ex);
                 this.logger.LogError(ex.Message);
-                this.PopulateEventData();
             }
 
-            return new AuthFlowResult(null, this.errors, this.eventData);
+            return new AuthFlowResult(null, this.errors, this.interactivePromptsCount);
         }
 
         private static HttpClient CreateHttpClient()
@@ -143,12 +135,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             };
 
             return client;
-        }
-
-        private void PopulateEventData()
-        {
-            this.eventData.Add("msal_correlation_ids", this.correlationIDs);
-            this.eventData.Measures.Add("no_of_interactive_prompts", this.interactivePromptsCount);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
+    using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
     /// The device code auth flow.
@@ -24,7 +25,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IList<Exception> errors;
+        private readonly EventData eventData;
+        private readonly IList<string> correlationIDs;
         private IPCAWrapper pcaWrapper;
+        private int interactivePromptsCount;
 
         #region Public configurable properties
 
@@ -58,6 +62,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
+            this.eventData = new EventData();
+            this.correlationIDs = new List<string>();
         }
 
         /// <summary>
@@ -66,6 +72,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
+            this.eventData.Add("auth_mode", "DeviceCode");
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
 
             if (account != null)
@@ -88,13 +95,16 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Silent);
-
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    this.correlationIDs.Add(tokenResult.CorrelationID.ToString());
+                    this.PopulateEventData();
+                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
                 }
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
+                    this.correlationIDs.Add(ex.CorrelationId?.ToString());
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                    this.interactivePromptsCount += 1;
                     var tokenResult = await TaskExecutor.CompleteWithin(
                         this.logger,
                         this.deviceCodeFlowTimeout,
@@ -106,17 +116,18 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.DeviceCodeFlow);
-
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    this.PopulateEventData();
+                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
                 }
             }
             catch (MsalException ex)
             {
                 this.errors.Add(ex);
                 this.logger.LogError(ex.Message);
+                this.PopulateEventData();
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.eventData);
         }
 
         private static HttpClient CreateHttpClient()
@@ -132,6 +143,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             };
 
             return client;
+        }
+
+        private void PopulateEventData()
+        {
+            this.eventData.Add("msal_correlation_ids", this.correlationIDs);
+            this.eventData.Measures.Add("no_of_interactive_prompts", this.interactivePromptsCount);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
+    using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
     /// The web auth flow.
@@ -24,7 +25,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IList<Exception> errors;
+        private readonly EventData eventData;
+        private readonly IList<string> correlationIDs;
         private IPCAWrapper pcaWrapper;
+        private int interactivePromptsCount;
 
         #region Public configurable properties
 
@@ -58,6 +62,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId, osxKeyChainSuffix);
+            this.eventData = new EventData();
+            this.correlationIDs = new List<string>();
         }
 
         /// <summary>
@@ -66,6 +72,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
+            this.eventData.Add("auth_mode", "Web");
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
 
             if (account != null)
@@ -87,13 +94,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             this.errors)
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Silent);
+                        this.correlationIDs.Add(tokenResult.CorrelationID.ToString());
+                        this.PopulateEventData();
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.eventData);
                     }
                     catch (MsalUiRequiredException ex)
                     {
                         this.errors.Add(ex);
+                        this.correlationIDs.Add(ex.CorrelationId?.ToString());
                         this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                        this.interactivePromptsCount += 1;
                         var tokenResult = await TaskExecutor.CompleteWithin(
                             this.logger,
                             this.interactiveAuthTimeout,
@@ -104,14 +115,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             this.errors)
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Interactive);
+                        this.PopulateEventData();
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.eventData);
                     }
                 }
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
+                    this.correlationIDs.Add(ex.CorrelationId?.ToString());
                     this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
+                    this.interactivePromptsCount += 1;
                     var tokenResult = await TaskExecutor.CompleteWithin(
                         this.logger,
                         this.interactiveAuthTimeout,
@@ -122,27 +136,37 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Interactive);
+                    this.PopulateEventData();
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.eventData);
                 }
             }
             catch (MsalServiceException ex)
             {
                 this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
+                this.PopulateEventData();
             }
             catch (MsalClientException ex)
             {
                 this.logger.LogWarning($"MSAL Client Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
+                this.PopulateEventData();
             }
             catch (NullReferenceException ex)
             {
                 this.logger.LogWarning($"MSAL unexpected null reference! (Not Expected)\n{ex.Message}");
                 this.errors.Add(ex);
+                this.PopulateEventData();
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.eventData);
+        }
+
+        private void PopulateEventData()
+        {
+            this.eventData.Add("msal_correlation_ids", this.correlationIDs);
+            this.eventData.Measures.Add("no_of_interactive_prompts", this.interactivePromptsCount);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/ExceptionExtensions.cs
+++ b/src/MSALWrapper/ExceptionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Identity.Client;
 
 /// <summary>
 /// Exceptions extensions.
@@ -65,5 +66,30 @@ public static class ExceptionsExtensions
                 yield return innerEx;
             }
         }
+    }
+
+    /// <summary>
+    /// Extracts correlation IDs from the list of exceptions.
+    /// </summary>
+    /// <param name="exceptions">List of exceptions from which correlation IDs are extracted.</param>
+    /// <returns>List of correlation IDs.</returns>
+    public static List<string> ExtractCorrelationIDsFromException(IList<Exception> exceptions)
+    {
+        var correlationIDs = new List<string>();
+        foreach (Exception exception in exceptions)
+        {
+            if (exception.GetType() == typeof(MsalServiceException))
+            {
+                var msalServiceException = (MsalServiceException)exception;
+                correlationIDs.Add(msalServiceException.CorrelationId?.ToString());
+            }
+            else if (exception.GetType() == typeof(MsalUiRequiredException))
+            {
+                var msalUiRequiredException = (MsalUiRequiredException)exception;
+                correlationIDs.Add(msalUiRequiredException.CorrelationId?.ToString());
+            }
+        }
+
+        return correlationIDs;
     }
 }

--- a/src/MSALWrapper/ExceptionListToStringConverter.cs
+++ b/src/MSALWrapper/ExceptionListToStringConverter.cs
@@ -28,6 +28,16 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
+        /// A method to serialize the exceptions to a JSON string.
+        /// </summary>
+        /// <param name="exceptions">The exceptions to be serialized.</param>
+        /// <returns>Returns a JSON string.</returns>
+        public static string SerializeExceptions(IList<Exception> exceptions)
+        {
+            return System.Text.Json.JsonSerializer.Serialize(exceptions);
+        }
+
+        /// <summary>
         /// Converts exceptions to a single string.
         /// </summary>
         /// <param name="ex">The exceptions.</param>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -30,6 +30,7 @@
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2022.1.6.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 return null;
             }
 
-            return new TokenResult(new JsonWebToken(result.AccessToken));
+            return new TokenResult(new JsonWebToken(result.AccessToken), result.CorrelationId);
         }
     }
 }

--- a/src/MSALWrapper/TokenResult.cs
+++ b/src/MSALWrapper/TokenResult.cs
@@ -45,9 +45,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Initializes a new instance of the <see cref="TokenResult"/> class.
         /// </summary>
         /// <param name="jwt">The jwt.</param>
-        public TokenResult(JsonWebToken jwt)
+        /// <param name="correlationID">The correlation ID.</param>
+        public TokenResult(JsonWebToken jwt, Guid correlationID)
         {
             this.JWT = jwt;
+            this.CorrelationID = correlationID;
         }
 
         /// <summary>
@@ -90,6 +92,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Gets the auth type.
         /// </summary>
         public AuthType AuthType { get; internal set; }
+
+        /// <summary>
+        /// Gets the correlation ID.
+        /// </summary>
+        public Guid CorrelationID { get; internal set; }
 
         /// <summary>
         /// To string that shows successful authentication for user.


### PR DESCRIPTION
This is the first PR for the feature - Improving the AzureAuth telemetry instrumentation.

The final agenda is to make the following schema changes:

<img width="907" alt="Drawing" src="https://user-images.githubusercontent.com/99682944/173475278-b35e30f4-dde3-43f5-ae54-ec50325c3e6f.png">

Changes in this PR:
1. Added Lasso to MSALWrapper as we need `ITelemetryService` and `EventData` classes to send custom events of Auth Flows.
2. Changed `CommandMain` and `AuthFlowExecutor` classes to make use of `ITelemetryService`.
3. Populate and send `EventData` from `AuthFlowExecutor` class.

TODO:
1. Unit Tests (adding new and updating some old ones)
2. Add new attributes mentioned in the above schema to the main event `azureauth_command_azureauth`. I will create a new PR for this.
3. Fix Authentication type logic - (Currently, we capture authentication types as silent/interactive/devicecodeflow. These are not enough/accurate to capture whether a given authentication session was silent or not as the type - devicecodeflow can indicate a silent or interactive auth prompt. So there is a need for a flag to be added to the schema which indicates whether the authentication was silent or not.). I will create a new PR for this.