### PR TITLE
Add unlit Azure DevOps PAT client classes

### DIFF
--- a/AzureAuth.sln
+++ b/AzureAuth.sln
@@ -127,8 +127,4 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {300B60CB-A1FB-41B1-BA81-F0FC2531E039}
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{4FDAE313-5BBD-4727-B67E-386A55C80C43} = {67705534-47DF-4B40-BEE1-F81B60EF3A28}
-		{D49B2FCE-2112-4071-A2AD-8979499B1D4D} = {E5760F6A-FB4E-47F1-B53A-F87EF8468C81}
-	EndGlobalSection
 EndGlobal

--- a/AzureAuth.sln
+++ b/AzureAuth.sln
@@ -22,6 +22,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{8ECA01
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSALWrapper.Benchmark", "src\MSALWrapper.Benchmark\MSALWrapper.Benchmark.csproj", "{22778DA9-2246-42D8-A6C4-6DA8E0D7638E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdoPat", "src\AdoPat\AdoPat.csproj", "{4FDAE313-5BBD-4727-B67E-386A55C80C43}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdoPat.Test", "src\AdoPat.Test\AdoPat.Test.csproj", "{D49B2FCE-2112-4071-A2AD-8979499B1D4D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,11 +96,39 @@ Global
 		{22778DA9-2246-42D8-A6C4-6DA8E0D7638E}.Release|x64.Build.0 = Release|Any CPU
 		{22778DA9-2246-42D8-A6C4-6DA8E0D7638E}.Release|x86.ActiveCfg = Release|Any CPU
 		{22778DA9-2246-42D8-A6C4-6DA8E0D7638E}.Release|x86.Build.0 = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|x64.Build.0 = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43}.Release|x86.Build.0 = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|x64.Build.0 = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Debug|x86.Build.0 = Debug|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x64.ActiveCfg = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x64.Build.0 = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x86.ActiveCfg = Release|Any CPU
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {300B60CB-A1FB-41B1-BA81-F0FC2531E039}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4FDAE313-5BBD-4727-B67E-386A55C80C43} = {67705534-47DF-4B40-BEE1-F81B60EF3A28}
+		{D49B2FCE-2112-4071-A2AD-8979499B1D4D} = {E5760F6A-FB4E-47F1-B53A-F87EF8468C81}
 	EndGlobalSection
 EndGlobal

--- a/src/AdoPat.Test/AdoPat.Test.csproj
+++ b/src/AdoPat.Test/AdoPat.Test.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <!-- Stylecop warnings as errors flag for build to fail -->
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Stylecop required items -->
+    <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
+      <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+      <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AdoPat\AdoPat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var regeneratedPat = await patClient.RegeneratePatAsync(patToken, regeneratedValidTo);
 
             // Assert
+            client.VerifyAll();
             regeneratedPat.Should().BeEquivalentTo(expectedToken);
         }
 

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Authentication.AdoPat.Test
         }
 
         [Test]
-        public async Task GetActivePatsAsync_ReturnsEmptySetWithNoResults()
+        public async Task GetActivePatsAsync_ReturnsEmptyDictionaryWithNoResults()
         {
             // Arrange
             var emptyPage = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken> { });
