### PR TITLE
User/mstannah/ nouser should not disable IWA authmode

### DIFF
--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -725,29 +725,46 @@ invalid_key = ""this is not a valid alias key""
         [TestCase("non-empty-string", false)]
         [TestCase("true", false)]
         [TestCase("", false)]
-        public void TestPCA_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
+        public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
             this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
-            subject.PCADisabled().Should().Be(expected);
+            subject.InteractiveAuthDisabled().Should().Be(expected);
         }
 
         [TestCase("1", true)]
         [TestCase("non-empty-string", true)]
         [TestCase("true", true)]
         [TestCase("", false)]
-        public void TestPCA_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
+        public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
             this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
-            subject.PCADisabled().Should().Be(expected);
+            subject.InteractiveAuthDisabled().Should().Be(expected);
         }
 
         [Test]
-        public void PCA_IsEnabledIfEnvVarsAreNotSet()
+        public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
-            subject.PCADisabled().Should().BeFalse();
+            subject.InteractiveAuthDisabled().Should().BeFalse();
+        }
+
+        [TestCase("non-empty-string")]
+        public void GetCombinedAuthMode_withInteractiveAuthDisabled(string noUser)
+        {
+            CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
+            subject.GetCombinedAuthMode().Should().Be(AuthMode.IWA);
+        }
+
+        public void GetCombinedAuthMode_withInteractiveAuthEnabled()
+        {
+            CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            var authModes = new List<AuthMode>();
+            authModes.Add(AuthMode.Broker);
+            subject.AuthModes = authModes;
+            subject.GetCombinedAuthMode().Should().Be(AuthMode.Broker);
         }
 
         /// <summary>

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -752,7 +752,6 @@ invalid_key = ""this is not a valid alias key""
 
 #if PlatformWindows
         [TestCase("non-empty-string")]
-        [Platform("Win")] // Only valid on Windows
         public void GetCombinedAuthMode_withInteractiveAuthDisabled(string noUser)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
@@ -760,7 +759,6 @@ invalid_key = ""this is not a valid alias key""
             subject.CombinedAuthMode.Should().Be(AuthMode.IWA);
         }
 
-        [Platform("Win")] // Only valid on Windows
         public void GetCombinedAuthMode_withInteractiveAuthEnabled()
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -751,20 +751,31 @@ invalid_key = ""this is not a valid alias key""
         }
 
         [TestCase("non-empty-string")]
+        [Platform("Win")] // Only valid on Windows
         public void GetCombinedAuthMode_withInteractiveAuthDisabled(string noUser)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
             this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
-            subject.GetCombinedAuthMode().Should().Be(AuthMode.IWA);
+            subject.CombinedAuthMode.Should().Be(AuthMode.IWA);
         }
 
+        [Platform("Win")] // Only valid on Windows
         public void GetCombinedAuthMode_withInteractiveAuthEnabled()
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
             var authModes = new List<AuthMode>();
             authModes.Add(AuthMode.Broker);
             subject.AuthModes = authModes;
-            subject.GetCombinedAuthMode().Should().Be(AuthMode.Broker);
+            subject.CombinedAuthMode.Should().Be(AuthMode.Broker);
+        }
+
+        public void GetCombinedAuthMode_withInteractiveAuthEnabled_NonWindowsPlatform()
+        {
+            CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            var authModes = new List<AuthMode>();
+            authModes.Add(AuthMode.Web);
+            subject.AuthModes = authModes;
+            subject.CombinedAuthMode.Should().Be(AuthMode.Web);
         }
 
         /// <summary>

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -750,6 +750,7 @@ invalid_key = ""this is not a valid alias key""
             subject.InteractiveAuthDisabled().Should().BeFalse();
         }
 
+#if PlatformWindows
         [TestCase("non-empty-string")]
         [Platform("Win")] // Only valid on Windows
         public void GetCombinedAuthMode_withInteractiveAuthDisabled(string noUser)
@@ -768,6 +769,7 @@ invalid_key = ""this is not a valid alias key""
             subject.AuthModes = authModes;
             subject.CombinedAuthMode.Should().Be(AuthMode.Broker);
         }
+#endif
 
         public void GetCombinedAuthMode_withInteractiveAuthEnabled_NonWindowsPlatform()
         {

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -217,7 +217,25 @@ Allowed values: [all, web, devicecode]";
             get { return this.authSettings; }
         }
 
-        private AuthMode CombinedAuthMode => this.GetCombinedAuthMode();
+        /// <summary>
+        /// Gets the CombinedAuthMode depending on env variables to disable interactive auth modes.
+        /// </summary>
+        public AuthMode CombinedAuthMode
+        {
+            get
+            {
+                if (this.InteractiveAuthDisabled())
+                {
+#if PlatformWindows
+                    return AuthMode.IWA;
+#else
+                    return 0;
+#endif
+                }
+
+                return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
+            }
+        }
 
         /// <summary>
         /// Combine the <see cref="PromptHintPrefix"/> with the caller provided prompt hint.
