### PR TITLE
Updating install scripts to no longer create latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,9 @@ jobs:
     - name: Install Zip
       run: sudo apt install -y zip
     - name: Create win10-x64 archive
-      run: zip -r azureauth-${{ github.event.inputs.version }}-win10-x64.zip azureauth-${{ github.event.inputs.version }}-win10-x64
+      run: |
+        cd azureauth-${{ github.event.inputs.version }}-win10-x64
+        zip ../azureauth-${{ github.event.inputs.version }}-win10-x64.zip *
     - name: Upload win10-x64 artifact
       uses: actions/upload-artifact@v3
       with:

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -151,7 +151,10 @@ function Install-Post-0-4-0 {
     Write-Verbose "Removing ${zipFile}"
     Remove-Item -Force $zipFile
 
-    if (!$NoUpdatePath) {
+    if ($NoUpdatePath) {
+        Write-Verbose "Not updating `$env:PATH"
+    }
+    else{
         $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
         $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
         $currentAzureauth = (get-command azureauth -ErrorAction SilentlyContinue).Source

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -153,17 +153,17 @@ function Install-Post-0-4-0 {
     if(!$NoUpdatePath) {
         $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
         $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
-        $azureauthSource = (get-command azureauth -ErrorAction SilentlyContinue).Source
-        $azureauthSourceParent = if($azureauthSource -ne $null) {
-            (get-item $azureauthSource).Directory.Parent.FullName }
+        $currentAzureauth = (get-command azureauth -ErrorAction SilentlyContinue).Source
+        $currentAzureauthParent = if($currentAzureauth -ne $null) {
+            (get-item $currentAzureauth).Directory.Parent.FullName }
         
         $newPath = "";
 
-        if (($currentPath -ne $null) -And ($currentPath.Contains($azureauthDirectory) -Or $currentPath.Contains($azureauthSourceParent))) {
+        if (($currentPath -ne $null) -And ($currentPath.Contains($azureauthDirectory) -Or $currentPath.Contains($currentAzureauthParent))) {
             $paths = $currentPath.Split(";")
             $pathArr = @()
             ForEach($path in $paths){
-                if(!(($path.Equals("")) -Or ($path.Contains($azureauthDirectory)) -Or (($azureauthSourceParent -ne $null) -And $azureauthSourceParent.Contains($path)))){
+                if(!(($path.Equals("")) -Or ($path.Contains($azureauthDirectory)) -Or (($currentAzureauthParent -ne $null) -And $currentAzureauthParent.Contains($path)))){
                     $pathArr += "${path}"
                 }
             }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -113,7 +113,7 @@ function Install-Post-0-4-0 {
     } else {
         $Env:AZUREAUTH_INSTALL_DIRECTORY
     }
-    $extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
+    
     $targetDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $version))
     $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
 
@@ -146,9 +146,7 @@ function Install-Post-0-4-0 {
 
     Write-Verbose "Extracting ${zipFile} to ${targetDirectory}"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
-
-    Rename-Item $extractedDirectory $targetDirectory
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $targetDirectory)
 
     Write-Verbose "Removing ${zipFile}"
     Remove-Item -Force $zipFile

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -86,13 +86,13 @@ function Install-Pre-0-4-0 {
     $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
     $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
     if ($currentPath -NotMatch 'AzureAuth') {
-        Write-Verbose "Updating `$PATH to include ${latestDirectory}"
+        Write-Verbose "Updating `$env:PATH to include ${latestDirectory}"
         $newPath = if ($null -eq $currentPath) {
             "${latestDirectory}"
         } else {
             "${currentPath};${latestDirectory}"
         }
-        Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+        setx PATH $newPath > $null
     }
 
     Write-Output "Installed azureauth $version!"
@@ -185,12 +185,13 @@ function Install-Post-0-4-0 {
             }
         }
 
-        Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath 
+        setx PATH $newPath > $null
     }
 
     Write-Output "Installed azureauth $version!"
 
 }
+
 switch ($version) {
      { $_ -in "v0.1.0","v0.2.0","v0.3.0","0.3.1" } {
         Install-Pre-0-4-0

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -164,8 +164,8 @@ function Install-Post-0-4-0 {
             $pathArr = @()
             ForEach($path in $paths){
                 if(!(($path.Equals("")) `
-                    -Or ($path.Contains($azureauthDirectory)) ` 
-                    -Or (($null -ne $currentAzureauthParent) ` 
+                    -Or ($path.Contains($azureauthDirectory)) `
+                    -Or (($null -ne $currentAzureauthParent) `
                             -And $currentAzureauthParent.Contains($path)))){
                     $pathArr += "${path}"
                 }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -90,6 +90,9 @@ function Install-Pre-0-4-0 {
         } else {
             "${currentPath};${latestDirectory}"
         }
+        # Update the $PATH environment variable with any modifications made above. We use `setx` here instead of
+        # directly writing back the registry value because `setx` signals new processes to pick up on the environment
+        # variable changes.
         setx PATH $newPath > $null
     }
     
@@ -191,7 +194,9 @@ function Install-Post-0-4-0 {
                 $newPath = "${currentPath};${targetDirectory}"
             }
         }
-        # Update the $PATH environment variable with any modifications made above.
+        # Update the $PATH environment variable with any modifications made above. We use `setx` here instead of
+        # directly writing back the registry value because `setx` signals new processes to pick up on the environment
+        # variable changes.
         setx PATH $newPath > $null
     }
     Write-Output "Installed azureauth $version!"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -113,7 +113,7 @@ function Install-Post-0-4-0 {
     } else {
         $Env:AZUREAUTH_INSTALL_DIRECTORY
     }
-    
+
     $targetDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $version))
     $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
 
@@ -168,14 +168,14 @@ function Install-Post-0-4-0 {
                     $pathArr += "${path}"
                 }
                 else {
-                    Write-Verbose "Removing ${path} from `$env:PATH"
+                    Write-Verbose "Removing '${path}' from `$env:PATH"
                 }
             }
             $pathArr += "${targetDirectory}"
             $newPath = $pathArr -join ";"
         }
         else {
-            Write-Verbose "Appending ${targetDirectory} to `$env:PATH"
+            Write-Verbose "Appending '${targetDirectory}' to `$env:PATH"
             if ($null -eq $currentPath) {
                 $newPath = "${targetDirectory}"
             } else {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -7,14 +7,12 @@ $script:ErrorActionPreference='Stop'
 
 # We don't currently have good cross-platform options for determining the latest release version, so we require
 # knowledge of the specific target version, which the user should set as an environment variable.
-
 $version = $Env:AZUREAUTH_VERSION
 if ([string]::IsNullOrEmpty($version)) {
     Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release'
 }
 
 function Install-Pre-0-4-0 {
-
     Write-Verbose "Installing using pre-0.4.0 method"
     $repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
     $releaseName = "azureauth-${version}-win10-x64"
@@ -94,20 +92,17 @@ function Install-Pre-0-4-0 {
         }
         setx PATH $newPath > $null
     }
-
+    
     Write-Output "Installed azureauth $version!"
-
 }
 
 function Install-Post-0-4-0 {
-
     Write-Verbose "Installing using post-0.4.0 method"
 
     $repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
     $releaseName = "azureauth-${version}-win10-x64"
     $releaseFile = "${releaseName}.zip"
     $releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
-
     $azureauthDirectory = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_INSTALL_DIRECTORY)) {
         ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "Programs", "AzureAuth"))
     } else {
@@ -119,7 +114,6 @@ function Install-Post-0-4-0 {
 
     Write-Verbose "Creating ${azureauthDirectory}"
     $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
-
 
     Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
     $client = New-Object System.Net.WebClient
@@ -159,15 +153,20 @@ function Install-Post-0-4-0 {
         $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
         $currentAzureauth = (get-command azureauth -ErrorAction SilentlyContinue).Source
         $currentAzureauthParent = if($null -ne $currentAzureauth) {
-            (get-item $currentAzureauth).Directory.Parent.FullName }
-        
+            (get-item $currentAzureauth).Directory.Parent.FullName }        
         $newPath = "";
 
-        if (($null -ne $currentPath) -And ($currentPath.Contains($azureauthDirectory) -Or $currentPath.Contains($currentAzureauthParent))) {
+        if (($null -ne $currentPath) `
+            -And ($currentPath.Contains($azureauthDirectory) `
+                    -Or (($null -ne $currentAzureauthParent) `
+                            -And ($currentPath.Contains($currentAzureauthParent))))) {
             $paths = $currentPath.Split(";")
             $pathArr = @()
             ForEach($path in $paths){
-                if(!(($path.Equals("")) -Or ($path.Contains($azureauthDirectory)) -Or (($null -ne $currentAzureauthParent) -And $currentAzureauthParent.Contains($path)))){
+                if(!(($path.Equals("")) `
+                    -Or ($path.Contains($azureauthDirectory)) ` 
+                    -Or (($null -ne $currentAzureauthParent) ` 
+                            -And $currentAzureauthParent.Contains($path)))){
                     $pathArr += "${path}"
                 }
                 else {
@@ -185,12 +184,9 @@ function Install-Post-0-4-0 {
                 $newPath = "${currentPath};${targetDirectory}"
             }
         }
-
         setx PATH $newPath > $null
     }
-
     Write-Output "Installed azureauth $version!"
-
 }
 
 switch ($version) {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -8,87 +8,196 @@ $script:ErrorActionPreference='Stop'
 # We don't currently have good cross-platform options for determining the latest release version, so we require
 # knowledge of the specific target version, which the user should set as an environment variable.
 $version = $Env:AZUREAUTH_VERSION
+#$version = "0.3.1"
 if ([string]::IsNullOrEmpty($version)) {
     Write-Error 'No $AZUREAUTH_VERSION specified, unable to download a release'
 }
 
-$repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
-$releaseName = "azureauth-${version}-win10-x64"
-$releaseFile = "${releaseName}.zip"
-$releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
 
-$azureauthDirectory = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_INSTALL_DIRECTORY)) {
-    ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "Programs", "AzureAuth"))
-} else {
-    $Env:AZUREAUTH_INSTALL_DIRECTORY
-}
-$extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
-$latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))
-$zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
 
-Write-Verbose "Creating ${azureauthDirectory}"
-$null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
+function V1-Install-With-Latest{
+    param()
 
-Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
-$client = New-Object System.Net.WebClient
-$client.DownloadFile($releaseUrl, $zipFile)
+    Write-Output "Using the Install with latest version"
 
-# A running instance of azureauth can cause installation to fail, so we try to kill any running instances first.
-# We suppress taskkill output here because this is a best effort attempt and we don't want the user to see its output.
-# Here, Get-Process is used to first determine whether there is an existing azureauth process. If there is, kill the existing process first.
-$ProcessCheck = Get-Process -Name azureauth -ErrorAction SilentlyContinue -ErrorVariable ProcessError
-if ($ProcessCheck -ne $null)
-{
-    Write-Verbose "Stopping any currently running azureauth instances"
-    taskkill /f /im azureauth.exe 2>&1 | Out-Null
+    $repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
+    $releaseName = "azureauth-${version}-win10-x64"
+    $releaseFile = "${releaseName}.zip"
+    $releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
 
-    # After killing the process it is still possible for there there to be locks on the files it was using (including
-    # its own DLLs). The OS may take an indeterminate amount of time to clean those up, but so far we've observed 1
-    # second to be enough.
-    Start-Sleep -Seconds 1
-}
-
-if (Test-Path -Path $extractedDirectory) {
-    Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"
-    Remove-Item -Force -Recurse $extractedDirectory
-}
-
-Write-Verbose "Extracting ${zipFile} to ${extractedDirectory}"
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-[System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
-
-if (Test-Path -Path $latestDirectory) {
-    Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
-    
-    # We use IO.Directory::Delete instead of Remove-Item because on Windows Server 2012 with PowerShell 4.0 the latter will not work.
-    [IO.Directory]::Delete($latestDirectory)
-}
-
-# We use a directory junction here because not all Windows users will have permissions to create a symlink.
-# We create this junction with cmd.exe's mklink because it has a stable interface across all active versions of Windows and Windows Server,
-# while PowerShell's New-Item has breaking changes and doesn't have the -Target param in 4.0 (the default PowerShell on Win Server 2012).
-
-Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
-cmd.exe /Q /C "mklink /J `"$latestDirectory`" `"$extractedDirectory`"" > $null
-if (!$?) {
-    Write-Error "Linking failed!"
-}
-
-Write-Verbose "Removing ${zipFile}"
-Remove-Item -Force $zipFile
-
-# Permanently add the latest directory to the current user's $PATH (if it's not already there).
-# Note that this will only take effect when a new terminal is started.
-$registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
-$currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
-if ($currentPath -NotMatch 'AzureAuth') {
-    Write-Verbose "Updating `$PATH to include ${latestDirectory}"
-    $newPath = if ($currentPath -Match $null) {
-        "${latestDirectory}"
+    $azureauthDirectory = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_INSTALL_DIRECTORY)) {
+        ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "Programs", "AzureAuth"))
     } else {
-        "${currentPath};${latestDirectory}"
+        $Env:AZUREAUTH_INSTALL_DIRECTORY
     }
-    Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+    $extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
+    $latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))
+    $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
+
+    Write-Verbose "Creating ${azureauthDirectory}"
+    $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
+
+#    Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
+#    $client = New-Object System.Net.WebClient
+#    $client.DownloadFile($releaseUrl, $zipFile)
+
+    # A running instance of azureauth can cause installation to fail, so we try to kill any running instances first.
+    # We suppress taskkill output here because this is a best effort attempt and we don't want the user to see its output.
+    # Here, Get-Process is used to first determine whether there is an existing azureauth process. If there is, kill the existing process first.
+    $ProcessCheck = Get-Process -Name azureauth -ErrorAction SilentlyContinue -ErrorVariable ProcessError
+    if ($ProcessCheck -ne $null)
+    {
+        Write-Verbose "Stopping any currently running azureauth instances"
+        taskkill /f /im azureauth.exe 2>&1 | Out-Null
+
+        # After killing the process it is still possible for there there to be locks on the files it was using (including
+        # its own DLLs). The OS may take an indeterminate amount of time to clean those up, but so far we've observed 1
+        # second to be enough.
+        Start-Sleep -Seconds 1
+    }
+
+    if (Test-Path -Path $extractedDirectory) {
+        Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"
+        Remove-Item -Force -Recurse $extractedDirectory
+    }
+
+    Write-Verbose "Extracting ${zipFile} to ${extractedDirectory}"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
+
+    if (Test-Path -Path $latestDirectory) {
+        Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
+        
+        # We use IO.Directory::Delete instead of Remove-Item because on Windows Server 2012 with PowerShell 4.0 the latter will not work.
+        [IO.Directory]::Delete($latestDirectory)
+    }
+
+    # We use a directory junction here because not all Windows users will have permissions to create a symlink.
+    # We create this junction with cmd.exe's mklink because it has a stable interface across all active versions of Windows and Windows Server,
+    # while PowerShell's New-Item has breaking changes and doesn't have the -Target param in 4.0 (the default PowerShell on Win Server 2012).
+
+    Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
+    cmd.exe /Q /C "mklink /J `"$latestDirectory`" `"$extractedDirectory`"" > $null
+    if (!$?) {
+        Write-Error "Linking failed!"
+    }
+
+    Write-Verbose "Removing ${zipFile}"
+    Remove-Item -Force $zipFile
+
+    # Permanently add the latest directory to the current user's $PATH (if it's not already there).
+    # Note that this will only take effect when a new terminal is started.
+    $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
+    $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
+    if ($currentPath -NotMatch 'AzureAuth') {
+        Write-Verbose "Updating `$PATH to include ${latestDirectory}"
+        $newPath = if ($currentPath -Match $null) {
+            "${latestDirectory}"
+        } else {
+            "${currentPath};${latestDirectory}"
+        }
+        Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+    }
+
+    Write-Output "Installed azureauth $version!"
+
+
 }
 
