### PR TITLE
Handling invalid AZUREAUTH_CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 ### Fixed
 - Use system web browser as the UI for web mode auth on Windows to prevent conditional access based over-prompting.
+- Catch `FileNotFoundException` if an invalid configuration file is specified via the `AZUREAUTH_CONFIG` environment variable.
 
 ### Changed
 - Upgrade the Windows build to use net6 now that net5 has reached end of life.

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -263,6 +263,26 @@ invalid_key = ""this is not a valid alias key""
         }
 
         /// <summary>
+        ///  The test to evaluate options when config file does not exist.
+        /// </summary>
+        [Test]
+        public void TestEvaluateOptionsConfigFileDoesNotExist()
+        {
+            string configFile = RootPath("does_not_exists_config.toml");
+
+            CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            subject.AliasName = "contoso";
+            subject.ConfigFilePath = null;
+
+            // Specify config via env var
+            this.envMock.Setup(e => e.Get("AZUREAUTH_CONFIG")).Returns(configFile);
+
+            subject.EvaluateOptions().Should().BeFalse();
+            this.logTarget.Logs.Should().ContainMatch($"The file '{configFile}' does not exist.*");
+            this.envMock.Verify();
+        }
+
+        /// <summary>
         /// The test to evaluate options provided invalid alias.
         /// </summary>
         [Test]

--- a/src/AzureAuth.Test/CommandMainTest.cs
+++ b/src/AzureAuth.Test/CommandMainTest.cs
@@ -87,9 +87,6 @@ invalid_key = ""this is not a valid alias key""
             this.telemetryServiceMock = new Mock<ITelemetryService>(MockBehavior.Strict);
             this.authFlowMock = new Mock<IAuthFlow>(MockBehavior.Strict);
 
