### PR TITLE
Remove setx and use WM_SETTINGCHANGE in install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Unreleased
+### Fixed
+- Remove `setx` usage and use `WM_SETTINGCHANGE` in the install script to prevent truncating `$PATH`.
+
 ## [0.6.0] - 2022-10-26
 ### Fixed
 - Use system web browser as the UI for web mode auth on Windows to prevent conditional access based over-prompting.


### PR DESCRIPTION
Bug fix for https://github.com/AzureAD/microsoft-authentication-cli/issues/166

`setx` truncated the `$PATH` when its size exceeded 1024 chars. As we always append azureauth installation, we were able to repro and catch the bug with install script using `setx`.

As a solution, I am removing the use of `setx` and using WM_SETTINGCHANGE to notify about environment variable changes.

Testing:
Test 1:
1. Remove any AzureAuth installations.
2. Put random values in PATH env var to increase size to 1024. 
3. Run modified install script in Powershell and verify that AzureAuth new version is appended to the PATH and not truncated.

Test2:
1. Follow first 2 steps of Test1.
2. Open `cmd.exe`. Run the install script.
3. Open new cmd.exe and verify that all new processes are notified of the env var change and that azureauth is usable.