-Write-Output "Installed azureauth $version!"
+function V2-No-Latest{
+    param()
+
+    Write-Output "Using the Install No Latest Version"
+
+    $repo = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_REPO)) { 'AzureAD/microsoft-authentication-cli' } else { $Env:AZUREAUTH_REPO }
+    $releaseName = "azureauth-${version}-win10-x64"
+    $releaseFile = "${releaseName}.zip"
+    $releaseUrl = "https://github.com/${repo}/releases/download/${version}/$releaseFile"
+
+    $azureauthDirectory = if ([string]::IsNullOrEmpty($Env:AZUREAUTH_INSTALL_DIRECTORY)) {
+        ([System.IO.Path]::Combine($Env:LOCALAPPDATA, "Programs", "AzureAuth"))
+    } else {
+        $Env:AZUREAUTH_INSTALL_DIRECTORY
+    }
+    $extractedDirectory = ([System.IO.Path]::Combine($azureauthDirectory, $releaseName))
+#    $latestDirectory = ([System.IO.Path]::Combine($azureauthDirectory, "latest"))
+    $versionPath = ([System.IO.Path]::Combine($azureauthDirectory, $version))
+    $zipFile = ([System.IO.Path]::Combine($azureauthDirectory, $releaseFile))
+
+    Write-Verbose "Creating ${azureauthDirectory}"
+    $null = New-Item -ItemType Directory -Force -Path $azureauthDirectory
+
+#   TODO uncomment downloading
+#    Write-Verbose "Downloading ${releaseUrl} to ${zipFile}"
+#    $client = New-Object System.Net.WebClient
+#    $client.DownloadFile($releaseUrl, $zipFile)
+
+    # A running instance of azureauth can cause installation to fail, so we try to kill any running instances first.
+    # We suppress taskkill output here because this is a best effort attempt and we don't want the user to see its output.
+    # Here, Get-Process is used to first determine whether there is an existing azureauth process. If there is, kill the existing process first.
+    $ProcessCheck = Get-Process -Name azureauth -ErrorAction SilentlyContinue -ErrorVariable ProcessError
+    if ($ProcessCheck -ne $null)
+    {
+        Write-Verbose "Stopping any currently running azureauth instances"
+        taskkill /f /im azureauth.exe 2>&1 | Out-Null
+
+        # After killing the process it is still possible for there there to be locks on the files it was using (including
+        # its own DLLs). The OS may take an indeterminate amount of time to clean those up, but so far we've observed 1
+        # second to be enough.
+        Start-Sleep -Seconds 1
+    }
+
+    if (Test-Path -Path $extractedDirectory) {
+        Write-Verbose "Removing pre-existing extracted directory at ${extractedDirectory}"
+        Remove-Item -Force -Recurse $extractedDirectory
+    }
+
+    Write-Verbose "Extracting ${zipFile} to ${extractedDirectory}"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $azureauthDirectory)
+
+##TODO - Remove the latestDirectory related code
+#    if (Test-Path -Path $latestDirectory) {
+#        Write-Verbose "Removing pre-existing latest directory at ${latestDirectory}"
+        
+        # We use IO.Directory::Delete instead of Remove-Item because on Windows Server 2012 with PowerShell 4.0 the latter will not work.
+#        [IO.Directory]::Delete($latestDirectory)
+#    }
+
+    # We use a directory junction here because not all Windows users will have permissions to create a symlink.
+    # We create this junction with cmd.exe's mklink because it has a stable interface across all active versions of Windows and Windows Server,
+    # while PowerShell's New-Item has breaking changes and doesn't have the -Target param in 4.0 (the default PowerShell on Win Server 2012).
+
+#    Write-Verbose "Linking ${latestDirectory} to ${extractedDirectory}"
+#    cmd.exe /Q /C "mklink /J `"$latestDirectory`" `"$extractedDirectory`"" > $null
+#    if (!$?) {
+#        Write-Error "Linking failed!"
+#    }
+
+    Write-Verbose "Removing ${zipFile}"
+    Remove-Item -Force $zipFile
+
+    # Permanently add the latest directory to the current user's $PATH (if it's not already there).
+    # Note that this will only take effect when a new terminal is started.
+    $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
+    $currentPath = (Get-ItemProperty -Path $registryPath -Name PATH -ErrorAction SilentlyContinue).Path
+    if ($currentPath -NotMatch 'AzureAuth') {
+        Write-Verbose "Updating `$PATH to include ${versionPath}"
+        $newPath = if ($currentPath -Match $null) {
+            "${versionPath}"
+        } else {
+            "${currentPath};${versionPath}"
+        }
+        Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+    }
+    else{
+        #Update the PATH variable
+    }
+
+    Write-Output "Installed azureauth $version!"
+
+}
+
+# TODO : Determination logic
+V1-Install-With-Latest
+#V2-No-Latest

