### PR TITLE
Reducing timeout warning noise and increasing default timeout to 15 mins

### DIFF
--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -53,7 +53,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// The default number of minutes CLI is allowed to run.
         /// </summary>
-        private static readonly TimeSpan GlobalTimeout = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan GlobalTimeout = TimeSpan.FromMinutes(15);
 
         private readonly EventData eventData;
         private readonly ILogger<CommandMain> logger;

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -754,8 +754,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             var remainingTimeForWarningMessage = TimeSpan.FromSeconds(10);
 
             stopwatch.Setup(tm => tm.Start());
-            stopwatch.Setup(tm => tm.Elapsed()).Returns(timeAfterwarningLength);
-            stopwatch.Setup(tm => tm.Remaining()).Returns(remainingTimeForWarningMessage);
             stopwatch.Setup(tm => tm.TimedOut()).Returns(true);
             stopwatch.Setup(tm => tm.Stop());
 

--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly ILogger logger;
         private readonly IStopwatch stopwatch;
 
-        private TimeSpan pollingInterval = TimeSpan.FromSeconds(30);
+        private TimeSpan pollingInterval = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthFlowExecutor"/> class.
@@ -102,12 +102,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             while (!flowResult.IsCompleted)
             {
-                if (this.stopwatch.Elapsed() >= WarningDelay)
-                {
-                    this.logger.LogWarning($"Waiting for {authFlowName} authentication. Look for an auth prompt.");
-                    this.logger.LogWarning($"Timeout in {this.stopwatch.Remaining():mm}m {this.stopwatch.Remaining():ss}s!");
-                }
-
                 if (this.stopwatch.TimedOut())
                 {
                     this.stopwatch.Stop();
@@ -118,6 +112,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     // Note that though the task running the auth flow will be killed once we return from this method,
                     // the interactive auth prompt will be killed as we exit the application (possibly due to the way GC works).
                     return timeoutResult;
+                }
+
+                if (this.stopwatch.Elapsed() >= WarningDelay)
+                {
+                    this.logger.LogWarning($"Waiting for {authFlowName} authentication. Look for an auth prompt.");
+                    this.logger.LogWarning($"Timeout in {this.stopwatch.Remaining():mm}m {this.stopwatch.Remaining():ss}s!");
                 }
 
                 await Task.WhenAny(Task.Delay(this.Delay()), flowResult);


### PR DESCRIPTION
Phase 2 of timeout feature. As a part of this PR I have
1. Increased default global timeout to ` 15 minutes `
2. Increased the polling interval from ` 30 seconds ` to ` 5 minutes `. Hence, for default timeout span of ` 15 minutes `, we will get warning messages only 3 times. This will help in reducing warning noise as per feedback
