### PR TITLE
Improve code style in `ExceptionExtensions.cs`

### DIFF
--- a/src/MSALWrapper.Test/ExceptionExtensionsTest.cs
+++ b/src/MSALWrapper.Test/ExceptionExtensionsTest.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using System.IO;
     using System.Linq;
     using FluentAssertions;
+    using Microsoft.Authentication.MSALWrapper;
     using NUnit.Framework;
 
     internal class ExceptionExtensionsTest

--- a/src/MSALWrapper/ExceptionExtensions.cs
+++ b/src/MSALWrapper/ExceptionExtensions.cs
@@ -1,68 +1,71 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-
-/// <summary>
-/// Exceptions extensions.
-/// </summary>
-public static class ExceptionsExtensions
+namespace Microsoft.Authentication.MSALWrapper
 {
-    /// <summary>
-    /// Convert exception to formatted string.
-    /// </summary>
-    /// <param name="exception">The exception.</param>
-    /// <returns>The <see cref="string"/>.</returns>
-    /// <exception cref="ArgumentNullException">.</exception>
-    public static string ToFormattedString(this Exception exception)
-    {
-        if (exception == null)
-        {
-            throw new ArgumentNullException("Cannot pass null to the exception extension method.");
-        }
-
-        IEnumerable<string> messages = exception
-            .GetAllExceptions()
-            .Where(e => !string.IsNullOrWhiteSpace(e.Message))
-            .Select(e => e.Message.Trim());
-
-        var flattened = string.Join(Environment.NewLine, messages);
-        return flattened;
-    }
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
-    /// Extracts all inner exceptions.
+    /// Exceptions extensions.
     /// </summary>
-    /// <param name="exception">The exception.</param>
-    /// <returns>The <see cref="IEnumerable"/>.</returns>
-    /// <exception cref="ArgumentNullException">Argument Null Exception.</exception>
-    public static IEnumerable<Exception> GetAllExceptions(this Exception exception)
+    public static class ExceptionExtensions
     {
-        if (exception == null)
+        /// <summary>
+        /// Convert exception to formatted string.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <returns>The <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentNullException">.</exception>
+        public static string ToFormattedString(this Exception exception)
         {
-            throw new ArgumentNullException("Cannot pass null to the exception extension method.");
-        }
-
-        if (!(exception is AggregateException))
-        {
-            yield return exception;
-        }
-
-        if (exception is AggregateException aggregateException)
-        {
-            foreach (Exception innerEx in aggregateException.InnerExceptions.SelectMany(e => e.GetAllExceptions()))
+            if (exception == null)
             {
-                yield return innerEx;
+                throw new ArgumentNullException("Cannot pass null to the exception extension method.");
             }
+
+            IEnumerable<string> messages = exception
+                .GetAllExceptions()
+                .Where(e => !string.IsNullOrWhiteSpace(e.Message))
+                .Select(e => e.Message.Trim());
+
+            var flattened = string.Join(Environment.NewLine, messages);
+            return flattened;
         }
-        else if (exception.InnerException != null)
+
+        /// <summary>
+        /// Extracts all inner exceptions.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <returns>The <see cref="IEnumerable"/>.</returns>
+        /// <exception cref="ArgumentNullException">Argument Null Exception.</exception>
+        public static IEnumerable<Exception> GetAllExceptions(this Exception exception)
         {
-            foreach (Exception innerEx in exception.InnerException.GetAllExceptions())
+            if (exception == null)
             {
-                yield return innerEx;
+                throw new ArgumentNullException("Cannot pass null to the exception extension method.");
+            }
+
+            if (!(exception is AggregateException))
+            {
+                yield return exception;
+            }
+
+            if (exception is AggregateException aggregateException)
+            {
+                foreach (Exception innerEx in aggregateException.InnerExceptions.SelectMany(e => e.GetAllExceptions()))
+                {
+                    yield return innerEx;
+                }
+            }
+            else if (exception.InnerException != null)
+            {
+                foreach (Exception innerEx in exception.InnerException.GetAllExceptions())
+                {
+                    yield return innerEx;
+                }
             }
         }
     }


### PR DESCRIPTION
1. `ExceptionExtensions` is not in namespace `Microsoft.Authentication.MSALWrapper`. Moved it.
2. File name ExceptionExtensions.cs didn't match the class name Exception**s**Extensions. According to the member function, rename the class name to `ExceptionExtensions`.
```diff
+ ExceptionExtensions
- ExceptionsExtensions
```
3. Adjusted the indent.