### PR TITLE
Upgrade CompleteWithin to forcefully timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Provided functionality to disable Public Client Authentication using an environment variable `AZUREAUTH_NO_USER`.
+- Provide functionality to disable Public Client Authentication using an environment variable `AZUREAUTH_NO_USER`.
 - Added `--timeout` functionality to provide reliable contract of allowed runtime (default: 10 minutes) and warnings as the timeout approaches.
+
+### Fixed
+- Fixed a bug where sometimes, when logged in with only a password (not a strong form of authentication) the broker flow could hang indefinitely, preventing fall back to another auth flow.
 
 ## [0.4.0] - 2022-06-23
 ### Added

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 0.1 minutes.");
             authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 0.1 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:20");
             authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 
@@ -385,7 +385,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("Broker");
         }
 

--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
             authFlowResult.AuthFlowName.Should().Be("DeviceCode");
         }
 

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 0.1 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:06");
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 5 minutes.");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
             authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
@@ -380,7 +380,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 15 minutes.");
+            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("Web");
         }
 
@@ -404,7 +404,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 15 minutes.");
+            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("Web");
         }
 

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The silent auth timeout.
         /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(6);
+        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(20);
 
         /// <summary>
         /// The interactive auth timeout.

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
 
@@ -29,7 +30,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The silent auth timeout.
         /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(6);
 
         /// <summary>
         /// The interactive auth timeout.

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The silent auth timeout.
         /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// The device code flow timeout.

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The silent auth timeout.
         /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromMinutes(5);
+        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// The interactive auth timeout.

--- a/src/MSALWrapper/TaskExecutor.cs
+++ b/src/MSALWrapper/TaskExecutor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (OperationCanceledException)
             {
-                var warningMessage = $"{taskName} timed out after {timeout.TotalMinutes} minutes.";
+                var warningMessage = $"{taskName} timed out after {timeout.ToString(@"hh\:mm\:ss")}";
                 logger?.LogWarning(warningMessage);
                 errorsList?.Add(new AuthenticationTimeoutException(warningMessage));
                 return null;


### PR DESCRIPTION
Sometimes, the broker flow can hang in a way that doesn't respect cancellation tokens. I've reproed this for 1 day, but then not the next, likely due to machine/OS state.

The basic effect was that AcquireTokenSilent was hung, and the broker wasn't responding, but we didn't timeout that task and fall back to web.

This update uses the same technic we use in the global timeout to race a Task.Delay against the actual task, and manually kill that main task if it does not win.

I've tested this by injecting a wait for 7 seconds in the broker silent token call (not added to the PR), and confirmed it falls back to web from there.