### PR TITLE
Dogfood azureauth for nuget auth

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
         env:
-          NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
+          ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
 
       - name: Build
         run: dotnet build --no-restore

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -20,9 +20,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
-          source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
 
       - name: Build
         run: dotnet build --no-restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Install dependencies
       run: dotnet restore --runtime ${{ matrix.runtime }}
+      env:
+          NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-        source-url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Install dependencies
       run: dotnet restore --runtime ${{ matrix.runtime }}
       env:
-          ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
+        ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore --runtime ${{ matrix.runtime }}
       env:
-          NUGET_AUTH_TOKEN: ${{ secrets.ADO_TOKEN }}
+          ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts

--- a/bin/azureauth
+++ b/bin/azureauth
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+here=$(dirname $(readlink -f "$0"))
+"${here}/dotnet" run --project "${here}/../src/AzureAuth" -- $* --debug

--- a/bin/azureauth.cmd
+++ b/bin/azureauth.cmd
@@ -2,4 +2,4 @@
 :: Licensed under the MIT License.
 
 @ECHO OFF
-CALL dotnet run --project src\AzureAuth -- %* --debug
+CALL %~dp0\dotnet.cmd run --project %~dp0\..\src\AzureAuth -- %* --debug

--- a/bin/dotnet
+++ b/bin/dotnet
@@ -2,5 +2,5 @@
 
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-export ADO_TOKEN=$(azureauth --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token)
+export ADO_TOKEN=$(azureauth --prompt-hint "azureauth dev nuget" --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token)
 dotnet $*

--- a/bin/dotnet
+++ b/bin/dotnet
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+export ADO_TOKEN=$(azureauth --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token)
+dotnet $*

--- a/bin/dotnet.cmd
+++ b/bin/dotnet.cmd
@@ -1,7 +1,7 @@
 @ECHO OFF
 
 rem This is a workaround for setting the ADO_TOKEN environment variable to the output of azureauth
-FOR /F "tokens=* USEBACKQ" %%F IN (`azureauth --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token`) DO (
+FOR /F "tokens=* USEBACKQ" %%F IN (`azureauth --prompt-hint "azureauth dev nuget" --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token`) DO (
 SET ADO_TOKEN=%%F
 )
 dotnet %*

--- a/bin/dotnet.cmd
+++ b/bin/dotnet.cmd
@@ -1,0 +1,7 @@
+@ECHO OFF
+
+rem This is a workaround for setting the ADO_TOKEN environment variable to the output of azureauth
+FOR /F "tokens=* USEBACKQ" %%F IN (`azureauth --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token`) DO (
+SET ADO_TOKEN=%%F
+)
+dotnet %*

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,13 @@
     <clear />
     <add value="https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json" key="Office" />
   </packageSources>
+  <packageSourceCredentials>
+    <Office>
+      <add key="Username" value="aad_token" />
+      <add key="ClearTextPassword" value="%ADO_TOKEN%" />
+    </Office>
+  </packageSourceCredentials>
+
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>


### PR DESCRIPTION
I dislike constantly battling the Azure Artifacts Credential provider and having to go through Device Code Flow auth all the time. Since version 1.0 of that tool web auth is still broken, so I propose a solution here to easily allow us to use AzureAuth to handle nuget authentication when building AzureAuth :)

## Opt-In to usage via new scripts
* `bin/dotnet` - a Mac dotnet wrapper that sets the `ADO_TOKEN` env var first.
* `bin/azureauth` - a Mac wrapper to build and run AzureAuth in debug mode.
* `bin\dotnet.cmd` - Runnable on Windows as `bin\dotnet` - sets `ADO_TOKEN` and calls `dotnet`
* `bin\azureauth.cmd` - Runnable on Windows as `bin\azureauth` - uses `bin\dotnet.cmd` to handle auth and run AzureAuth in debug mode.

## Entry in `nuget.config`

### Locally
The new entry in nuget.config won't have any impact if the env var is not set locally. If the ADO cred provider is still installed and configured it will be used if the nuget.config gets an empty value that can't auth.

### In GitHub Actions
Having this entry will actually make the CI able to use the same auth config as we can use locally, and our CI can set the same ADO_TOKEN to a valid SYSTEM_ACCESSTOKEN (an ADO PAT).