### PR TITLE
[Unlit] Add options to the `ado token` command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "cSpell.words": [
-        "MSAL"
+        "authflow",
+        "Corext",
+        "devicecode",
+        "MSAL",
+        "prompthint",
+        "validargs"
     ]
 }

--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -9,6 +9,17 @@ namespace Microsoft.Authentication.AzureAuth.Ado
     internal static class Constants
     {
         /// <summary>
+        /// Azure tenant IDs.
+        /// </summary>
+        public static class Tenant
+        {
+            /// <summary>
+            /// Microsoft tenant ID.
+            /// </summary>
+            public static string Msft = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+        }
+
+        /// <summary>
         /// App Registration Client IDs.
         /// </summary>
         public static class Client

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -3,8 +3,9 @@
 
 namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 {
+    using System.Collections.Generic;
     using McMaster.Extensions.CommandLineUtils;
-
+    using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Extensions.Logging;
     using Microsoft.Office.Lasso.Telemetry;
 
@@ -15,6 +16,30 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
     public class CommandToken
     {
+        /// <summary>
+        /// Gets or sets the Azure Tenant ID to use for authentication.
+        /// </summary>
+        [Option(CommandAad.TenantOption, Description = "The Azure Tenant ID to use for authentication. Defaults to Microsoft.")]
+        public string Tenant { get; set; } = AzureAuth.Ado.Constants.Tenant.Msft;
+
+        /// <summary>
+        /// Gets or sets the auth modes.
+        /// </summary>
+        [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
+        public IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
+
+        /// <summary>
+        /// Gets or sets domain suffix to filter on.
+        /// </summary>
+        [Option(CommandAad.DomainOption, Description = CommandAad.DomainHelpText)]
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// Gets or sets the global timeout option.
+        /// </summary>
+        [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]
+        public double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
+
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
         /// </summary>

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -41,6 +41,12 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         public double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
 
         /// <summary>
+        /// Gets or sets the prompt hint.
+        /// </summary>
+        [Option(CommandAad.PromptHintOption, CommandAad.PromptHintHelpText, CommandOptionType.SingleValue)]
+        public string PromptHint { get; set; }
+
+        /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{T}"/> instance that is used for logging.</param>

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -27,34 +27,68 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     [Command("aad", Description = "todo")]
     public class CommandAad
     {
-        private const string ResourceOption = "--resource";
-        private const string ClientOption = "--client";
-        private const string TenantOption = "--tenant";
-        private const string PromptHintOption = "--prompt-hint";
-        private const string ScopeOption = "--scope";
-        private const string ClearOption = "--clear";
-        private const string DomainOption = "--domain";
-        private const string ModeOption = "--mode";
-        private const string OutputOption = "--output";
-        private const string AliasOption = "--alias";
-        private const string ConfigOption = "--config";
-        private const string PromptHintPrefix = "AzureAuth";
-        private const string TimeoutOption = "--timeout";
+        /// <summary>
+        /// The option syntax for the Domain option.
+        /// </summary>
+        public const string DomainOption = "--domain";
+
+        /// <summary>
+        /// The option syntax for the Tenant option.
+        /// </summary>
+        public const string TenantOption = "--tenant";
+
+        /// <summary>
+        /// The option syntax for the Timeout option.
+        /// </summary>
+        public const string TimeoutOption = "--timeout";
+
+        /// <summary>
+        /// The option syntax for the Mode option.
+        /// </summary>
+        public const string ModeOption = "--mode";
 
 #if PlatformWindows
-        private const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
+        /// <summary>
+        /// The help text for the <see cref="ModeOption"/> option.
+        /// </summary>
+        public const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
 You can use any combination of modes with multiple instances of the --mode flag.
 Allowed values: [all, iwa, broker, web, devicecode]";
 #else
-        private const string AuthModeHelperText = @"Authentication mode. Default: web.
+        /// <summary>
+        /// The help text for the <see cref="ModeOption"/> option.
+        /// </summary>
+        public const string AuthModeHelperText = @"Authentication mode. Default: web.
 You can use any combination with multiple instances of the --mode flag.
 Allowed values: [all, web, devicecode]";
 #endif
 
         /// <summary>
+        /// The help text for the <see cref="DomainOption"/> option.
+        /// </summary>
+        public const string DomainHelpText = "Preferred domain to filter cached accounts by.If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.\n";
+
+        /// <summary>
+        /// The help text for the <see cref="TimeoutOption"/> option.
+        /// </summary>
+        public const string TimeoutHelpText = "The number of minutes before authentication times out.\nDefault: 15 minutes.";
+
+        /// <summary>
         /// The default number of minutes CLI is allowed to run.
         /// </summary>
-        private static readonly TimeSpan GlobalTimeout = TimeSpan.FromMinutes(15);
+        public static readonly TimeSpan GlobalTimeout = TimeSpan.FromMinutes(15);
+
+        private const string ResourceOption = "--resource";
+        private const string ClientOption = "--client";
+
+        private const string PromptHintOption = "--prompt-hint";
+        private const string ScopeOption = "--scope";
+        private const string ClearOption = "--clear";
+
+        private const string OutputOption = "--output";
+        private const string AliasOption = "--alias";
+        private const string ConfigOption = "--config";
+        private const string PromptHintPrefix = "AzureAuth";
 
         private readonly EventData eventData;
         private readonly ILogger<CommandAzureAuth> logger;
@@ -141,7 +175,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets the preferred domain.
         /// </summary>
-        [Option(DomainOption, "Preferred domain to filter cached accounts by. If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.\n", CommandOptionType.SingleValue)]
+        [Option(DomainOption, DomainHelpText, CommandOptionType.SingleValue)]
         public string PreferredDomain { get; set; }
 
         /// <summary>
@@ -172,7 +206,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets global Timeout.
         /// </summary>
-        [Option(TimeoutOption, "The number of minutes before authentication times out.\nDefault: 10 minutes.", CommandOptionType.SingleValue)]
+        [Option(TimeoutOption, TimeoutHelpText, CommandOptionType.SingleValue)]
         public double Timeout { get; set; } = GlobalTimeout.TotalMinutes;
 
         /// <summary>
@@ -439,10 +473,10 @@ Allowed values: [all, web, devicecode]";
                     // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.
                     catch (AbandonedMutexException)
                     {
-                        // If another process crashes or exits accidently, we can still acquire the lock.
+                        // If another process crashes or exits accidentally, we can still acquire the lock.
                         lockAcquired = true;
 
-                        // In this case, basicly we can just leave a log warning, because the worst side effect is propmting more than once.
+                        // In this case, basically we can just leave a log warning, because the worst side effect is prompting more than once.
                         this.logger.LogWarning("The authentication attempt mutex was abandoned. Another thread or process may have exited unexpectedly.");
                     }
 

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -76,7 +76,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// The help text for the <see cref="DomainOption"/> option.
         /// </summary>
-        public const string DomainHelpText = "Preferred domain to filter cached accounts by.If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.\n";
+        public const string DomainHelpText = "Preferred domain to filter cached accounts by. If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.\n";
 
         /// <summary>
         /// The help text for the <see cref="TimeoutOption"/> option.

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -47,6 +47,16 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// </summary>
         public const string ModeOption = "--mode";
 
+        /// <summary>
+        /// The Prompt Hint option.
+        /// </summary>
+        public const string PromptHintOption = "--prompt-hint";
+
+        /// <summary>
+        /// The Prompt Hint help text.
+        /// </summary>
+        public const string PromptHintHelpText = "A prompt hint to contextualize prompts and identify uses in telemetry";
+
 #if PlatformWindows
         /// <summary>
         /// The help text for the <see cref="ModeOption"/> option.
@@ -81,7 +91,6 @@ Allowed values: [all, web, devicecode]";
         private const string ResourceOption = "--resource";
         private const string ClientOption = "--client";
 
-        private const string PromptHintOption = "--prompt-hint";
         private const string ScopeOption = "--scope";
         private const string ClearOption = "--clear";
 
@@ -157,7 +166,7 @@ Allowed values: [all, web, devicecode]";
         /// <summary>
         /// Gets or sets the customized prompt hint text for WAM prompts and web mode.
         /// </summary>
-        [Option(PromptHintOption, "The prompt hint text for WAM prompts and web mode.", CommandOptionType.SingleValue)]
+        [Option(PromptHintOption, PromptHintHelpText, CommandOptionType.SingleValue)]
         public string PromptHint { get; set; }
 
         /// <summary>

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -28,22 +28,22 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     public class CommandAad
     {
         /// <summary>
-        /// The option syntax for the Domain option.
+        /// The Domain option.
         /// </summary>
         public const string DomainOption = "--domain";
 
         /// <summary>
-        /// The option syntax for the Tenant option.
+        /// The Tenant option.
         /// </summary>
         public const string TenantOption = "--tenant";
 
         /// <summary>
-        /// The option syntax for the Timeout option.
+        /// The Timeout option.
         /// </summary>
         public const string TimeoutOption = "--timeout";
 
         /// <summary>
-        /// The option syntax for the Mode option.
+        /// The Mode option.
         /// </summary>
         public const string ModeOption = "--mode";
 


### PR DESCRIPTION
This PR adds the options declared in our design spec for the `ado token` command. Several of the options are intentionally the same as those on the `aad` command, so those have been made public, and re-used in this command.

The only options where that is not done, is where their behavior differs. 