### PR TITLE
Upgrade to C# 10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <LangVersion>10.0</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Package Naming, Building, & Versioning -->
     <PackageId>Microsoft.Authentication.MSALWrapper</PackageId>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Authentication.MSALWrapper</RootNamespace>
 
     <PackageOutputPath>../</PackageOutputPath>
@@ -45,4 +45,3 @@
   </ItemGroup>
 
 </Project>
-


### PR DESCRIPTION
There's nothing stopping us from using net6 across all our projects now which lets us update to C# 10.0. It's not always clear which version of the language you are using so I've explicitly set it using the `Directory.Build.props` file. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version for reference.  