--- a/install/install.sh
+++ b/install/install.sh
@@ -50,55 +50,163 @@ release_name() {
     echo "${name}"
 }
 
-: ${AZUREAUTH_REPO='AzureAD/microsoft-authentication-cli'}
-repo="${AZUREAUTH_REPO}"
-release_file="$(release_name).tar.gz"
-release_url="https://github.com/${repo}/releases/download/${version}/${release_file}"
+remove_from_profile() {
+    path="${1}"
+    shell_profile="${2}"
 
-: ${AZUREAUTH_INSTALL_DIRECTORY="${HOME}/.azureauth"}
-azureauth_directory="${AZUREAUTH_INSTALL_DIRECTORY}"
-target_directory="${azureauth_directory}/$(release_name)"
-latest_directory="${azureauth_directory}/latest"
-tarball="${azureauth_directory}/${release_file}"
+    if grep "${path}" "${shell_profile}" &>/dev/null; then
+        # Output which path we're removing for debugging purposes.
+        path_suffix=$(echo "${path}" | awk -F : '{print $NF}' | tr -d '"')
+        verbose "Removing '${path_suffix}' from \$PATH in ${shell_profile}"
 
-verbose "Creating ${azureauth_directory}"
-mkdir -p $azureauth_directory
-
-verbose "Downloading ${release_url} to ${tarball}"
-if ! curl -sfL $release_url > $tarball; then
-    error "Failed to download azureauth ${version}"
-    exit 1
-fi
-
-if [ -d "${target_directory}" ]; then
-    verbose "Removing pre-existing target directory at ${target_directory}"
-    rm -rf $target_directory
-fi
-
-verbose "Extracting ${tarball} to ${target_directory}"
-mkdir -p $target_directory
-tar -xf $tarball -C $target_directory
-
-# The files extracted from the tarball are all executable, but only two need to be.
-chmod -x ${target_directory}/*
-chmod +x ${target_directory}/azureauth
-
-verbose "Removing ${tarball}"
-rm $tarball
-
-verbose "Linking ${latest_directory} to ${target_directory}"
-# It's very important we use -n and -f here or the symlink won't actually be overwritten during upgrades.
-ln -snf $target_directory $latest_directory
-
-# We currently only support automatically appending $PATH modifications for the default
-# Bash and ZSH profiles as the syntax is identical.
-path_modification='export PATH="${PATH}:${HOME}/.azureauth/latest"'
-for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
-do
-    if ! grep "${path_modification}" "${shell_profile}" &>/dev/null; then
-        verbose "Updating \$PATH in ${shell_profile} to include ${latest_directory}"
-        printf "\n${path_modification}\n" >> $shell_profile
+        # Escape the current path so that / are replaced with \/ and the string
+        # can be given to sed as a valid expression.
+        escaped_path=$(echo "${path}" | sed -e 's;/;\\/;g')
+        # Delete a matching path (including trailing newline) from the profile.
+        sed -i -e /"${escaped_path}"/d "${shell_profile}"
     fi
-done
+}
 
-echo "Installed azureauth ${version}!"
+install_pre_0_4_0() {
+    : ${AZUREAUTH_REPO='AzureAD/microsoft-authentication-cli'}
+    repo="${AZUREAUTH_REPO}"
+    release_file="$(release_name).tar.gz"
+    release_url="https://github.com/${repo}/releases/download/${version}/${release_file}"
+
+    : ${AZUREAUTH_INSTALL_DIRECTORY="${HOME}/.azureauth"}
+    azureauth_directory="${AZUREAUTH_INSTALL_DIRECTORY}"
+    target_directory="${azureauth_directory}/$(release_name)"
+    latest_directory="${azureauth_directory}/latest"
+    tarball="${azureauth_directory}/${release_file}"
+
+    verbose "Installing using pre-0.4.0 method"
+
+    verbose "Creating ${azureauth_directory}"
+    mkdir -p $azureauth_directory
+
+    verbose "Downloading ${release_url} to ${tarball}"
+    if ! curl -sfL $release_url > $tarball; then
+        error "Failed to download azureauth ${version}"
+        exit 1
+    fi
+
+    if [ -d "${target_directory}" ]; then
+        verbose "Removing pre-existing target directory at ${target_directory}"
+        rm -rf $target_directory
+    fi
+
+    verbose "Extracting ${tarball} to ${target_directory}"
+    mkdir -p $target_directory
+    tar -xf $tarball -C $target_directory
+
+    # The files extracted from the tarball are all executable, but only two need to be.
+    chmod -x ${target_directory}/*
+    chmod +x ${target_directory}/azureauth
+
+    verbose "Removing ${tarball}"
+    rm $tarball
+
+    verbose "Linking ${latest_directory} to ${target_directory}"
+    # It's very important we use -n and -f here or the symlink won't actually be overwritten during upgrades.
+    ln -snf $target_directory $latest_directory
+
+    # We currently only support automatically appending $PATH modifications for the default
+    # Bash and ZSH profiles as the syntax is identical.
+    path_modification='export PATH="${PATH}:${HOME}/.azureauth/latest"'
+    for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
+    do
+        if ! grep "${path_modification}" "${shell_profile}" &>/dev/null; then
+            verbose "Updating \$PATH in ${shell_profile} to include ${latest_directory}"
+            printf "\n${path_modification}\n" >> $shell_profile
+        fi
+    done
+
+    echo "Installed azureauth ${version}!"
+}
+
+install_post_0_4_0() {
+    : ${AZUREAUTH_REPO='AzureAD/microsoft-authentication-cli'}
+    repo="${AZUREAUTH_REPO}"
+    release_file="$(release_name).tar.gz"
+    release_url="https://github.com/${repo}/releases/download/${version}/${release_file}"
+
+    : ${AZUREAUTH_INSTALL_DIRECTORY="${HOME}/.azureauth"}
+    azureauth_directory="${AZUREAUTH_INSTALL_DIRECTORY}"
+    target_directory="${azureauth_directory}/${version}"
+    tarball="${azureauth_directory}/${release_file}"
+
+    # Ignore profile updates if the user has requested we not touch their profile(s).
+    : ${AZUREAUTH_NO_UPDATE_PATH=""}
+    no_update_path="${AZUREAUTH_NO_UPDATE_PATH}"
+
+    verbose "Installing using post-0.4.0 method"
+
+    verbose "Creating ${azureauth_directory}"
+    mkdir -p $azureauth_directory
+
+    verbose "Downloading ${release_url} to ${tarball}"
+    if ! curl -sfL $release_url > $tarball; then
+        error "Failed to download azureauth ${version}"
+        exit 1
+    fi
+
+    if [ -d "${target_directory}" ]; then
+        verbose "Removing pre-existing target directory at ${target_directory}"
+        rm -rf $target_directory
+    fi
+
+    verbose "Extracting ${tarball} to ${target_directory}"
+    mkdir -p $target_directory
+    tar -xf $tarball -C $target_directory
+
+    verbose "Removing ${tarball}"
+    rm $tarball
+
+    if [ -n "${no_update_path}" ]; then
+        verbose "Not updating the \$PATH in any user profiles"
+    else
+        # We previously added `latest` to the $PATH, but we no longer support that, so
+        # we remove this from the $PATH to avoid confusion.
+        latest_path='export PATH="${PATH}:${HOME}/.azureauth/latest"'
+
+        # If there is an existing installation we can identify, then we remove it from
+        # the $PATH so that it will be replaced by the new installation. Note that we use
+        # `true` here because we set -e above and this expression would fail and cause
+        # unnecessary early termination otherwise.
+        current_azureauth="$(which azureauth || true)"
+        if [ -f "${current_azureauth}" ]; then
+            current_azureauth_parent=$(dirname "${current_azureauth}")
+            current_path='export PATH="${PATH}:'${current_azureauth_parent}'"'
+        fi
+
+        for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
+        do
+            remove_from_profile "${latest_path}" "${shell_profile}"
+            if [ -n "${current_path}" ]; then
+                remove_from_profile "${current_path}" "${shell_profile}"
+            fi
+        done
+
+        # We currently only support automatically appending $PATH modifications for the default
+        # Bash and ZSH profiles as the syntax is identical.
+        new_path='export PATH="${PATH}:'${target_directory}'"'
+        for shell_profile in "${HOME}/.bashrc" "${HOME}/.zshrc"
+        do
+            if ! grep "${new_path}" "${shell_profile}" &>/dev/null; then
+                verbose "Appending '${target_directory}' to \$PATH in ${shell_profile}"
+                printf "${new_path}\n" >> $shell_profile
+            fi
+        done
+    fi
+
+    echo "Installed azureauth ${version}!"
+}
+
+case "${version}" in
+    v0.1.0|v0.2.0|v0.3.0|0.3.1)
+        install_pre_0_4_0
+        ;;
+    *)
+        install_post_0_4_0
+        ;;
+esac


### PR DESCRIPTION
As a part of this PR, following changes have been made in the install scripts (install.sh and install.ps1)

1. Separate the install logic into 2 functions - installing pre-0.4.0 version and post-0.4.0 version
2. Keep the current installation script logic in pre-0.4.0 
3. For post-0.4.0 :
- Update the install script to stop creating a latest directory and instead create a release version directory
- Add a ` -NoUpdatePath ` flag to help avoid modifications to the global $PATH when the flag is provided
-  Improve verbose output by specifying whether we are Appending/Removing from PATH
- Clean up previously added installation path (for currently installed azurauth) including default path, custom path
- Append our newly installed version's path to PATH (when` -NoUpdatePath ` is not provided)
4. Use setx instead of set-item command to signal PATH changes to the OS
5. Version determination logic to call respective functions
6. For install.ps1 - minor refactoring including inverting the null equality comparison for better coding standards 

Changes in release.yml
1. Update the release.yml to improve windows packaging i.e. removing the extra directory hierarchy from the windows archive 