### PR TITLE
Adding section in usage docs for setting custom timeout 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ Use the option `--output` to get the token in the desired formats. Available cho
 4. `--output none` returns nothing.
 
 ## Setting custom timeout
-Azureauth currently defaults to 15 minutes timeout. You can also mention your custom timeout in minutes which can be a decimal number.
+Azureauth currently defaults to 15 minutes timeout. You can also set your custom timeout in minutes which can be a decimal number.
 
 Usage:
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ Use the option `--output` to get the token in the desired formats. Available cho
 4. `--output none` returns nothing.
 
 ## Setting custom timeout
-Azureauth currently defaults to 15 minutes timeout. You can also set your custom timeout in minutes which can be a decimal number.
+Azureauth defaults to a 15 minute timeout. You can override this with a custom timeout value using `--timeout`. The value is interpreted as a decimal number of minutes. The example below will wait 10 minutes and 45 seconds.
 
 Usage:
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,14 @@ Use the option `--output` to get the token in the desired formats. Available cho
 3. `--output status` returns the status of the authentication and the cache.
 4. `--output none` returns nothing.
 
+## Setting custom timeout
+Azureauth currently defaults to 15 minutes timeout. You can also mention your custom timeout in minutes which can be a decimal number.
+
+Usage:
+```
+azureauth --alias alias1 --timeout 10.75
+```
+
 Use the command `azureauth --help` to understand more available options.
 
 ### Examples


### PR DESCRIPTION
Recently, we received [feedback](https://office.visualstudio.com/OE/_workitems/edit/5851307#22462190) to add the information about default timeout and it's usage in our docs.

This PR contains adding a section in `docs/usage` for setting custom timeout.