### PR TITLE
Iwa timeoutfix and newrelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2022-09-28
+### Fixed
+- Increase IWA Timeout to 15 second and log WS-Trust endpoint error
+
 ## [0.5.2] - 2022-09-28
 ### Fixed
 - Option `--resource` is not needed if option `--scope` is provided.
@@ -73,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.2...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.3...HEAD
+[0.5.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.4.0...0.5.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Microsoft Authentication CLI
 
 [![Tests](https://shields.io/github/workflow/status/AzureAD/microsoft-authentication-cli/Build%20and%20Test/main?style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/actions/workflows/dotnet-test.yml)
-[![Release](https://shields.io/github/v/release/AzureAD/microsoft-authentication-cli?display_name=tag&include_prereleases&sort=semver&style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/0.5.2)
-![GitHub release (latest by SemVer)](https://img.shields.io/github/downloads/azuread/microsoft-authentication-cli/0.5.2/total?logo=github&style=for-the-badge&color=blue)
+[![Release](https://shields.io/github/v/release/AzureAD/microsoft-authentication-cli?display_name=tag&include_prereleases&sort=semver&style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/0.5.3)
+![GitHub release (latest by SemVer)](https://img.shields.io/github/downloads/azuread/microsoft-authentication-cli/0.5.3/total?logo=github&style=for-the-badge&color=blue)
 [![License](https://shields.io/badge/license-MIT-purple?style=for-the-badge)](./LICENSE.txt)
 
 ---
@@ -34,8 +34,8 @@ provide a means of downloading the latest release, so you **must** specify your 
 To install the application, run
 
 ```powershell
-# 0.5.2 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-$env:AZUREAUTH_VERSION = '0.5.2'
+# 0.5.3 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = '0.5.3'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/${env:AZUREAUTH_VERSION}/install/install.ps1) } -Verbose"
 ```
@@ -43,8 +43,8 @@ iex "& { $(irm https://raw.githubusercontent.com/AzureAD/microsoft-authenticatio
 Or, if you want a method more resilient to failure than `Invoke-Expression`, run
 
 ```powershell
-# 0.5.2 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-$env:AZUREAUTH_VERSION = '0.5.2'
+# 0.5.3 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = '0.5.3'
 $script = "${env:TEMP}\install.ps1"
 $url = "https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/${env:AZUREAUTH_VERSION}/install/install.ps1"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -64,8 +64,8 @@ release, so you **must** specify your desired version via the `$AZUREAUTH_VERSIO
 To install the application, run
 
 ```bash
-# 0.5.2 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-export AZUREAUTH_VERSION='0.5.2'
+# 0.5.3 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+export AZUREAUTH_VERSION='0.5.3'
 curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/$AZUREAUTH_VERSION/install/install.sh | sh
 ```
 

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:06");
+            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
             authFlowResult.Errors[1].Should().BeOfType(typeof(NullTokenResultException));
             authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
         }

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -109,6 +109,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             {
                 this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
+                if (ex.Message.StartsWith("WS-Trust endpoint not found", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.logger.LogWarning($"IWA only works on Corp Net, please turn on VPN.");
+                }
             }
             catch (NullReferenceException ex)
             {

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <summary>
         /// The integrated windows auth flow timeout.
         /// </summary>
-        private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromSeconds(6);
+        private TimeSpan integratedWindowsAuthTimeout = TimeSpan.FromSeconds(15);
         #endregion
 
         /// <summary>

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             {
                 this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
-                if (ex.Message.StartsWith("WS-Trust endpoint not found", StringComparison.OrdinalIgnoreCase))
+                if (ex.Message.Contains("WS-Trust endpoint not found"))
                 {
                     this.logger.LogWarning($"IWA only works on Corp Net, please turn on VPN.");
                 }


### PR DESCRIPTION
While testing the new release 0.5.2 we uncovered that IWA calls might need more than 6 seconds to succeed at least for the first time.
We also saw s MSAL Client exception "WS-Trust endpoint not found in metadata document." which means you are not on Corp net and need to turn on your VPN. Adding warning logs in this PR to reflect this error.

This PR also has updates to the Changelog and README files for the new release 0.5.3 along with the fixes.