### PR TITLE
Use double quotes to allow interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Or, if you want a method more resilient to failure than `Invoke-Expression`, run
 # 0.4.0 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
 $env:AZUREAUTH_VERSION = '0.4.0'
 $script = "${env:TEMP}\install.ps1"
-$url = 'https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/${env:AZUREAUTH_VERSION}/install/install.ps1'
+$url = "https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/${env:AZUREAUTH_VERSION}/install/install.ps1"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest $url -OutFile $script; if ($?) { &$script }; if ($?) { rm $script }
 ```


### PR DESCRIPTION
Looks like we just forgot to use the right type of quotes here. Resolves #129.