### PR TITLE
Adding IWA to AuthModeHelperText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Implemented Integrated Windows Authentication as one of the auth flows.
+
+## [Unreleased]
+### Added
 - Environment variable `AZUREAUTH_CACHE_FILE` and option `--cache` to support a custom cache location on Windows.
 
 ## [0.3.1] - 2022-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Implemented Integrated Windows Authentication as one of the auth flows.
+- Added Integrated Windows Authentication functionality as one of the auth flows.
 
 ## [Unreleased]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added Integrated Windows Authentication functionality as one of the auth flows.
-
-## [Unreleased]
-### Added
 - Environment variable `AZUREAUTH_CACHE_FILE` and option `--cache` to support a custom cache location on Windows.
+- Added Integrated Windows Authentication functionality as one of the auth flows.
 
 ## [0.3.1] - 2022-06-07
 ### Fixed

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Authentication.AzureAuth
         private const string PromptHintPrefix = "AzureAuth";
 
 #if PlatformWindows
-        private const string AuthModeHelperText = @"Authentication mode. Default: broker, with web fallback.
+        private const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker and web fallback.
 You can use any combination of modes with multiple instances of the --mode flag.
-Allowed values: [all, broker, web, devicecode]";
+Allowed values: [all, iwa, broker, web, devicecode]";
 #else
         private const string AuthModeHelperText = @"Authentication mode. Default: web.
 You can use any combination with multiple instances of the --mode flag.

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Authentication.AzureAuth
 
 #if PlatformWindows
         private const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
-
 You can use any combination of modes with multiple instances of the --mode flag.
 Allowed values: [all, iwa, broker, web, devicecode]";
 #else

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Authentication.AzureAuth
         private const string PromptHintPrefix = "AzureAuth";
 
 #if PlatformWindows
-        private const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker and web fallback.
+        private const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
+
 You can use any combination of modes with multiple instances of the --mode flag.
 Allowed values: [all, iwa, broker, web, devicecode]";
 #else


### PR DESCRIPTION
This is the final PR for IWA:

1. Added IWA to AuthModeHelperText.
2. Tested IWA with `--mode=iwa` locally and validated IWA being the only auth flow to queue up.
3. Updated the change log file.

Please refer to PR https://github.com/AzureAD/microsoft-authentication-cli/pull/101 to see how I added IWA as one of the Auth modes. There are no other changes needed on the CLI side or tests.