### PR TITLE
Add AuthFlowName to the AuthFlowResult

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task SingleAuthFlow_Returns_TokenResult()
         {
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
-            var authFlowResult = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, null, null);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
             // Act
@@ -136,7 +136,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult = new AuthFlowResult(null, errors1);
+            var authFlowResult = new AuthFlowResult(null, errors1, null);
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
         {
             var authFlowResult1 = new AuthFlowResult();
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -205,8 +205,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -268,7 +268,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(null, errors2);
+            var authFlowResult = new AuthFlowResult(null, errors2, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -303,7 +303,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -329,7 +329,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var authFlowResult1 = new AuthFlowResult();
             var authFlowResult2 = new AuthFlowResult();
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -372,9 +372,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 4."),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(null, errors2);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, null);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -451,8 +451,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(null, errors2);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -495,8 +495,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult3 = new AuthFlowResult(null, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult3 = new AuthFlowResult(null, errors3, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -540,8 +540,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 3"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -585,8 +585,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2, null);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task SingleAuthFlow_Returns_TokenResult()
         {
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
-            var authFlowResult = new AuthFlowResult(this.tokenResult, null, null);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, null, string.Empty);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
             // Act
@@ -136,7 +136,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult = new AuthFlowResult(null, errors1, null);
+            var authFlowResult = new AuthFlowResult(null, errors1, string.Empty);
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task HasTwoAuthFlows_Returns_Null_TokenResult()
         {
             var authFlowResult1 = new AuthFlowResult();
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, null);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -205,8 +205,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             {
                 new Exception("Exception 1."),
             };
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, null, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -268,7 +268,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(null, errors2, null);
+            var authFlowResult = new AuthFlowResult(null, errors2, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -303,7 +303,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2, null);
+            var authFlowResult = new AuthFlowResult(this.tokenResult, errors2, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync((AuthFlowResult)null);
@@ -329,7 +329,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var authFlowResult1 = new AuthFlowResult();
             var authFlowResult2 = new AuthFlowResult();
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null, null);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, null, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -372,9 +372,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 4."),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult2 = new AuthFlowResult(null, errors2, null);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, string.Empty);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -451,8 +451,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new NullTokenResultException(NullAuthFlowResultExceptionMessage),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult2 = new AuthFlowResult(null, errors2, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult2 = new AuthFlowResult(null, errors2, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -495,8 +495,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 2"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult3 = new AuthFlowResult(null, errors3, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult3 = new AuthFlowResult(null, errors3, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -540,8 +540,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("Exception 3"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult3 = new AuthFlowResult(this.tokenResult, errors3, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);
@@ -585,8 +585,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 new Exception("This is a catastrophic failure. AuthFlow result is null!"),
             };
 
-            var authFlowResult1 = new AuthFlowResult(null, errors1, null);
-            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2, null);
+            var authFlowResult1 = new AuthFlowResult(null, errors1, string.Empty);
+            var authFlowResult2 = new AuthFlowResult(this.tokenResult, errors2, string.Empty);
 
             var authFlow1 = new Mock<IAuthFlow>(MockBehavior.Strict);
             authFlow1.Setup(p => p.GetTokenAsync()).ReturnsAsync(authFlowResult1);

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -24,6 +24,17 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.Success.Should().BeFalse();
             subject.TokenResult.Should().BeNull();
             subject.Errors.Should().BeEmpty();
+            subject.AuthFlowName.Should().BeEmpty();
+        }
+
+        [Test]
+        public void ConstructorWithNullAuthFlowName_ThrowsNullArgumentException()
+        {
+            var tokenResult = new TokenResult(new JsonWebToken(FakeToken));
+            var errors = new List<Exception>();
+            Action authFLowResult = () => new AuthFlowResult(tokenResult, errors, null);
+
+            authFLowResult.Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             var tokenResult = new TokenResult(new JsonWebToken(FakeToken));
             var errors = new List<Exception>();
-            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors);
+            var authFlowName = "AuthFlowName";
+            AuthFlowResult subject = new AuthFlowResult(tokenResult, errors, authFlowName);
 
             subject.Success.Should().BeTrue();
             subject.TokenResult.Should().Be(tokenResult);

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -112,6 +113,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -132,6 +134,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -151,6 +154,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -191,6 +195,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -210,6 +215,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -228,6 +234,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -246,6 +253,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -267,6 +275,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -287,6 +296,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -309,6 +319,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -329,6 +340,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -350,6 +362,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]
@@ -373,6 +386,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -114,6 +115,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.DeviceCodeFlow);
             authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -131,6 +133,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -150,6 +153,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -170,6 +174,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.DeviceCodeFlow);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -189,6 +194,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         [Test]
