### PR TITLE
Make top level command backwards compatible for now. 

### DIFF
--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -13,11 +13,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     /// The command main class parses commands and dispatches to the corresponding methods.
     /// </summary>
     [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library)." +
-        "\n\n⚠️ NOTICE: This top level command has moved!" +
-        "\n\nCalling 'azureauth' with no commands in future versions will print the avaialble commands instead of performing authentication." +
-        "\n\n ❌ azureauth [options]" +
-        "\n              ⬇️⬇️" +
-        "\n ✅ azureauth aad [options]\n")]
+        "\n\n⚠️ NOTICE: Use `azureauth aad [options]`.\n⚠️ The top-level azureauth command is deprecated and will print help text soon." +
+        "\n\n\u001b[31m-- azureauth [options]\u001b[0m" +
+        "\n\u001b[32m++ azureauth aad [options]\u001b[0m\n")]
     [Subcommand(typeof(CommandAad))]
     [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]

--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -12,7 +12,12 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     /// <summary>
     /// The command main class parses commands and dispatches to the corresponding methods.
     /// </summary>
-    [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library)")]
+    [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library)." +
+        "\n\n⚠️ NOTICE: This top level command has moved!" +
+        "\n\nCalling 'azureauth' with no commands in future versions will print the avaialble commands instead of performing authentication." +
+        "\n\n ❌ azureauth [options]" +
+        "\n              ⬇️⬇️" +
+        "\n ✅ azureauth aad [options]\n")]
     [Subcommand(typeof(CommandAad))]
     [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]

--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Authentication.AzureAuth.Commands
 {
+    using System.IO.Abstractions;
     using McMaster.Extensions.CommandLineUtils;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Office.Lasso.Interfaces;
+    using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
     /// The command main class parses commands and dispatches to the corresponding methods.
@@ -12,24 +16,14 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     [Subcommand(typeof(CommandAad))]
     [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]
-    public class CommandAzureAuth
+    public class CommandAzureAuth : CommandAad
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommandAzureAuth"/> class.
-        /// </summary>
-        public CommandAzureAuth()
+#pragma warning disable SA1648 // inheritdoc should be used with inheriting class
+        /// <inheritdoc/>
+        public CommandAzureAuth(CommandExecuteEventData eventData, ITelemetryService telemetryService, ILogger<CommandAzureAuth> logger, IFileSystem fileSystem, IEnv env)
+#pragma warning restore SA1648 // inheritdoc should be used with inheriting class
+            : base(eventData, telemetryService, logger, fileSystem, env)
         {
-        }
-
-        /// <summary>
-        /// Execute.
-        /// </summary>
-        /// <param name="app"><see cref="CommandLineApplication"/> instance of the current command.</param>
-        /// <returns>0 - this command only shows help.</returns>
-        public int OnExecute(CommandLineApplication app)
-        {
-            app.ShowHelp();
-            return 0;
         }
     }
 }


### PR DESCRIPTION
To allow for a smoother update for your customers, we can prevent the new command structure from breaking existing usage by duplicating the logic on both the `CommandAzureAUth` and the new `CommandAad`. 

This is simple to do by inheriting from `CommandAad`. 

The plan will be to remove this, once we have proved with telemetry, that usage has moved over to use the `aad` command.

## Example Back Compat
```
microsoft-authentication-cli - backwards-compat via .NET v7.0.102
❯ .\bin\azureauth.cmd --alias ado
Token cache warm for <kyle>

microsoft-authentication-cli on - backwards-compat via .NET v7.0.102 took 4s
❯ .\bin\azureauth.cmd aad --alias ado
Token cache warm for <kyle>
```

## Help
It's colored
![image](https://user-images.githubusercontent.com/4755420/217684836-af63c477-4835-45c7-9ebe-abf48e30d187.png)

```
.\bin\azureauth.cmd --help
1.0.0.0

A CLI interface to MSAL (Microsoft Authentication Library).

⚠️ NOTICE: Use `azureauth aad [options]`.
⚠️ The top-level azureauth command is deprecated and will print help text soon.

-- azureauth [options]
++ azureauth aad [options]


Usage: azureauth [command] [options]

Options:
  --resource     The ID of the resource you are authenticating to.
  --client       The ID of the App registration you are authenticating as.
  --tenant       The ID of the Tenant where the client and resource entities exist in
  --prompt-hint  The prompt hint text for WAM prompts and web mode.
  --scope        Scopes to request. By default, the only scope requested is <resource ID>\.default.
                 Passing in one or more values here will override the default.
  --clear        Clear the token cache for this AAD Application.

  --domain       Preferred domain to filter cached accounts by. If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.

  --mode         Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
                 You can use any combination of modes with multiple instances of the --mode flag.
                 Allowed values: [all, iwa, broker, web, devicecode]
  --output       Output mode. Controls how the token information is printed to stdout.
                 Default: status (only print status, no token).
                 Available: [status, token, json, none]

  --alias        The name of an alias for config options loaded from the config file.
  --config       The path to a configuration file.
  --timeout      The number of minutes before authentication times out.
                 Default: 10 minutes.
  -?|-h|--help   Show help information.
  --version      Show version information.
  --debug        Turn off telemetry reporting and enable trace logging
  --verbosity    Configure the minimum log level to show.
                 Allowed values are: trace, debug, info, information, warn, warning, error, critical, fatal, none, off.

Commands:
  aad            todo
  ado            A collection of Azure Devops (ADO) specific authentication commands.
  info           Shows AzureAuth debug information. Please provide when asking for help.

Run 'azureauth [command] -?|-h|--help' for more information about a command.
```

And
```
.\bin\azureauth.cmd aad --help
1.0.0.0

todo

Usage: azureauth aad [options]

Options:
  --resource     The ID of the resource you are authenticating to.
  --client       The ID of the App registration you are authenticating as.
  --tenant       The ID of the Tenant where the client and resource entities exist in
  --prompt-hint  The prompt hint text for WAM prompts and web mode.
  --scope        Scopes to request. By default, the only scope requested is <resource ID>\.default.
                 Passing in one or more values here will override the default.
  --clear        Clear the token cache for this AAD Application.

  --domain       Preferred domain to filter cached accounts by. If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.

  --mode         Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
                 You can use any combination of modes with multiple instances of the --mode flag.
                 Allowed values: [all, iwa, broker, web, devicecode]
  --output       Output mode. Controls how the token information is printed to stdout.
                 Default: status (only print status, no token).
                 Available: [status, token, json, none]

  --alias        The name of an alias for config options loaded from the config file.
  --config       The path to a configuration file.
  --timeout      The number of minutes before authentication times out.
                 Default: 10 minutes.
  -?|-h|--help   Show help information.
  --version      Show version information.
  --debug        Turn off telemetry reporting and enable trace logging
  --verbosity    Configure the minimum log level to show.
                 Allowed values are: trace, debug, info, information, warn, warning, error, critical, fatal, none, off.
```

