### PR TITLE
Always add a newline before the path install on Mac.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -194,7 +194,7 @@ install_post_0_4_0() {
         do
             if ! grep "${new_path}" "${shell_profile}" &>/dev/null; then
                 verbose "Appending '${target_directory}' to \$PATH in ${shell_profile}"
-                printf "${new_path}\n" >> $shell_profile
+                printf "\n${new_path}\n" >> $shell_profile
             fi
         done
     fi


### PR DESCRIPTION
If someone already has content in this file, and it doesn't end with a newline, then this will be appended incorrectly. I a simple way to avoid this is always include our own newline.