-            // Environment variables should be null by default.
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-
             // Setup Dependency Injection container to provide logger and out class under test (the "subject").
             this.serviceProvider = new ServiceCollection()
                 .AddLogging(loggingBuilder =>
@@ -163,6 +160,7 @@ invalid_key = ""this is not a valid alias key""
         {
             string configFile = RootPath("complete.toml");
             this.fileSystem.File.WriteAllText(configFile, CompleteAliasTOML);
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
             Alias expected = new Alias
             {
                 Resource = "67eeda51-3891-4101-a0e3-bf0c64047157",
@@ -204,6 +202,8 @@ invalid_key = ""this is not a valid alias key""
             subject.AliasName = "contoso";
             subject.ConfigFilePath = configFile;
 
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+
             // Specify a client override on the command line.
             subject.Client = clientOverride;
 
@@ -220,6 +220,7 @@ invalid_key = ""this is not a valid alias key""
             string configFile = RootPath("complete.toml");
             string clientOverride = "3933d919-5ba4-4eb7-b4b1-19d33e8b82c0";
             this.fileSystem.File.WriteAllText(configFile, CompleteAliasTOML);
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
             Alias expected = new Alias
             {
                 Resource = "67eeda51-3891-4101-a0e3-bf0c64047157",
@@ -279,7 +280,7 @@ invalid_key = ""this is not a valid alias key""
 
             subject.EvaluateOptions().Should().BeFalse();
             this.logTarget.Logs.Should().ContainMatch($"The file '{configFile}' does not exist.*");
-            this.envMock.Verify();
+            this.envMock.VerifyAll();
         }
 
         /// <summary>
@@ -309,6 +310,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = null;
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeFalse();
             this.logTarget.Logs.Should().Contain("The --resource field or the --scope field is required.");
@@ -324,6 +326,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = null;
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeFalse();
             this.logTarget.Logs.Should().Contain("The --client field is required.");
@@ -339,6 +342,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = null;
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeFalse();
             this.logTarget.Logs.Should().Contain("The --tenant field is required.");
@@ -354,6 +358,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = null;
             subject.Client = null;
             subject.Tenant = null;
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeFalse();
             this.logTarget.Logs.Should().Contain(new[]
@@ -375,6 +380,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
             subject.Scopes = new string[] { "f0e8d801-3a50-48fd-b2da-6476d6e832a2/.default" };
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeTrue();
         }
@@ -389,6 +395,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeTrue();
         }
@@ -404,6 +411,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
             subject.Scopes = new string[] { "f0e8d801-3a50-48fd-b2da-6476d6e832a2/.default" };
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeTrue();
             this.logTarget.Logs.Should().Contain(new[]
@@ -431,6 +439,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeTrue();
             subject.TokenFetcherOptions.Should().BeEquivalentTo(expected);
@@ -527,6 +536,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             subject.EvaluateOptions().Should().BeTrue();
 
@@ -549,6 +559,7 @@ invalid_key = ""this is not a valid alias key""
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
             subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
             subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             string path = "..\\test\\relative.cache";
             subject.CacheFilePath = path;
@@ -657,6 +668,7 @@ invalid_key = ""this is not a valid alias key""
             this.telemetryServiceMock.Setup(s => s.SendEvent("authflow_Sample", It.IsAny<EventData>()));
 
             var subject = this.serviceProvider.GetService<CommandMain>();
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
 
             // mock valid args
             subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
@@ -748,6 +760,7 @@ invalid_key = ""this is not a valid alias key""
         public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
             this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
             subject.InteractiveAuthDisabled().Should().Be(expected);
         }
@@ -759,6 +772,7 @@ invalid_key = ""this is not a valid alias key""
         public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
             this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
             subject.InteractiveAuthDisabled().Should().Be(expected);
         }
@@ -767,6 +781,7 @@ invalid_key = ""this is not a valid alias key""
         public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
         {
             CommandMain subject = this.serviceProvider.GetService<CommandMain>();
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
             subject.InteractiveAuthDisabled().Should().BeFalse();
         }
 

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -172,7 +172,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets global Timeout.
         /// </summary>
-        [Option(TimeoutOption, "The number of minutes before authentication times out.\nDefault: 15 minutes.", CommandOptionType.SingleValue)]
+        [Option(TimeoutOption, "The number of minutes before authentication times out.\nDefault: 10 minutes.", CommandOptionType.SingleValue)]
         public double Timeout { get; set; } = GlobalTimeout.TotalMinutes;
 
         /// <summary>

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -339,6 +339,11 @@ Allowed values: [all, web, devicecode]";
                     Alias configFileOptions = config.Alias[this.AliasName];
                     evaluatedOptions = configFileOptions.Override(evaluatedOptions);
                 }
+                catch (System.IO.FileNotFoundException)
+                {
+                    this.logger.LogError($"The file '{fullConfigPath}' does not exist.");
+                    return false;
+                }
                 catch (Tomlyn.TomlException ex)
                 {
                     this.logger.LogError($"Error parsing TOML in config file at '{fullConfigPath}':\n{ex.Message}");

--- a/src/AzureAuth/CommandMain.cs
+++ b/src/AzureAuth/CommandMain.cs
@@ -172,7 +172,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets global Timeout.
         /// </summary>
-        [Option(TimeoutOption, "The number of minutes before authentication times out.\nDefault: 10 minutes.", CommandOptionType.SingleValue)]
+        [Option(TimeoutOption, "The number of minutes before authentication times out.\nDefault: 15 minutes.", CommandOptionType.SingleValue)]
         public double Timeout { get; set; } = GlobalTimeout.TotalMinutes;
 
         /// <summary>


### PR DESCRIPTION
If an invalid configuration file is specified via the `AZUREAUTH_CONFIG` environment variable, then the user is given a stack trace. In contrast, if the `--config` flag is used then the user gets a proper message which says "The file '<filename>.toml' does not exist.". This is because the config flag is checked and the error is handled with [FileExists] options check, while if we use `AZUREAUTH_CONFIG` environment variable, we have to specifically catch that error.

Adding a catch statement to make sure we catch `FileNotFound` exception and provide similar experience.

Also added a test case to verify the code works as expected.