@@ -209,6 +215,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalException));
+            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -110,6 +111,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -128,6 +130,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -166,6 +169,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -185,6 +189,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 0.1 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -203,6 +208,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -221,6 +227,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -239,6 +246,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.IntegratedWindowsAuthenticationFlow);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -256,6 +264,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -274,6 +283,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[0].Message.Should().Be("AADSTS50076 MSAL UI Required Exception!");
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -292,6 +302,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[0].Message.Should().Be("MSAL UI Required Exception!");
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -311,6 +322,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
@@ -329,6 +341,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Silent);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -112,6 +113,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -129,6 +131,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -149,6 +152,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -168,6 +172,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -208,6 +213,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -227,6 +233,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -245,6 +252,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -263,6 +271,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -284,6 +293,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.AuthType.Should().Be(AuthType.Interactive);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -304,6 +314,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -326,6 +337,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -346,6 +358,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -367,6 +380,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         [Test]
@@ -390,6 +404,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            AuthFlowResult result = new AuthFlowResult(null, new List<Exception>());
+            AuthFlowResult result = new AuthFlowResult(null, new List<Exception>(), string.Empty);
 
             if (this.authflows.Count() == 0)
             {

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
         /// </summary>
         public AuthFlowResult()
-            : this(null, null, null)
+            : this(null, null, string.Empty)
         {
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.Authentication.MSALWrapper
         {
             this.TokenResult = tokenResult;
             this.Errors = errors ?? new List<Exception>();
-            this.AuthFlowName = authFlowName;
+            this.AuthFlowName = authFlowName ?? throw new ArgumentNullException(nameof(authFlowName));
         }
 
         /// <summary>

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
         /// </summary>
         public AuthFlowResult()
-            : this(null, null)
+            : this(null, null, null)
         {
         }
 
@@ -24,10 +24,12 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
         /// <param name="errors">A list of errors encountered while getting (or failing to get) the given token result. Will initialize a new empty List if null is given.</param>
-        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors)
+        /// <param name="authFlowName">The name of the authflow from which the AuthFlowResult is returned or cretaed.</param>
+        public AuthFlowResult(TokenResult tokenResult, IList<Exception> errors, string authFlowName)
         {
             this.TokenResult = tokenResult;
             this.Errors = errors ?? new List<Exception>();
+            this.AuthFlowName = authFlowName;
         }
 
         /// <summary>
@@ -39,6 +41,11 @@ namespace Microsoft.Authentication.MSALWrapper
         /// Gets a list of errors.
         /// </summary>
         public IList<Exception> Errors { get; internal set; }
+
+        /// <summary>
+        /// Gets the AuthFlowName.
+        /// </summary>
+        public string AuthFlowName { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether the TokenResult represents a non-null <see cref="MSALWrapper.TokenResult"/>.

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Silent);
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                     }
                     catch (MsalUiRequiredException ex)
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Interactive);
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                     }
                 }
                 catch (MsalUiRequiredException ex)
@@ -118,7 +118,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Interactive);
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                 }
             }
             catch (MsalServiceException ex)
@@ -137,7 +137,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.GetType().Name);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Silent);
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                 }
                 catch (MsalUiRequiredException ex)
                 {
@@ -107,7 +107,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.DeviceCodeFlow);
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                 }
             }
             catch (MsalException ex)
@@ -116,7 +116,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.logger.LogError(ex.Message);
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.GetType().Name);
         }
 
         private static HttpClient CreateHttpClient()

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Silent);
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                     }
                     catch (MsalUiRequiredException ex)
                     {
@@ -107,7 +107,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                                     .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.IntegratedWindowsAuthenticationFlow);
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                 }
                 catch (MsalUiRequiredException ex) when (
                              ex.Classification == UiRequiredExceptionClassification.BasicAction
@@ -134,7 +134,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 }
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.GetType().Name);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Silent);
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                     }
                     catch (MsalUiRequiredException ex)
                     {
@@ -105,7 +105,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetAuthenticationType(AuthType.Interactive);
 
-                        return new AuthFlowResult(tokenResult, this.errors);
+                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                     }
                 }
                 catch (MsalUiRequiredException ex)
@@ -123,7 +123,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         .ConfigureAwait(false);
                     tokenResult.SetAuthenticationType(AuthType.Interactive);
 
-                    return new AuthFlowResult(tokenResult, this.errors);
+                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
                 }
             }
             catch (MsalServiceException ex)
@@ -142,7 +142,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return new AuthFlowResult(null, this.errors);
+            return new AuthFlowResult(null, this.errors, this.GetType().Name);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix)


### PR DESCRIPTION
This is related to making telemetry schema changes described in this PR #106 

Based on the comments on PR #106 , this new PR is created.

Changes:
1. Add `AuthFlowName` to the `AuthFlowResult` Class.

In the next PRs following changes will be made:
1. Currently, we send one final result from `AuthFlowExecutor` after each `AuthFlow` is attempted until succeeded. This will be changed to return all `AuthFlowResult`s for each `AuthFlow` attempted instead of just one. This is done so that these results can be leveraged in the `AzureAuth` CLI and send telemetry from there. With this approach, `MSALWrapper` will not have any dependency on `Lasso`.
2. Make changes to send telemetry events from the `AuthFlowResult` s returned to the CLI.