### PR TITLE
Always set the output of AzureAuth to utf-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgrade the Windows build to use net6 now that net5 has reached end of life.
+- Set console output encoding to `utf-8` explicitly.
 
 ## [0.5.4] - 2022-09-29
 ### Fixed

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Authentication.AzureAuth
 {
     using System;
+    using System.Text;
+
     using McMaster.Extensions.CommandLineUtils;
     using Microsoft.Office.Lasso;
     using Microsoft.Office.Lasso.Telemetry;
@@ -15,6 +17,10 @@ namespace Microsoft.Authentication.AzureAuth
     {
         private static void Main(string[] args)
         {
+            // Use UTF-8 output encoding.
+            // This will impact the NLog Console Target as well as any other Console usage.
+            Console.OutputEncoding = Encoding.UTF8;
+
             CommandLineApplication app = new CommandLineApplication<CommandMain>();
 
             // We always instantiate and depend on telemetry services, but these defaults


### PR DESCRIPTION
Right now, if we try to output JSON or a status message containing Unicode characters, the JSON output can be malformed. This is an issue for some tools that use the authenticated user for got configuration. 