### PR TITLE
User/mstannah/iwa update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Option `--resource` is not needed if option `--scope` is provided.
+- Refactoring IWA AuthFlow to call GetTokenIWA when we have a MsalUiRequiredException 
 
 ## [0.5.1] - 2022-09-08
 ### Fixed

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -79,11 +79,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public AuthFlow.IntegratedWindowsAuthentication Subject() => this.serviceProvider.GetService<AuthFlow.IntegratedWindowsAuthentication>();
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_HappyPath()
+        public async Task CachedAuthSuccess()
         {
-            this.SilentAuthResult();
-
             this.MockAccount();
+            this.CachedAuthResult();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -98,29 +97,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_ReturnsNull()
+        public async Task GetCachedToken_ReturnsNull()
         {
-            this.SilentAuthReturnsNull();
-
             this.MockAccount();
-
-            // Act
-            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
-            var authFlowResult = await iwa.GetTokenAsync();
-
-            // Assert
-            this.pcaWrapperMock.VerifyAll();
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
-        }
-
-        [Test]
-        public async Task IntegratedWindowsAuthFlow_MsalUIException()
-        {
-            this.SilentAuthUIRequired();
-
-            this.MockAccount();
+            this.CachedAuthReturnsNull();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -130,12 +110,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
-        public void IntegratedWindowsAuthFlow_General_Exceptions_Are_ReThrown()
+        public void General_Exceptions_Are_ReThrown()
         {
             var message = "Something somwhere has gone terribly wrong!";
             this.pcaWrapperMock
@@ -155,11 +134,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_MsalServiceException()
+        public async Task CachedAccount_Throws_ServiceException()
         {
-            this.SilentAuthServiceException();
-
             this.MockAccount();
+            this.CachedAuthServiceException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -174,11 +152,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_OperationCanceledException()
+        public async Task GetTokenSilent_OperationCanceledException()
         {
-            this.SilentAuthTimeout();
-
             this.MockAccount();
+            this.SilentAuthTimeout();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -187,9 +164,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // Assert
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:06");
+            authFlowResult.Errors[1].Should().BeOfType(typeof(NullTokenResultException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
@@ -232,11 +210,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA()
+        public async Task NoCachedAccounts_IWASuccess()
         {
-            this.IntegratedWindowsAuthenticationResult();
-
             this.MockAccountReturnsNull();
+            this.GetTokenSilentUIRequiredNoAccount();
+            this.IntegratedWindowsAuthenticationResult();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -246,16 +224,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
-            authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_ReturnsNull()
+        public async Task GetTokenIWA_ReturnsNull()
         {
-            this.IntegratedWindowsAuthenticationReturnsNull();
-
             this.MockAccountReturnsNull();
+            this.CachedAuthUIRequired();
+            this.IntegratedWindowsAuthenticationReturnsNull();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -264,16 +242,37 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // Assert
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().BeEmpty();
+            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalUIRequired_2FA()
+        public async Task GetTokenIWA_MsalUIRequired_2FA()
         {
+            this.MockAccountReturnsNull();
+            this.CachedAuthUIRequired();
             this.IntegratedWindowsAuthenticationUIRequiredFor2FA();
 
+            // Act
+            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
+            var authFlowResult = await iwa.GetTokenAsync();
+
+            this.pcaWrapperMock.VerifyAll();
+            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Message.Should().Be("AADSTS50076 MSAL UI Required Exception!");
+            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+        }
+
+        [Test]
+        public async Task GetTokenIWA_GenericMsalUIRequired()
+        {
             this.MockAccountReturnsNull();
+            this.CachedAuthUIRequired();
+            this.IWAGenericUIRequiredException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -281,37 +280,19 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
+            authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[0].Message.Should().Be("AADSTS50076 MSAL UI Required Exception!");
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Message.Should().Be("MSAL UI Required Exception!");
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalUIRequired_AADBrokeIWA()
+        public async Task GetTokenIWA_MsalServiceException()
         {
-            this.IntegratedWindowsAuthenticationUIRequiredForAADBrokeIWA();
-
             this.MockAccountReturnsNull();
-
-            // Act
-            AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
-            var authFlowResult = await iwa.GetTokenAsync();
-
-            this.pcaWrapperMock.VerifyAll();
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[0].Message.Should().Be("MSAL UI Required Exception!");
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
-        }
-
-        [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalServiceException()
-        {
+            this.CachedAuthUIRequired();
             this.IntegratedWindowsAuthenticationServiceException();
-
-            this.MockAccountReturnsNull();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -321,17 +302,18 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // our caller can retry auth another way.
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenIWA_MsalClientException()
+        public async Task GetTokenIWA_MsalClientException()
         {
-            this.IntegratedWindowsAuthenticationClientException();
-
             this.MockAccountReturnsNull();
+            this.CachedAuthUIRequired();
+            this.IntegratedWindowsAuthenticationClientException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -340,33 +322,34 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // Assert
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+            authFlowResult.Errors.Should().HaveCount(2);
+            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalClientException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }
 
-        private void SilentAuthResult()
+        private void CachedAuthResult()
         {
             this.pcaWrapperMock
                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                .ReturnsAsync(this.tokenResult);
         }
 
-        private void SilentAuthReturnsNull()
+        private void CachedAuthReturnsNull()
         {
             this.pcaWrapperMock
                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                .ReturnsAsync((TokenResult)null);
         }
 
-        private void SilentAuthUIRequired()
+        private void CachedAuthUIRequired()
         {
             this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, null, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "UI is required"));
         }
 
-        private void SilentAuthServiceException()
+        private void CachedAuthServiceException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
@@ -408,6 +391,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                .ReturnsAsync((TokenResult)null);
         }
 
+        private void GetTokenSilentUIRequiredNoAccount()
+        {
+            this.pcaWrapperMock
+                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, null, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "No account hint given!"));
+        }
+
         private void IntegratedWindowsAuthenticationUIRequiredFor2FA()
         {
             this.pcaWrapperMock
@@ -415,7 +405,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Throws(new MsalUiRequiredException("1", "AADSTS50076 MSAL UI Required Exception!"));
         }
 
-        private void IntegratedWindowsAuthenticationUIRequiredForAADBrokeIWA()
+        private void IWAGenericUIRequiredException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task CachedAccount_Throws_ServiceException()
+        public async Task CachedAuth_Throws_ServiceException()
         {
             this.MockAccount();
             this.CachedAuthServiceException();
@@ -155,7 +155,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task GetTokenSilent_OperationCanceledException()
         {
             this.MockAccount();
-            this.SilentAuthTimeout();
+            this.CachedAuthTimeout();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -172,11 +172,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_MsalClientException()
+        public async Task GetTokenSilent_MsalClientException()
         {
-            this.SilentAuthClientException();
-
             this.MockAccount();
+            this.CachedAuthClientException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -191,11 +190,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task IntegratedWindowsAuthFlow_GetTokenSilent_NullReferenceException()
+        public async Task GetTokenSilent_NullReferenceException()
         {
-            this.SilentAuthNullReferenceException();
-
             this.MockAccount();
+            this.CachedAuthNullReferenceException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -213,8 +211,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public async Task NoCachedAccounts_IWASuccess()
         {
             this.MockAccountReturnsNull();
-            this.GetTokenSilentUIRequiredNoAccount();
-            this.IntegratedWindowsAuthenticationResult();
+            this.CachedAuthUIRequiredNoAccount();
+            this.IWAReturnsResult();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -233,7 +231,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccountReturnsNull();
             this.CachedAuthUIRequired();
-            this.IntegratedWindowsAuthenticationReturnsNull();
+            this.IWAReturnsNull();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -252,7 +250,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccountReturnsNull();
             this.CachedAuthUIRequired();
-            this.IntegratedWindowsAuthenticationUIRequiredFor2FA();
+            this.IWAUIRequiredFor2FA();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -292,7 +290,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccountReturnsNull();
             this.CachedAuthUIRequired();
-            this.IntegratedWindowsAuthenticationServiceException();
+            this.IWAServiceException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -313,7 +311,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccountReturnsNull();
             this.CachedAuthUIRequired();
-            this.IntegratedWindowsAuthenticationClientException();
+            this.IWAClientException();
 
             // Act
             AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
@@ -356,49 +354,49 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
         }
 
-        private void SilentAuthTimeout()
+        private void CachedAuthTimeout()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
         }
 
-        private void SilentAuthClientException()
+        private void CachedAuthClientException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
         }
 
-        private void SilentAuthNullReferenceException()
+        private void CachedAuthNullReferenceException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
         }
 
-        private void IntegratedWindowsAuthenticationResult()
+        private void IWAReturnsResult()
         {
             this.pcaWrapperMock
                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
                .ReturnsAsync(this.tokenResult);
         }
 
-        private void IntegratedWindowsAuthenticationReturnsNull()
+        private void IWAReturnsNull()
         {
             this.pcaWrapperMock
                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
                .ReturnsAsync((TokenResult)null);
         }
 
-        private void GetTokenSilentUIRequiredNoAccount()
+        private void CachedAuthUIRequiredNoAccount()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, null, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "No account hint given!"));
         }
 
-        private void IntegratedWindowsAuthenticationUIRequiredFor2FA()
+        private void IWAUIRequiredFor2FA()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
@@ -412,14 +410,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Throws(new MsalUiRequiredException("2", "MSAL UI Required Exception!"));
         }
 
-        private void IntegratedWindowsAuthenticationServiceException()
+        private void IWAServiceException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))
                 .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
         }
 
-        private void IntegratedWindowsAuthenticationClientException()
+        private void IWAClientException()
         {
             this.pcaWrapperMock
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, It.IsAny<CancellationToken>()))

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="cacheFilePath">The pca cache file path.</param>
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
-        public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes,  string cacheFilePath, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
+        public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string cacheFilePath, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
         {
             this.errors = new List<Exception>();
             this.logger = logger;
@@ -54,88 +54,67 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         public async Task<AuthFlowResult> GetTokenAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
+            this.logger.LogDebug($"Using cached account '{account?.Username}'");
+            TokenResult tokenResult = null;
 
-            if (account != null)
-            {
-                this.logger.LogDebug($"Using cached account '{account.Username}'");
-                try
-                {
-                    try
-                    {
-                        var tokenResult = await TaskExecutor.CompleteWithin(
-                            this.logger,
-                            this.integratedWindowsAuthTimeout,
-                            "Get Token Silent",
-                            (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
-                            this.errors)
-                            .ConfigureAwait(false);
-                        tokenResult.SetSilent();
-
-                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
-                    }
-                    catch (MsalUiRequiredException ex)
-                    {
-                        this.errors.Add(ex);
-                        this.logger.LogDebug($"Silent auth failed, re-auth is required.\n{ex.Message}");
-                    }
-                }
-                catch (MsalServiceException ex)
-                {
-                    this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
-                    this.errors.Add(ex);
-                }
-                catch (MsalClientException ex)
-                {
-                    this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
-                    this.errors.Add(ex);
-                }
-                catch (NullReferenceException ex)
-                {
-                    this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
-                    this.errors.Add(ex);
-                }
-            }
-            else
+            try
             {
                 try
                 {
-                    var tokenResult = await TaskExecutor.CompleteWithin(
-                                    this.logger,
-                                    this.integratedWindowsAuthTimeout,
-                                    "Get Token Integrated Windows Authentication",
-                                    (cancellationToken) => this.pcaWrapper.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, cancellationToken),
-                                    this.errors)
-                                    .ConfigureAwait(false);
+                    tokenResult = await TaskExecutor.CompleteWithin(
+                        this.logger,
+                        this.integratedWindowsAuthTimeout,
+                        "Get Token Silent",
+                        (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
+                        this.errors)
+                        .ConfigureAwait(false);
                     tokenResult.SetSilent();
-
-                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
-                }
-                catch (MsalUiRequiredException ex) when (
-                             ex.Classification == UiRequiredExceptionClassification.BasicAction
-                          && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
-                {
-                    this.errors.Add(ex);
-                    this.logger.LogWarning($"IWA failed, 2FA is required.\n" +
-                        $"IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.\n{ex.Message}");
+                    if (tokenResult == null)
+                    {
+                        this.errors.Add(new NullTokenResultException("IWA Get Token Silent returned null.(Not expected)"));
+                    }
                 }
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
-                    this.logger.LogDebug($"MSAL UI Required Exception.\n{ex.Message}");
-                }
-                catch (MsalServiceException ex)
-                {
-                    this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
-                    this.errors.Add(ex);
-                }
-                catch (MsalClientException ex)
-                {
-                    this.logger.LogWarning($"Msal Client Exception! Could not identify logged in user.\n{ex.Message}");
-                    this.errors.Add(ex);
+                    this.logger.LogDebug($"Cached auth failed\n{ex.Message}");
+                    tokenResult = await TaskExecutor.CompleteWithin(
+                                  this.logger,
+                                  this.integratedWindowsAuthTimeout,
+                                  "Get Token Integrated Windows Authentication",
+                                  (cancellationToken) => this.pcaWrapper.GetTokenIntegratedWindowsAuthenticationAsync(this.scopes, cancellationToken),
+                                  this.errors)
+                                  .ConfigureAwait(false);
+                    tokenResult.SetSilent();
                 }
             }
+            catch (MsalUiRequiredException ex)
+            {
+                this.errors.Add(ex);
+                if (ex.Classification == UiRequiredExceptionClassification.BasicAction
+                      && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.logger.LogWarning($"IWA failed, 2FA is required.\n" +
+                        $"IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.\n{ex.Message}");
+                }
+            }
+            catch (MsalServiceException ex)
+            {
+                this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
+                this.errors.Add(ex);
+            }
+            catch (MsalClientException ex)
+            {
+                this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
+                this.errors.Add(ex);
+            }
+            catch (NullReferenceException ex)
+            {
+                this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
+                this.errors.Add(ex);
+            }
 
-            return new AuthFlowResult(null, this.errors, this.GetType().Name);
+            return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, string osxKeyChainSuffix, string cacheFilePath)

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 catch (MsalUiRequiredException ex)
                 {
                     this.errors.Add(ex);
-                    this.logger.LogDebug($"Cached auth failed\n{ex.Message}");
+                    this.logger.LogDebug("Cached auth failed.");
+                    this.logger.LogDebug(ex.Message);
                     tokenResult = await TaskExecutor.CompleteWithin(
                                   this.logger,
                                   this.integratedWindowsAuthTimeout,
@@ -94,8 +95,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 if (ex.Classification == UiRequiredExceptionClassification.BasicAction
                       && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
                 {
-                    this.logger.LogWarning($"IWA failed, 2FA is required.\n" +
-                        $"IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.\n{ex.Message}");
+                    this.logger.LogWarning("IWA failed, 2FA is required.");
+                    this.logger.LogWarning("IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.");
+                    this.logger.LogWarning(ex.Message);
                 }
             }
             catch (MsalServiceException ex)


### PR DESCRIPTION
Refactoring IWA AuthFlow to call IWA after GetTokenSilent.
Previously GetTokenIntegratedWindowsAuthenticationAsync would only get called if there were no accounts found in cache.
But we want it to be called immediately if GetTokenSilent call fails. 