@@ -232,20 +250,6 @@ Allowed values: [all, web, devicecode]";
             }
 
             return $"{PromptHintPrefix}: {promptHint}";
-        }
-
-        /// <summary>
-        /// Get the correct CombinedAuthMode depending on env variables to disable interactive auth modes.
-        /// </summary>
-        /// <returns>AuthModes.</returns>
-        public AuthMode GetCombinedAuthMode()
-        {
-            if (this.InteractiveAuthDisabled())
-            {
-                return AuthMode.IWA;
-            }
-
-            return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
         }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -217,7 +217,7 @@ Allowed values: [all, web, devicecode]";
             get { return this.authSettings; }
         }
 
-        private AuthMode CombinedAuthMode => this.AuthModes.Aggregate((a1, a2) => a1 | a2);
+        private AuthMode CombinedAuthMode => this.GetCombinedAuthMode();
 
         /// <summary>
         /// Combine the <see cref="PromptHintPrefix"/> with the caller provided prompt hint.
@@ -232,6 +232,20 @@ Allowed values: [all, web, devicecode]";
             }
 
             return $"{PromptHintPrefix}: {promptHint}";
+        }
+
+        /// <summary>
+        /// Get the correct CombinedAuthMode depending on env variables to disable interactive auth modes.
+        /// </summary>
+        /// <returns>AuthModes</returns>
+        public AuthMode GetCombinedAuthMode()
+        {
+            if (this.InteractiveAuthDisabled())
+            {
+                return AuthMode.IWA;
+            }
+
+            return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
         }
 
         /// <summary>
@@ -359,11 +373,11 @@ Allowed values: [all, web, devicecode]";
             // Small bug in Lasso - Add does not accept a null IEnumerable here.
             this.eventData.Add("settings_scopes", this.authSettings.Scopes ?? new List<string>());
 
-            if (this.PCADisabled())
+            if (this.InteractiveAuthDisabled())
             {
-                this.eventData.Add("no_user", true);
-                this.logger.LogCritical($"User based authentication is disabled");
-                return 1;
+                this.eventData.Add(EnvVars.CorextNonInteractive, this.env.Get(EnvVars.CorextNonInteractive));
+                this.eventData.Add(EnvVars.NoUser, this.env.Get(EnvVars.NoUser));
+                this.logger.LogWarning($"Interactive authentication is disabled. Supported auth mode is Integrated Windows Authentication");
             }
 
             return this.ClearCache ? this.ClearLocalCache() : this.GetToken();
@@ -373,7 +387,7 @@ Allowed values: [all, web, devicecode]";
         /// Determines whether Public Client Authentication (PCA) is disabled or not.
         /// </summary>
         /// <returns>A boolean to indicate PCA is disabled.</returns>
-        public bool PCADisabled()
+        public bool InteractiveAuthDisabled()
         {
             return !string.IsNullOrEmpty(this.env.Get(EnvVars.NoUser)) ||
                 string.Equals("1", this.env.Get(EnvVars.CorextNonInteractive));

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -237,7 +237,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Get the correct CombinedAuthMode depending on env variables to disable interactive auth modes.
         /// </summary>
-        /// <returns>AuthModes</returns>
+        /// <returns>AuthModes.</returns>
         public AuthMode GetCombinedAuthMode()
         {
             if (this.InteractiveAuthDisabled())

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -240,12 +240,17 @@ Allowed values: [all, web, devicecode]";
         /// <returns>AuthModes.</returns>
         public AuthMode GetCombinedAuthMode()
         {
+#if PlatformWindows
             if (this.InteractiveAuthDisabled())
             {
                 return AuthMode.IWA;
             }
 
             return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
+#else
+            return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
+#endif
+
         }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -240,17 +240,12 @@ Allowed values: [all, web, devicecode]";
         /// <returns>AuthModes.</returns>
         public AuthMode GetCombinedAuthMode()
         {
-#if PlatformWindows
             if (this.InteractiveAuthDisabled())
             {
                 return AuthMode.IWA;
             }
 
             return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
-#else
-            return this.AuthModes.Aggregate((a1, a2) => a1 | a2);
-#endif
-
         }
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -381,7 +381,10 @@ Allowed values: [all, web, devicecode]";
             {
                 this.eventData.Add(EnvVars.CorextNonInteractive, this.env.Get(EnvVars.CorextNonInteractive));
                 this.eventData.Add(EnvVars.NoUser, this.env.Get(EnvVars.NoUser));
-                this.logger.LogWarning($"Interactive authentication is disabled. Supported auth mode is Integrated Windows Authentication");
+                this.logger.LogWarning($"Interactive authentication is disabled.");
+#if PlatformWindows
+                this.logger.LogWarning($"Supported auth mode is Integrated Windows Authentication");
+#endif
             }
 
             return this.ClearCache ? this.ClearLocalCache() : this.GetToken();


### PR DESCRIPTION
When users set env variables to disable user interaction for auth in their automated processes, we currently disable all auth modes.
Instead, we would still need to run just IWA even if that env variable is set, since there would be no user interaction required for IWA and automated processes will be able to auth successfully.