### PR TITLE
Collect env vars for Azure pipelines and Cloud Build Agent machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 ### Added
-- Set the environment variable for Azure pipeline and Cloud Build Agent machine to avoid skewing aggregated telemetry.
+- Collect environment variables in telemetry distinguishing Azure Pipelines and Cloud Build.
 
 ### Added
 - Added On-premises Security Identifier in Telemetry as `sid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 ### Added
+- Set the environment variable for Azure pipeline and Cloud Build Agent machine to avoid skewing aggregated telemetry.
+
+### Added
 - Added On-premises Security Identifier in Telemetry as `sid`.
 
 ### Changed

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Authentication.AzureAuth
                 backend = TelemetryOutput.ApplicationInsights;
             }
 
-            TelemetryConfig telemetryConfig = new TelemetryConfig()
-            {
-                Backend = backend,
-                IngestionToken = ingestionToken,
-                Async = true,
-            };
+            TelemetryConfig telemetryConfig = new TelemetryConfig(
+                eventNamespace: "azureauth",
+                backend: backend,
+                ingestionToken: ingestionToken,
+                useAsync: true,
+                envVarsToCollect: new[] { "SYSTEM_DEFINITIONID" });
 
             // We want redirect stdout to get just token output
             // while warnings and errors still go to stderr to be seen by a user.

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Authentication.AzureAuth
                 backend: backend,
                 ingestionToken: ingestionToken,
                 useAsync: true,
-                envVarsToCollect: new[] { "SYSTEM_DEFINITIONID" });
+                envVarsToCollect: new[] { "SYSTEM_DEFINITIONID", "QBUILD_DISTRIBUTED" });
 
             // We want redirect stdout to get just token output
             // while warnings and errors still go to stderr to be seen by a user.


### PR DESCRIPTION
The telemetry events coming from Azure pipelines and Cloud Build Agent machines skew up AzureAuth telemetry. In this PR, I am adding environment variables to be set as a part of telemetry config. 

1. SYSTEM_DEFINITIONID will be set if a telemetry event is coming from Azure pipeline.
2. QBUILD_DISTRIBUTED is set if a telemetry event is coming from Cloud Build Agent machines.

Test: 
`.\bin\azureauth.cmd --verbosity trace`
The env vars get added to trace as:
`"env_system_definitionid": "",
 "env_qbuild_distributed": ""`

If these are set then we can exclude them from our aggregated data.