### PR TITLE
Remove paths filter for dotnet-test workflow

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3,11 +3,6 @@ name: Build and Test
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - '.github/**'
-      - 'src/**'
-      - '**.sln'
-      - 'nuget.config'
 
 jobs:
   test:


### PR DESCRIPTION
We have set the workflows associated with this workflow file to be required for all PRs. This is the only way I can find to catch bugs introduced into the CI itself (because if you break the YAML, the workflow simply won't trigger and run), so the PR will appear green, because nothing actually ran, so nothing failed. 