-            var expectedTokens = new HashSet<PatToken>();
+            var expectedTokens = new Dictionary<Guid, PatToken>();
 
             var client = new Mock<ITokensHttpClientWrapper>(MockBehavior.Strict);
             client.Setup(c => c.ListPatsAsync(
@@ -101,14 +101,14 @@ namespace Microsoft.Authentication.AdoPat.Test
         }
 
         [Test]
-        public async Task GetActivePatsAsync_ReturnsSetWithAllPages()
+        public async Task GetActivePatsAsync_ReturnsDictionaryWithAllPages()
         {
             // Arrange
-            var pat1 = new PatToken { DisplayName = "PAT 1" };
-            var pat2 = new PatToken { DisplayName = "PAT 2" };
+            var pat1 = new PatToken { AuthorizationId = new Guid("8e510ed2-f485-4dfb-963c-bbaa30d60ba0"), DisplayName = "PAT 1" };
+            var pat2 = new PatToken { AuthorizationId = new Guid("40ba0030-1dad-4bbe-82c5-8c49266d4e1d"), DisplayName = "PAT 2" };
             var page1 = new PagedPatTokens(continuationToken: "Page 1", patTokens: new List<PatToken> { pat1 });
             var page2 = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken> { pat2 });
-            var expectedTokens = new HashSet<PatToken>() { pat1, pat2 };
+            var expectedTokens = new Dictionary<Guid, PatToken>() { { pat1.AuthorizationId, pat1 }, { pat2.AuthorizationId, pat2 } };
 
             var client = new Mock<ITokensHttpClientWrapper>(MockBehavior.Strict);
             client.SetupSequence(c => c.ListPatsAsync(

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Authentication.AdoPat.Test
 
             // Assert
             await act.Should().ThrowAsync<PatClientException>()
-                .WithMessage("Failed to create PAT during regeneration: InvalidAuthorizationId");
+                .WithMessage("Failed to create PAT: InvalidAuthorizationId");
         }
     }
 }

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+    using Moq;
+    using NUnit.Framework;
+
+    public class PatClientTest
+    {
+        [Test]
+        public async Task CreatePatAsync()
+        {
+            // Arrange
+            var displayName = "Test PAT";
+            var scope = "test.scope";
+            var validTo = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var allOrgs = false;
+            var patTokenCreateRequest = new PatTokenCreateRequest
+            {
+                DisplayName = displayName,
+                Scope = scope,
+                ValidTo = validTo,
+                AllOrgs = allOrgs,
+            };
+            var patToken = new PatToken
+            {
+                DisplayName = displayName,
+                Scope = scope,
+                TargetAccounts = new List<Guid> { new Guid("b7b59161-cd70-46e9-aca5-883f24060eb1") },
+                ValidTo = validTo,
+                ValidFrom = DateTime.UtcNow,
+                AuthorizationId = new Guid("ee0c5586-a96f-4a44-b1d9-8613028b1078"),
+                Token = "A real token would be much, much longer.",
+            };
+            var expectedResult = new PatTokenResult { PatToken = patToken, PatTokenError = SessionTokenError.None };
+
+            var client = new Mock<ITokensHttpClientProvider>(MockBehavior.Strict);
+            client.Setup(thcp => thcp.CreatePatAsync(
+                It.IsAny<PatTokenCreateRequest>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+            var patClient = new PatClient(client.Object);
+
+            // Act
+            var patTokenResult = await patClient.CreatePatAsync(patTokenCreateRequest);
+
+            // Assert
+            patTokenResult.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Test]
+        public async Task GetActivePatsAsync_ReturnsEmptySetWithNoResults()
+        {
+            // Arrange
+            var emptyPage = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken> { });
+            var expectedTokens = new HashSet<PatToken>();
+
+            var client = new Mock<ITokensHttpClientProvider>(MockBehavior.Strict);
+            client.SetupSequence(thcp => thcp.ListPatsAsync(
+                It.IsAny<DisplayFilterOptions?>(),
+                It.IsAny<SortByOptions?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<string>(),
+                It.IsAny<int?>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyPage);
+
+            var patClient = new PatClient(client.Object);
+
+            // Act
+            var activePats = await patClient.GetActivePatsAsync();
+
+            // Assert
+            activePats.Should().BeEquivalentTo(expectedTokens);
+        }
+
+        [Test]
+        public async Task GetActivePatsAsync_ReturnsSetWithAllPages()
+        {
+            // Arrange
+            var pat1 = new PatToken { DisplayName = "PAT 1" };
+            var pat2 = new PatToken { DisplayName = "PAT 2" };
+            var page1 = new PagedPatTokens(continuationToken: "Page 1", patTokens: new List<PatToken> { pat1 });
+            var page2 = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken> { pat2 });
+            var expectedTokens = new HashSet<PatToken>() { pat1, pat2 };
+
+            var client = new Mock<ITokensHttpClientProvider>(MockBehavior.Strict);
+            client.SetupSequence(thcp => thcp.ListPatsAsync(
+                It.IsAny<DisplayFilterOptions?>(),
+                It.IsAny<SortByOptions?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<string>(),
+                It.IsAny<int?>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page1)
+            .ReturnsAsync(page2);
+
+            var patClient = new PatClient(client.Object);
+
+            // Act
+            var activePats = await patClient.GetActivePatsAsync();
+
+            // Assert
+            activePats.Should().BeEquivalentTo(expectedTokens);
+        }
+    }
+}

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -4,8 +4,6 @@
     <PackageId>Microsoft.Authentication.AdoPat</PackageId>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.Authentication.AdoPat</RootNamespace>
-    <!-- TODO? <ImplicitUsings>enable</ImplicitUsings> -->
-    <!-- TODO? <Nullable>enable</Nullable> -->
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Authentication.AdoPat</PackageId>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <RootNamespace>Microsoft.Authentication.AdoPat</RootNamespace>
+    <!-- TODO? <ImplicitUsings>enable</ImplicitUsings> -->
+    <!-- TODO? <Nullable>enable</Nullable> -->
+  </PropertyGroup>
+
+    <ItemGroup>
+    <!-- Stylecop required items -->
+    <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
+    <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.212.0-preview" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Authentication.AdoPat</PackageId>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.Authentication.AdoPat</RootNamespace>
     <!-- TODO? <ImplicitUsings>enable</ImplicitUsings> -->
     <!-- TODO? <Nullable>enable</Nullable> -->

--- a/src/AdoPat/ITokensHttpClientProvider.cs
+++ b/src/AdoPat/ITokensHttpClientProvider.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+    /// <summary>
+    /// TODO.
+    /// </summary>
+    public interface ITokensHttpClientProvider
+    {
+        /// <summary>
+        /// [Preview API] Creates a new personal access token (PAT) for the requesting user.
+        /// </summary>
+        /// <param name="patTokenCreateRequest">(Undocumented).</param>
+        /// <param name="userState">(Undocumented).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
+        Task<PatTokenResult> CreatePatAsync(
+            PatTokenCreateRequest patTokenCreateRequest,
+            object userState = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///  [Preview API] Gets a paged list of personal access tokens (PATs) created in this organization. Subsequent calls to the API require the same filtering options to be supplied.
+        /// </summary>
+        /// <param name="displayFilterOption">(Optional) Refers to the status of the personal access token (PAT).</param>
+        /// <param name="sortByOption">(Optional) Which field to sort by.</param>
+        /// <param name="isSortAscending">(Optional) Ascending or descending.</param>
+        /// <param name="continuationToken">(Optional) Where to start returning tokens from.</param>
+        /// <param name="top">(Optional) How many tokens to return, limit of 100.</param>
+        /// <param name="userState">(Undocumented).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="Task"/> with <see cref="PagedPatTokens"/>.</returns>
+        Task<PagedPatTokens> ListPatsAsync(
+            DisplayFilterOptions? displayFilterOption = null,
+            SortByOptions? sortByOption = null,
+            bool? isSortAscending = null,
+            string continuationToken = null,
+            int? top = null,
+            object userState = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// TODO.
+        /// </summary>
+        /// <param name="authorizationId">The authorizationId identifying a single, unique personal access token (PAT).</param>
+        /// <param name="userState">(Undocumented).</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>Void.</returns>
+        // Task RevokeAsync(
+        //    Guid authorizationId,
+        //    object userState = null,
+        //    CancellationToken cancellationToken = default);
+    }
+}

--- a/src/AdoPat/ITokensHttpClientWrapper.cs
+++ b/src/AdoPat/ITokensHttpClientWrapper.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Authentication.AdoPat
     using Microsoft.VisualStudio.Services.DelegatedAuthorization;
 
     /// <summary>
-    /// TODO.
+    /// An interface for a transparent wrapper of <see cref="TokensHttpClient"/>.
     /// </summary>
-    public interface ITokensHttpClientProvider
+    public interface ITokensHttpClientWrapper
     {
         /// <summary>
         /// [Preview API] Creates a new personal access token (PAT) for the requesting user.
@@ -52,9 +52,9 @@ namespace Microsoft.Authentication.AdoPat
         /// <param name="userState">(Undocumented).</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>Void.</returns>
-        // Task RevokeAsync(
-        //    Guid authorizationId,
-        //    object userState = null,
-        //    CancellationToken cancellationToken = default);
+        Task RevokeAsync(
+            Guid authorizationId,
+            object userState = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/AdoPat/ITokensHttpClientWrapper.cs
+++ b/src/AdoPat/ITokensHttpClientWrapper.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Authentication.AdoPat
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// TODO.
+        /// [Preview API] Revokes a personal access token (PAT) by authorizationId.
         /// </summary>
         /// <param name="authorizationId">The authorizationId identifying a single, unique personal access token (PAT).</param>
         /// <param name="userState">(Undocumented).</param>

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Authentication.AdoPat
 
             if (patTokenResult.PatToken == null)
             {
-                throw new PatClientException($"Failed to create PAT during regeneration: {patTokenResult.PatTokenError}");
+                throw new PatClientException($"Failed to create PAT: {patTokenResult.PatTokenError}");
             }
 
             return patTokenResult.PatToken;

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -15,7 +15,11 @@ namespace Microsoft.Authentication.AdoPat
     public class PatClient
     {
         private const int PageSize = 100; // Using the maximum allowable page size allows us to reduce HTTP calls.
-        private const bool AllOrgs = false; // Azure DevOps have recommended we always set this to false.
+
+        // The AllOrgs field controls whether a PAT token create request is for all of a user's accessible organizations.
+        // The default of false means that the token is for a specific organization. The Azure DevOps team have
+        // recommended we always set this to false.
+        private const bool AllOrgs = false;
 
         private ITokensHttpClientWrapper client;
 

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -3,56 +3,74 @@
 
 namespace Microsoft.Authentication.AdoPat
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Services.DelegatedAuthorization;
 
     /// <summary>
-    /// TODO.
+    /// An abstraction over common operations with the Azure DevOps PAT Lifecycle Management REST API.
     /// </summary>
     public class PatClient
     {
-        private ITokensHttpClientProvider client;
-        private int pageSize = 100;
+        private const int PageSize = 100; // Using the maximum allowable page size allows us to reduce HTTP calls.
+        private const bool AllOrgs = false; // Azure DevOps have recommended we always set this to false.
+
+        private ITokensHttpClientWrapper client;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PatClient"/> class.
         /// </summary>
-        /// <param name="client">TODO.</param>
-        public PatClient(ITokensHttpClientProvider client)
+        /// <param name="client">Any class which implements the <see cref="ITokensHttpClientWrapper"/> interface.</param>
+        public PatClient(ITokensHttpClientWrapper client)
         {
             this.client = client;
         }
 
         /// <summary>
-        /// TODO: Summarize this method. Should we actually return PatTokenResults and take PatTokenCreateRequests or use our own types.
+        /// Creates a new PAT.
         /// </summary>
-        /// <param name="patTokenCreateRequest">(Undocumented).</param>
-        /// <param name="userState">Undocumented.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <param name="patTokenCreateRequest">
+        /// XXX: Not documented by Visual Studio client libraries. Should we depend on this or
+        /// should this method use the corresponding primitives as arguments? Not yet clear.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
-        public async Task<PatTokenResult> CreatePatAsync(PatTokenCreateRequest patTokenCreateRequest, object userState = null, CancellationToken cancellationToken = default)
+        public async Task<PatToken> CreatePatAsync(
+            PatTokenCreateRequest patTokenCreateRequest,
+            CancellationToken cancellationToken = default)
         {
-            return await this.client.CreatePatAsync(patTokenCreateRequest, userState, cancellationToken).ConfigureAwait(false);
+            var patTokenResult = await this.client.CreatePatAsync(
+                patTokenCreateRequest,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+            if (patTokenResult.PatToken == null)
+            {
+                throw new PatClientException($"Failed to create PAT during regeneration: {patTokenResult.PatTokenError}");
+            }
+
+            return patTokenResult.PatToken;
         }
 
         /// <summary>
-        /// TODO: It might be better to yield results one page at a time instead of collecting them all up into a set.
+        /// Gets all active PATs.
         /// </summary>
-        /// <param name="cancellationToken">Foo.</param>
-        /// <returns>Bar.</returns>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>The set of active PATs.</returns>
         public async Task<ISet<PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
         {
             // Initialize a PagedPatTokens so that we can use the continuation token
-            // in the scope of the conditional of the do while loop below.
+            // in the scope of the conditional of the do while loop below. Azure
+            // DevOps will return the empty string when there are no more pages.
             var pagedPatTokens = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken>());
             var pats = new HashSet<PatToken>();
             do
             {
                 pagedPatTokens = await this.client.ListPatsAsync(
                     displayFilterOption: DisplayFilterOptions.Active,
-                    top: this.pageSize,
+                    top: PageSize,
                     continuationToken: pagedPatTokens.ContinuationToken,
                     sortByOption: SortByOptions.DisplayDate,
                     cancellationToken: cancellationToken)
@@ -66,6 +84,56 @@ namespace Microsoft.Authentication.AdoPat
             while (!string.IsNullOrEmpty(pagedPatTokens.ContinuationToken));
 
             return pats;
+        }
+
+        /// <summary>
+        /// Creates a new PAT with a new 'valid to' date by replicating an existing one.
+        /// </summary>
+        /// <param name="patToken">An existing <see cref="PatToken"/>.</param>
+        /// <param name="validTo">The new expiration date for the regenerated token.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A <see cref="Task"/> returning a <see cref="PatToken"/>.</returns>
+        public async Task<PatToken> RegeneratePatAsync(
+            PatToken patToken,
+            DateTime validTo,
+            CancellationToken cancellationToken = default)
+        {
+            // Regeneration is an option for existing PATs in the Azure DevOps UI,
+            // but from the API's viewpoint it is an abstraction over 3 operations.
+            //
+            // 1. Understand the metadata of the PAT using a GET call.
+            // 2. Create a new PAT with the old PAT's metadata using a POST call.
+            // 3. Revoke the old PAT using a DELETE call.
+            //
+            // We skip the initial GET call because the given patToken should have
+            // its own metadata. It risks being out of date depending on where it
+            // was fetched from.
+            //
+            // For more info see:
+            // https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-personal-access-tokens-via-api?view=azure-devops#q-how-can-i-regeneraterotate-pats-through-the-api-i-saw-that-option-in-the-ui-but-i-dont-see-a-similar-method-in-the-api
+            PatTokenCreateRequest patTokenCreateRequest = new PatTokenCreateRequest
+            {
+                DisplayName = patToken.DisplayName,
+                Scope = patToken.Scope,
+                ValidTo = validTo,
+                AllOrgs = AllOrgs,
+            };
+
+            var renewedPatToken = await this.CreatePatAsync(
+                patTokenCreateRequest,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+            // XXX: If we create a new PAT, but fail to revoke the old PAT, should
+            // we continue or should we try to undo the creation and bail? It's
+            // possible this could fail because the token has already been revoked.
+            // Is that an error we should allow?
+            await this.client.RevokeAsync(
+                patToken.AuthorizationId,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+            return renewedPatToken;
         }
     }
 }

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+    /// <summary>
+    /// TODO.
+    /// </summary>
+    public class PatClient
+    {
+        private ITokensHttpClientProvider client;
+        private int pageSize = 100;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatClient"/> class.
+        /// </summary>
+        /// <param name="client">TODO.</param>
+        public PatClient(ITokensHttpClientProvider client)
+        {
+            this.client = client;
+        }
+
+        /// <summary>
+        /// TODO: Summarize this method. Should we actually return PatTokenResults and take PatTokenCreateRequests or use our own types.
+        /// </summary>
+        /// <param name="patTokenCreateRequest">(Undocumented).</param>
+        /// <param name="userState">Undocumented.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
+        public async Task<PatTokenResult> CreatePatAsync(PatTokenCreateRequest patTokenCreateRequest, object userState = null, CancellationToken cancellationToken = default)
+        {
+            return await this.client.CreatePatAsync(patTokenCreateRequest, userState, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// TODO: It might be better to yield results one page at a time instead of collecting them all up into a set.
+        /// </summary>
+        /// <param name="cancellationToken">Foo.</param>
+        /// <returns>Bar.</returns>
+        public async Task<ISet<PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
+        {
+            // Initialize a PagedPatTokens so that we can use the continuation token
+            // in the scope of the conditional of the do while loop below.
+            var pagedPatTokens = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken>());
+            var pats = new HashSet<PatToken>();
+            do
+            {
+                pagedPatTokens = await this.client.ListPatsAsync(
+                    displayFilterOption: DisplayFilterOptions.Active,
+                    top: this.pageSize,
+                    continuationToken: pagedPatTokens.ContinuationToken,
+                    sortByOption: SortByOptions.DisplayDate,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+                foreach (PatToken pat in pagedPatTokens.PatTokens)
+                {
+                    pats.Add(pat);
+                }
+            }
+            while (!string.IsNullOrEmpty(pagedPatTokens.ContinuationToken));
+
+            return pats;
+        }
+    }
+}

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -62,14 +62,14 @@ namespace Microsoft.Authentication.AdoPat
         /// Gets all active PATs.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>The set of active PATs.</returns>
-        public async Task<ISet<PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
+        /// <returns>A mapping of authorization ID to active PATs.</returns>
+        public async Task<IDictionary<Guid, PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
         {
             // Initialize a PagedPatTokens so that we can use the continuation token
             // in the scope of the conditional of the do while loop below. Azure
             // DevOps will return the empty string when there are no more pages.
             var pagedPatTokens = new PagedPatTokens(continuationToken: string.Empty, patTokens: new List<PatToken>());
-            var pats = new HashSet<PatToken>();
+            var pats = new Dictionary<Guid, PatToken>();
             do
             {
                 pagedPatTokens = await this.client.ListPatsAsync(
@@ -82,7 +82,7 @@ namespace Microsoft.Authentication.AdoPat
 
                 foreach (PatToken pat in pagedPatTokens.PatTokens)
                 {
-                    pats.Add(pat);
+                    pats.Add(pat.AuthorizationId, pat);
                 }
             }
             while (!string.IsNullOrEmpty(pagedPatTokens.ContinuationToken));

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -35,10 +35,7 @@ namespace Microsoft.Authentication.AdoPat
         /// <summary>
         /// Creates a new PAT.
         /// </summary>
-        /// <param name="patTokenCreateRequest">
-        /// XXX: Not documented by Visual Studio client libraries. Should we depend on this or
-        /// should this method use the corresponding primitives as arguments? Not yet clear.
-        /// </param>
+        /// <param name="patTokenCreateRequest">The PAT creation request.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
         public async Task<PatToken> CreatePatAsync(
@@ -128,10 +125,8 @@ namespace Microsoft.Authentication.AdoPat
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-            // XXX: If we create a new PAT, but fail to revoke the old PAT, should
-            // we continue or should we try to undo the creation and bail? It's
-            // possible this could fail because the token has already been revoked.
-            // Is that an error we should allow?
+            // Note: This method will not try to undo creation of a PAT if the
+            // revocation fails.
             await this.client.RevokeAsync(
                 patToken.AuthorizationId,
                 cancellationToken: cancellationToken)

--- a/src/AdoPat/PatClientException.cs
+++ b/src/AdoPat/PatClientException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Authentication.AdoPat
 {
     using System;

--- a/src/AdoPat/PatClientException.cs
+++ b/src/AdoPat/PatClientException.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.Authentication.AdoPat
+{
+    using System;
+
+    /// <summary>
+    /// PAT client exception.
+    /// </summary>
+    public class PatClientException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatClientException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public PatClientException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/AdoPat/TokensHttpClientWrapper.cs
+++ b/src/AdoPat/TokensHttpClientWrapper.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Authentication.AdoPat
             object userState = null,
             CancellationToken cancellationToken = default)
         {
-            await this.RevokeAsync(
+            await this.client.RevokeAsync(
                 authorizationId,
                 userState,
                 cancellationToken)

--- a/src/AdoPat/TokensHttpClientWrapper.cs
+++ b/src/AdoPat/TokensHttpClientWrapper.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization.Client;
+    using Microsoft.VisualStudio.Services.WebApi;
+
+    /// <summary>
+    /// A thin wrapper around a <see cref="TokensHttpClient"/> that implements the <see cref="ITokensHttpClientWrapper"/> interface.
+    /// </summary>
+    public class TokensHttpClientWrapper : ITokensHttpClientWrapper
+    {
+        private TokensHttpClient client;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokensHttpClientWrapper"/> class.
+        /// </summary>
+        /// <param name="connection">An instance of <see cref="VssConnection"/>.</param>
+        public TokensHttpClientWrapper(VssConnection connection)
+        {
+            this.client = connection.GetClient<TokensHttpClient>();
+        }
+
+        /// <inheritdoc/>
+        public async Task<PatTokenResult> CreatePatAsync(
+            PatTokenCreateRequest patTokenCreateRequest,
+            object userState = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await this.client.CreatePatAsync(
+                patTokenCreateRequest,
+                userState,
+                cancellationToken)
+            .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<PagedPatTokens> ListPatsAsync(
+            DisplayFilterOptions? displayFilterOption = null,
+            SortByOptions? sortByOption = null,
+            bool? isSortAscending = null,
+            string continuationToken = null,
+            int? top = null,
+            object userState = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await this.client.ListPatsAsync(
+                displayFilterOption,
+                sortByOption,
+                isSortAscending,
+                continuationToken,
+                top,
+                userState,
+                cancellationToken)
+            .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task RevokeAsync(
+            Guid authorizationId,
+            object userState = null,
+            CancellationToken cancellationToken = default)
+        {
+            await this.RevokeAsync(
+                authorizationId,
+                userState,
+                cancellationToken)
+            .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/stylecop/GlobalSuppressions.cs
+++ b/src/stylecop/GlobalSuppressions.cs
@@ -8,3 +8,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "We might want to keep a few different classes in a single file if it's not length. Doing this specifically to by-pass Exceptions.cs file.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "This is just an unnescessary mandate.")]
 [assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Internal fields are needed for tests.")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1625:Element documentation should not be copied and pasted", Justification = "Some elements are legitimate duplicates.")]


### PR DESCRIPTION
This PR adds a `PatClient` class to the `Microsoft.Authentication.AdoPat` namespace. It also adds supporting interfaces and classes, namely
- a `PatClientException` for raising a subset of error conditions
- a corresponding `TokensHttpClientWrapper` class, which wraps `TokensHttpClient` from [`Microsoft.VisualStudio.Services.Client` 19.212.0-preview](https://www.nuget.org/packages/Microsoft.VisualStudio.Services.Client/19.212.0-preview)
- an `ITokensHttpClientWrapper` interface to make testing easier
- tests in the `Microsoft.Authentication.AdoPat.Test` namespace

There will need to be a handful of follow up PRs to fully implement this feature. I consider this phase 1 of 4. Until all of the phases are complete this code won't be "lit" or "live" in the application and should not factor into production builds.

This entity relationship diagram shows the rough layout of parts needed to make this work. This PR covers `PatClient` and `TokensHttpClientWrapper`, so there's still work to be done for the other pieces of the puzzle.

```mermaid
erDiagram
    CLI ||..|| PatManager : uses
    PatManager ||..|{ PatCache : uses
    PatManager ||..|{ PatClient : uses
    PatCache }|..|{ MSALCacheWrapper : uses
    PatClient }|..|{ TokensHttpClientWrapper : uses
```

I've marked this PR as a draft for now because I'd like to get feedback while I work on the other phases. If it's well received, however, it should be safe to merge it, and I can lift the draft status. There are some questions marked as `XXX` or `TODO` that I'm particularly interested in getting feedback on, so keep an eye out for those.