### PR TITLE
Launch broker auth prompts in the foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provided functionality to disable Public Client Authentication using an environment variable `AZUREAUTH_NO_USER`.
 - Added `--timeout` functionality to provide reliable contract of allowed runtime (default: 10 minutes) and warnings as the timeout approaches.
 
+### Fixed
+- Fixed a bug where broker auth prompt is hanging in the background and gives a false impression to the user that the console app is hung.
+
 ## [0.4.0] - 2022-06-23
 ### Added
 - Environment variable `AZUREAUTH_CACHE` and option `--cache` to support a custom cache location on Windows.

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -406,20 +406,19 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
         }
 
-        //[Test]
-        //public void TestConstructor_WithParentActivityOrWindowFunc()
-        //{
-        //    IntPtr ownerPtr = new IntPtr(23478);
+        // [Test]
+        // public void TestConstructor_WithParentActivityOrWindowFunc()
+        // {
+        //     IntPtr ownerPtr = new IntPtr(23478);
 
-        //    var pca = PublicClientApplicationBuilder
-        //        .Create(TestConstants.ClientId)
-        //        .WithParentActivityOrWindow(() => ownerPtr)
-        //        .Build();
+        //     var pca = PublicClientApplicationBuilder
+        //         .Create($"{ClientId}")
+        //         .WithParentActivityOrWindow(() => ownerPtr)
+        //         .Build();
 
-        //    Assert.IsNotNull(pca.AppConfig.ParentActivityOrWindowFunc);
-        //    Assert.AreEqual(ownerPtr, pca.AppConfig.ParentActivityOrWindowFunc());
-        //}
-
+        //     Assert.IsNotNull(pca.AppConfig.ParentActivityOrWindowFunc);
+        //     Assert.AreEqual(ownerPtr, pca.AppConfig.ParentActivityOrWindowFunc());
+        // }
 
         private void SilentAuthResult()
         {

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -406,6 +406,21 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
         }
 
+        //[Test]
+        //public void TestConstructor_WithParentActivityOrWindowFunc()
+        //{
+        //    IntPtr ownerPtr = new IntPtr(23478);
+
+        //    var pca = PublicClientApplicationBuilder
+        //        .Create(TestConstants.ClientId)
+        //        .WithParentActivityOrWindow(() => ownerPtr)
+        //        .Build();
+
+        //    Assert.IsNotNull(pca.AppConfig.ParentActivityOrWindowFunc);
+        //    Assert.AreEqual(ownerPtr, pca.AppConfig.ParentActivityOrWindowFunc());
+        //}
+
+
         private void SilentAuthResult()
         {
             this.pcaWrapperMock

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -406,20 +406,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
         }
 
-        // [Test]
-        // public void TestConstructor_WithParentActivityOrWindowFunc()
-        // {
-        //     IntPtr ownerPtr = new IntPtr(23478);
-
-        //     var pca = PublicClientApplicationBuilder
-        //         .Create($"{ClientId}")
-        //         .WithParentActivityOrWindow(() => ownerPtr)
-        //         .Build();
-
-        //     Assert.IsNotNull(pca.AppConfig.ParentActivityOrWindowFunc);
-        //     Assert.AreEqual(ownerPtr, pca.AppConfig.ParentActivityOrWindowFunc());
-        // }
-
         private void SilentAuthResult()
         {
             this.pcaWrapperMock

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 {
                     HeaderText = this.promptHint,
                 })
-                .WithParentActivityOrWindow(() => this.consoleWindowHandleProvider); 
+                .WithParentActivityOrWindow(() => this.consoleWindowHandleProvider);
 
 #if NETFRAMEWORK
             clientBuilder.WithWindowsBroker();

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly IList<Exception> errors;
         private IPCAWrapper pcaWrapper;
 
+        // Pass parent window ID to MSAL so it can parent the authentication dialogs.
+        private Func<IntPtr> consoleWindowHandleProvider = () => GetConsoleWindow();
+
         #region Public configurable properties
 
         /// <summary>
@@ -157,16 +160,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 .WithWindowsBrokerOptions(new WindowsBrokerOptions
                 {
                     HeaderText = this.promptHint,
-                });
-
-            // The return value is a handle to the window used by the console associated with the calling process or
-            // NULL if there is no such associated console.
-            // Retrieves the window handle used by the console associated with the calling process.
-
-            // check if windows and Pass parent window ID to MSAL so it can parent the authentication dialogs.
-            IntPtr consoleWindowHandle = GetConsoleWindow();
-            Func<IntPtr> consoleWindowHandleProvider = () => consoleWindowHandle;
-            clientBuilder.WithParentActivityOrWindow(() => consoleWindowHandleProvider);
+                })
+                .WithParentActivityOrWindow(() => this.consoleWindowHandleProvider); 
 
 #if NETFRAMEWORK
             clientBuilder.WithWindowsBroker();

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -161,9 +161,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetConsoleWindow();
 
+        /// <summary>
+        /// Retrieves the handle to the ancestor of the specified window.
+        /// </summary>
+        /// <param name="windowsHandle">A handle to the window whose ancestor is to be retrieved.
+        /// If this parameter is the desktop window, the function returns NULL. </param>
+        /// <param name="flags">The ancestor to be retrieved.</param>
+        /// <returns>The return value is the handle to the ancestor window.</returns>[DllImport("user32.dll", ExactSpelling = true)]
         [DllImport("user32.dll", ExactSpelling = true)]
         private static extern IntPtr GetAncestor(IntPtr windowsHandle, GetAncestorFlags flags);
 
+        // MSAL will be providing a similar helper in the future that we can use to simplify this(AzureAD/microsoft-authentication-library-for-dotnet#3590).
         private IntPtr GetParentWindowHandle()
         {
             IntPtr consoleHandle = GetConsoleWindow();

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 {
                     HeaderText = this.promptHint,
                 })
-                .WithParentActivityOrWindow(() => this.GetParentWindowHandle()); // Pass parent window ID to MSAL so it can parent the authentication dialogs.
+                .WithParentActivityOrWindow(() => this.GetParentWindowHandle()); // Pass parent window handle to MSAL so it can parent the authentication dialogs.
 #if NETFRAMEWORK
             clientBuilder.WithWindowsBroker();
 #else


### PR DESCRIPTION
**Current State**

With the broker auth prompt hanging in the background, it gives a false impression to the user that the console app is hung, and there is no obvious way of finding the WAM dialog box. Using Alt + Tab doesn't show the WAM dialog box and this also gives an impression that there was no auth prompt. If a window handle is not given, MSAL currently uses the center of the desktop, which can cause this problem.

**Scenario to support**

 If the broker auth prompt is launched to the foreground of the calling process, users can interact with it immediately and sign in instead of being unaware that an auth prompt is waiting for their interaction.
MSAL has also made the WithParentActivityOrWindow() API [mandatory in their latest version.](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/wam#parent-window-handles)

**Solution**

Get the parent window handle of the process calling auth and pass that into MSAL.
Note : MSAL will be providing a helper for this in their library in a newer version - AzureAD/microsoft-authentication-library-for-dotnet#3590.


**Testing**
Manual validation in Windows has been done to make sure the broker auth prompt appears in front of the calling process.