### PR TITLE
Increase the initial warning delay to 20 seconds

### DIFF
--- a/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowExecutor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The amount of time to wait before we start warning on stderr about waiting for auth.
         /// </summary>
-        public static TimeSpan WarningDelay = TimeSpan.FromSeconds(10);
+        public static TimeSpan WarningDelay = TimeSpan.FromSeconds(20);
 
         private readonly IEnumerable<IAuthFlow> authflows;
         private readonly ILogger logger;


### PR DESCRIPTION
With recent changes, we have increased the timeout period for `Broker` silent `authflow` to `20 seconds`. However, we first warn the user to look for an auth prompt after `10 seconds`. So there is rough edge case where the silent mode might still be running and we warn the user to look for an prompt. 
As a part of this PR, I am increasing the initial `WarningDelay` in `AuthFlowExecutor` to `20 seconds` so that we provide enough time for silent auth to timeout before we warn for an auth prompt.