### PR TITLE
Fix Release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts
-      run: dotnet publish src/AzureAuth/AzureAuth.csproj -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
+      run: dotnet publish src/AzureAuth/AzureAuth.csproj --no-restore -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Because of the change in `nuget.config` the `dotnet publish` is now failing, since the dotnet setup no longer writes out a nuget.config with a PAT directly in it. We need not restore on publish since we explicitly do that in it's own step first. 