### PR TITLE
Use System Web Browser for Web mode to avoid cache poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Unreleased
+### Fixed
+- Use system web browser as the UI for web mode auth on Windows to prevent conditional access based over-prompting.
 
 ### Changed
 - Upgrade the Windows build to use net6 now that net5 has reached end of life.

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -153,10 +153,11 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     Identity.Client.LogLevel.Verbose,
                     enablePiiLogging: false,
                     enableDefaultPlatformLogging: true)
-                    .WithHttpClientFactory(httpFactoryAdaptor)
-                    .WithRedirectUri(Constants.AadRedirectUri.ToString());
+                .WithHttpClientFactory(httpFactoryAdaptor)
+                .WithRedirectUri(Constants.AadRedirectUri.ToString());
 
-            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix, cacheFilePath);
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix, cacheFilePath)
+                .WithSystemWebBrowser(true);
         }
 
         private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -156,8 +156,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 .WithHttpClientFactory(httpFactoryAdaptor)
                 .WithRedirectUri(Constants.AadRedirectUri.ToString());
 
-            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix, cacheFilePath)
-                .WithSystemWebBrowser(true);
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId, osxKeyChainSuffix, cacheFilePath);
         }
 
         private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)

--- a/src/MSALWrapper/IPCAWrapper.cs
+++ b/src/MSALWrapper/IPCAWrapper.cs
@@ -67,6 +67,13 @@ namespace Microsoft.Authentication.MSALWrapper
         IPCAWrapper WithPromptHint(string promptHint);
 
         /// <summary>
+        /// Enable or disable using a system web brwoser for web mode prompts.
+        /// </summary>
+        /// <param name="enabled">Whether or not to use the system web browser for web mode prompts.</param>
+        /// <returns>This.</returns>
+        IPCAWrapper WithSystemWebBrowser(bool enabled);
+
+        /// <summary>
         /// Tries to return a cached account when the list has only one account using the preferred domain if provided.
         /// A null return indicates one of the following.
         /// No accounts were found in cache.

--- a/src/MSALWrapper/IPCAWrapper.cs
+++ b/src/MSALWrapper/IPCAWrapper.cs
@@ -67,11 +67,12 @@ namespace Microsoft.Authentication.MSALWrapper
         IPCAWrapper WithPromptHint(string promptHint);
 
         /// <summary>
-        /// Enable or disable using a system web brwoser for web mode prompts.
+        /// Enable or disable using an embedded web view for web mode prompts.
+        /// Embedded web view is inherently unreliable for passing CA conditions and is off by default.
         /// </summary>
-        /// <param name="enabled">Whether or not to use the system web browser for web mode prompts.</param>
+        /// <param name="enabled">Whether or not to use the embedded web view for web mode prompts.</param>
         /// <returns>This.</returns>
-        IPCAWrapper WithSystemWebBrowser(bool enabled);
+        IPCAWrapper WithEmbeddedWebView(bool enabled);
 
         /// <summary>
         /// Tries to return a cached account when the list has only one account using the preferred domain if provided.

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -59,9 +59,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <summary>
         /// Gets a value indicating whether or not to use the system web browser for web mode prompts. Default: false.
         /// </summary>
-        public bool UseSystemWebBrowser { get; private set; } = false;
-
-        private bool UseEmbeddedWebView => !this.UseSystemWebBrowser;
+        public bool UseEmbeddedWebView { get; private set; } = false;
 
         /// <inheritdoc/>
         public IPCAWrapper WithPromptHint(string promptHint)
@@ -71,9 +69,9 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <inheritdoc/>
-        public IPCAWrapper WithSystemWebBrowser(bool enabled)
+        public IPCAWrapper WithEmbeddedWebView(bool enabled)
         {
-            this.UseSystemWebBrowser = enabled;
+            this.UseEmbeddedWebView = enabled;
             return this;
         }
 

--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Authentication.MSALWrapper
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
     using Microsoft.IdentityModel.JsonWebTokens;
@@ -51,14 +52,28 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
-        /// Gets or sets, The prompt hint displayed in the title bar.
+        /// Gets or sets the prompt hint displayed in the title bar.
         /// </summary>
         public string PromptHint { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to use the system web browser for web mode prompts. Default: false.
+        /// </summary>
+        public bool UseSystemWebBrowser { get; private set; } = false;
+
+        private bool UseEmbeddedWebView => !this.UseSystemWebBrowser;
 
         /// <inheritdoc/>
         public IPCAWrapper WithPromptHint(string promptHint)
         {
             this.PromptHint = promptHint;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IPCAWrapper WithSystemWebBrowser(bool enabled)
+        {
+            this.UseSystemWebBrowser = enabled;
             return this;
         }
 
@@ -78,6 +93,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 {
                     Title = this.PromptHint,
                 })
+                .WithUseEmbeddedWebView(this.UseEmbeddedWebView)
                 .WithAccount(account)
                 .ExecuteAsync(cancellationToken)
                 .ConfigureAwait(false);
@@ -93,6 +109,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 {
                     Title = this.PromptHint,
                 })
+                .WithUseEmbeddedWebView(this.UseEmbeddedWebView)
                 .WithClaims(claims)
                 .ExecuteAsync(cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
With the build system using AzureAuth directly the last source of cache poisoning is using web mode when pre-warming ado auth for Nuget. We can avoid cache poisoning by going back to system web browser when web auth is needed. Falling back to web should rarely happen now that IWA and broker are both used before web. By using system web browser instead of embedded web view - we won't risk cache poisoning since the system web browser should always be able to pass the device management CA policy properly. 

This does mean that the prompt hint will not show if being prompted with the web browser. Which is tragic. But we also expect to see it far less.