### PR TITLE
Upgrade Lasso and match the API changes.

### DIFF
--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.2.21.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.2.24.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.2.2" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.2.3" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.2.24.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.2.2" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 

--- a/src/AzureAuth/Commands/CommandInfo.cs
+++ b/src/AzureAuth/Commands/CommandInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// <param name="fileSystem">The file system.</param>
         /// <param name="app">The command line application.</param>
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
-        public int OnExecute(ILogger<CommandInfo> logger, IFileSystem fileSystem, CommandLineApplication<CommandInfo> app)
+        public int OnExecute(ILogger<CommandInfo> logger, IFileSystem fileSystem, CommandLineApplication app)
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
             string azureauthVersion = assembly.GetName().Version.ToString();

--- a/src/AzureAuth/Commands/CommandInfo.cs
+++ b/src/AzureAuth/Commands/CommandInfo.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     using McMaster.Extensions.CommandLineUtils;
     using Microsoft.Authentication.AzureAuth.Commands.Info;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Office.Lasso.Interfaces;
     using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
@@ -21,13 +22,13 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// This method executes the info process.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        /// <param name="fileSystem">The file system.</param>
+        /// <param name="telemetryService">The telemetry service.</param>
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
-        public int OnExecute(ILogger<CommandInfo> logger, IFileSystem fileSystem)
+        public int OnExecute(ILogger<CommandInfo> logger, ITelemetryService telemetryService)
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
             string azureauthVersion = assembly.GetName().Version.ToString();
-            string deviceID = TelemetryDeviceID.GetAsync(fileSystem).Result;
+            string deviceID = (telemetryService as TelemetryServiceBase)?.MachineGUID;
 
             logger.LogInformation($"AzureAuth Version: {azureauthVersion}");
             logger.LogInformation($"Telemetry Device ID: {deviceID}");

--- a/src/AzureAuth/Commands/CommandInfo.cs
+++ b/src/AzureAuth/Commands/CommandInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     using McMaster.Extensions.CommandLineUtils;
     using Microsoft.Authentication.AzureAuth.Commands.Info;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Office.Lasso.Interfaces;
+    using Microsoft.Office.Lasso.Extensions;
     using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
@@ -22,13 +22,14 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// This method executes the info process.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        /// <param name="telemetryService">The telemetry service.</param>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="app">The command line application.</param>
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
-        public int OnExecute(ILogger<CommandInfo> logger, ITelemetryService telemetryService)
+        public int OnExecute(ILogger<CommandInfo> logger, IFileSystem fileSystem, CommandLineApplication<CommandInfo> app)
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
             string azureauthVersion = assembly.GetName().Version.ToString();
-            string deviceID = (telemetryService as TelemetryServiceBase)?.MachineGUID;
+            string deviceID = TelemetryDeviceID.GetAsync(fileSystem, app.GetRoot().Name).Result;
 
             logger.LogInformation($"AzureAuth Version: {azureauthVersion}");
             logger.LogInformation($"Telemetry Device ID: {deviceID}");

--- a/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
+++ b/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Info
     [Command(Name = "reset-device-id", Description = "Reset your AzureAuth telemetry device identifier.")]
     public class CommandResetDeviceID
     {
-        private const string ApplicationName = "azureauth";
-
         /// <summary>
         /// This method executes the reset device ID process.
         /// </summary>

--- a/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
+++ b/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Info
         /// <param name="fileSystem">The file system.</param>
         /// <param name="app">The command line application.</param>
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
-        public int OnExecute(ILogger<CommandResetDeviceID> logger, IFileSystem fileSystem, CommandLineApplication<CommandResetDeviceID> app)
+        public int OnExecute(ILogger<CommandResetDeviceID> logger, IFileSystem fileSystem, CommandLineApplication app)
         {
             TelemetryDeviceID.Delete(fileSystem, app.GetRoot().Name);
             logger.LogSuccess($"Telemetry Device ID was reset.");

--- a/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
+++ b/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Info
     [Command(Name = "reset-device-id", Description = "Reset your AzureAuth telemetry device identifier.")]
     public class CommandResetDeviceID
     {
+        private const string ApplicationName = "azureauth";
+
         /// <summary>
         /// This method executes the reset device ID process.
         /// </summary>
@@ -23,7 +25,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Info
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
         public int OnExecute(ILogger<CommandResetDeviceID> logger, IFileSystem fileSystem)
         {
-            TelemetryDeviceID.Delete(fileSystem);
+            TelemetryDeviceID.Delete(fileSystem, ApplicationName);
             logger.LogSuccess($"Telemetry Device ID was reset.");
 
             return 0;

--- a/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
+++ b/src/AzureAuth/Commands/Info/CommandInfoResetDeviceID.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Info
         /// </summary>
         /// <param name="logger">The logger.</param>
         /// <param name="fileSystem">The file system.</param>
+        /// <param name="app">The command line application.</param>
         /// <returns>The error code: 0 is normal execution, and the rest means errors during execution.</returns>
-        public int OnExecute(ILogger<CommandResetDeviceID> logger, IFileSystem fileSystem)
+        public int OnExecute(ILogger<CommandResetDeviceID> logger, IFileSystem fileSystem, CommandLineApplication<CommandResetDeviceID> app)
         {
-            TelemetryDeviceID.Delete(fileSystem, ApplicationName);
+            TelemetryDeviceID.Delete(fileSystem, app.GetRoot().Name);
             logger.LogSuccess($"Telemetry Device ID was reset.");
 
             return 0;


### PR DESCRIPTION
Lasso gets the machine id config from App name. We get the root app name from `CommandLineApplication`.
The extension method `GetRoot` came from Lasso since `2023.3.2.3`.
Concurrency bug also got fixed by Lasso.