### PR TITLE
Use restore on publish but set auth token so it works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,9 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --configuration release
     - name: Build artifacts
-      run: dotnet publish src/AzureAuth/AzureAuth.csproj --no-restore -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
+      run: dotnet publish src/AzureAuth/AzureAuth.csproj -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
+      env:
+        ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
So we do need to enable the restore during publish in order to build with the ReadyToRun optimization, unfortunately.