### PR TITLE
Updating CHANGELOG for 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.1] - 2022-09-08
+### Fixed
+- Fixed a bug where we early exited before sending individual events telemetry data containing valuable `error_messages`.
+
 ## [0.5.0] - 2022-09-06
 ### Added
 - Added functionality to disable Public Client Authentication using an environment variable `AZUREAUTH_NO_USER`.
@@ -66,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/v0.3.0...0.3.1


### PR DESCRIPTION
Adding references to `0.5.1` and short bug fix entry for releasing `0.5.1`