### PR TITLE
Add unlit PatManager and supporting interfaces

### DIFF
--- a/src/AdoPat.Test/PatCacheTest.cs
+++ b/src/AdoPat.Test/PatCacheTest.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Authentication.AdoPat.Test
         // This is a test token. A real value would be a much longer string.
         private const string Token = "Test Token";
 
-        // The Unix Epoch is used as an obviously fake test time which occurs in the past and cannot accidentally be valid.
-        private readonly DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         // This list of accounts uses dummy data, not real accounts.
         private readonly List<Guid> targetAccounts = new List<Guid> { new Guid("b7b59161-cd70-46e9-aca5-883f24060eb1") };
 
@@ -75,8 +72,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(-7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(-7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };
@@ -105,8 +102,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(-7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(-7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };
@@ -138,8 +135,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(-7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(-7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };
@@ -172,8 +169,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(-7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(-7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };
@@ -213,8 +210,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(-7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(-7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };

--- a/src/AdoPat.Test/PatCacheTest.cs
+++ b/src/AdoPat.Test/PatCacheTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            var patToken = cache.GetPat(key);
+            var patToken = cache.Get(key);
 
             // Assert
             patToken.Should().BeNull();
@@ -59,7 +59,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            var patToken = cache.GetPat(key);
+            var patToken = cache.Get(key);
 
             // Assert
             patToken.Should().BeNull();
@@ -89,7 +89,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            var patToken = cache.GetPat(key);
+            var patToken = cache.Get(key);
 
             // Assert
             patToken.Should().BeEquivalentTo(expectedPat);
@@ -123,7 +123,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            var patToken = cache.GetPat(key);
+            var patToken = cache.Get(key);
 
             // Assert
             patToken.Should().BeEquivalentTo(expectedPat);
@@ -154,12 +154,12 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            cache.PutPat(key, pat);
+            cache.Put(key, pat);
 
             // Assert
             // The in-memory cache should contain the PatToken and so should
             // the underlying storage.
-            cache.GetPat(key).Should().BeEquivalentTo(pat);
+            cache.Get(key).Should().BeEquivalentTo(pat);
             data.Should().BeEquivalentTo(expectedData);
         }
 
@@ -195,12 +195,12 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            cache.PutPat(key, pat);
+            cache.Put(key, pat);
 
             // Assert
             // The in-memory cache should contain the PatToken and so should
             // the underlying storage.
-            cache.GetPat(key).Should().BeEquivalentTo(pat);
+            cache.Get(key).Should().BeEquivalentTo(pat);
             data.Should().BeEquivalentTo(expectedData);
         }
 
@@ -239,12 +239,12 @@ namespace Microsoft.Authentication.AdoPat.Test
             var cache = new PatCache(storage.Object);
 
             // Act
-            cache.PutPat(key, pat);
+            cache.Put(key, pat);
 
             // Assert
             // The in-memory cache should contain *ONLY* the expected PatToken
             // and so should the underlying storage.
-            cache.GetPat(key).Should().BeEquivalentTo(expectedPat);
+            cache.Get(key).Should().BeEquivalentTo(expectedPat);
             data.Should().BeEquivalentTo(expectedData);
         }
     }

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Authentication.AdoPat.Test
         // This is a test token. A real value would be a much longer string.
         private const string Token = "Test Token";
 
-        // The Unix Epoch is used as an obviously fake test time which occurs in the past and cannot accidentally be valid.
-        private readonly DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         // This list of accounts uses dummy data, not real accounts.
         private readonly List<Guid> targetAccounts = new List<Guid> { new Guid("b7b59161-cd70-46e9-aca5-883f24060eb1") };
 
@@ -38,7 +35,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             {
                 DisplayName = DisplayName,
                 Scope = Scope,
-                ValidTo = this.unixEpoch.AddDays(7),
+                ValidTo = DateTime.UnixEpoch.AddDays(7),
                 AllOrgs = AllOrgs,
             };
             var patToken = new PatToken
@@ -46,8 +43,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scope = Scope,
                 TargetAccounts = this.targetAccounts,
-                ValidTo = this.unixEpoch.AddDays(7),
-                ValidFrom = this.unixEpoch,
+                ValidTo = DateTime.UnixEpoch.AddDays(7),
+                ValidFrom = DateTime.UnixEpoch,
                 AuthorizationId = this.authorizationId,
                 Token = Token,
             };
@@ -135,9 +132,9 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task RegeneratePatAsync_RevokesOldPatAndReturnsNewPat()
         {
             // Arrange
-            var issued = this.unixEpoch.AddDays(-7);
-            var validTo = this.unixEpoch;
-            var regeneratedValidTo = this.unixEpoch.AddDays(7);
+            var issued = DateTime.UnixEpoch.AddDays(-7);
+            var validTo = DateTime.UnixEpoch;
+            var regeneratedValidTo = DateTime.UnixEpoch.AddDays(7);
             var patToken = new PatToken
             {
                 DisplayName = DisplayName,
@@ -184,9 +181,9 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task RegeneratePatAsync_CreationFailureNullPatToken()
         {
             // Arrange
-            var issued = this.unixEpoch.AddDays(-7);
-            var validTo = this.unixEpoch;
-            var regeneratedValidTo = this.unixEpoch.AddDays(7);
+            var issued = DateTime.UnixEpoch.AddDays(-7);
+            var validTo = DateTime.UnixEpoch;
+            var regeneratedValidTo = DateTime.UnixEpoch.AddDays(7);
             var patToken = new PatToken
             {
                 DisplayName = DisplayName,

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            var renewedPatToken = await patClient.CreatePatAsync(patTokenCreateRequest);
+            var renewedPatToken = await patClient.CreateAsync(patTokenCreateRequest);
 
             // Assert
             renewedPatToken.Should().BeEquivalentTo(patToken);
@@ -91,7 +91,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            var activePats = await patClient.GetActivePatsAsync();
+            var activePats = await patClient.ListActiveAsync();
 
             // Assert
             activePats.Should().BeEquivalentTo(expectedTokens);
@@ -122,7 +122,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            var activePats = await patClient.GetActivePatsAsync();
+            var activePats = await patClient.ListActiveAsync();
 
             // Assert
             activePats.Should().BeEquivalentTo(expectedTokens);
@@ -170,7 +170,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            var regeneratedPat = await patClient.RegeneratePatAsync(patToken, regeneratedValidTo);
+            var regeneratedPat = await patClient.RegenerateAsync(patToken, regeneratedValidTo);
 
             // Assert
             client.VerifyAll();
@@ -210,7 +210,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            Func<Task> act = () => patClient.RegeneratePatAsync(patToken, regeneratedValidTo);
+            Func<Task> act = () => patClient.RegenerateAsync(patToken, regeneratedValidTo);
 
             // Assert
             await act.Should().ThrowAsync<PatClientException>()

--- a/src/AdoPat.Test/PatClientTest.cs
+++ b/src/AdoPat.Test/PatClientTest.cs
@@ -31,13 +31,6 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task CreatePatAsync()
         {
             // Arrange
-            var patTokenCreateRequest = new PatTokenCreateRequest
-            {
-                DisplayName = DisplayName,
-                Scope = Scope,
-                ValidTo = DateTime.UnixEpoch.AddDays(7),
-                AllOrgs = AllOrgs,
-            };
             var patToken = new PatToken
             {
                 DisplayName = DisplayName,
@@ -64,7 +57,10 @@ namespace Microsoft.Authentication.AdoPat.Test
             var patClient = new PatClient(client.Object);
 
             // Act
-            var renewedPatToken = await patClient.CreateAsync(patTokenCreateRequest);
+            var renewedPatToken = await patClient.CreateAsync(
+                DisplayName,
+                Scope,
+                validTo: DateTime.UnixEpoch.AddDays(7));
 
             // Assert
             renewedPatToken.Should().BeEquivalentTo(patToken);

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+    using Moq;
+    using NUnit.Framework;
+
+    public class PatManagerTest
+    {
+        private const string Organization = "contoso";
+        private const string DisplayName = "Test PAT";
+        private const string Scope = "test.scope";
+
+        // This is a test token. A real value would be a much longer string.
+        private const string Token = "Test Token";
+
+        // The Unix Epoch is used as an obviously fake test time which occurs in the past and cannot accidentally be valid.
+        private readonly DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // This list of accounts uses dummy data, not real accounts.
+        private readonly List<Guid> targetAccounts = new List<Guid> { new Guid("b7b59161-cd70-46e9-aca5-883f24060eb1") };
+
+        // This is a dummy authorization ID, not valid in any real contexts.
+        private readonly Guid authorizationId = new Guid("ee0c5586-a96f-4a44-b1d9-8613028b1078");
+
+        // Common mocks which are configured via the Setup and Teardown methods.
+        private Mock<IPatCache> cache;
+        private Mock<IPatClient> client;
+
+        // PAT options which are common to all tests.
+        private static PatOptions PatOptions => new ()
+        {
+            DisplayName = DisplayName,
+            Organization = Organization,
+            Scopes = new string[] { Scope },
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            this.cache = new Mock<IPatCache>(MockBehavior.Strict);
+            this.client = new Mock<IPatClient>(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            // To be certain we have called all the necessary methods we verify
+            // each mock after every test.
+            this.cache.VerifyAll();
+            this.client.VerifyAll();
+        }
+
+        public PatToken PatToken(
+            string displayName = null,
+            string scope = null,
+            List<Guid> targetAccounts = null,
+            DateTime? validTo = null,
+            DateTime? validFrom = null,
+            Guid? authorizationId = null,
+            string token = null)
+        {
+            return new PatToken
+            {
+                DisplayName = displayName ?? DisplayName,
+                Scope = scope ?? Scope,
+                TargetAccounts = targetAccounts ?? this.targetAccounts,
+                ValidTo = validTo ?? this.unixEpoch.AddDays(7),
+                ValidFrom = validFrom ?? this.unixEpoch,
+                AuthorizationId = authorizationId ?? this.authorizationId,
+                Token = token ?? Token,
+            };
+        }
+
+        [Test]
+        public async Task GetPatAsync_ReturnsCachedPatWhenCacheHasValidPat()
+        {
+            // Arrange
+            var expectedPat = this.PatToken();
+            var activePats = new Dictionary<Guid, PatToken>
+            {
+                { expectedPat.AuthorizationId, expectedPat },
+            };
+
+            // The cache should contain our target PAT.
+            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(expectedPat);
+
+            // The client needs to be injected into the manager, but should be unused.
+            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+
+            var manager = new PatManager(
+                this.cache.Object,
+                this.client.Object,
+                now: () => this.unixEpoch);
+
+            // Act
+            var pat = await manager.GetPatAsync(PatOptions);
+
+            // Assert
+            pat.Should().BeEquivalentTo(expectedPat);
+        }
+
+        [Test]
+        public async Task GetPatAsync_CreatesNewPatWhenCacheIsMissingPat()
+        {
+            // Arrange
+            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var expectedPat = this.PatToken();
+
+            // The cache is empty and therefore returns `null` for any key.
+            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns<PatToken>(null);
+            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+
+            // The client will return a new PatToken upon creation request.
+            this.client.Setup(c => c.CreatePatAsync(
+                It.IsAny<PatTokenCreateRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedPat);
+
+            var manager = new PatManager(
+                this.cache.Object,
+                this.client.Object,
+                now: () => this.unixEpoch);
+
+            // Act
+            var pat = await manager.GetPatAsync(PatOptions);
+
+            // Assert
+            pat.Should().BeEquivalentTo(expectedPat);
+        }
+
+        [Test]
+        public async Task GetPatAsync_RegeneratesPatWhenPatHasExpired()
+        {
+            // Arrange
+            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var expiringPat = this.PatToken(
+                validTo: this.unixEpoch,
+                validFrom: this.unixEpoch.AddDays(-7));
+            var expectedPat = this.PatToken(
+                authorizationId: new Guid("6135c9a4-d08c-467f-9902-6ff439651657"),
+                token: "Fake Token");
+            var activePats = new Dictionary<Guid, PatToken>
+            {
+                { expiringPat.AuthorizationId, expiringPat },
+            };
+
+            // The PAT is found within the cache, but it has expired.
+            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(expiringPat);
+            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+
+            // The client will return a new PatToken upon creation request.
+            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+            this.client.Setup(c => c.RegeneratePatAsync(
+                It.IsAny<PatToken>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedPat);
+
+            var manager = new PatManager(
+                this.cache.Object,
+                this.client.Object,
+                now: () => this.unixEpoch);
+
+            // Act
+            var pat = await manager.GetPatAsync(PatOptions);
+
+            // Assert
+            pat.Should().BeEquivalentTo(expectedPat);
+        }
+
+        [Test]
+        public async Task GetPatAsync_CreatesNewPatWhenPatIsInactive()
+        {
+            // Arrange
+            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var inactivePat = this.PatToken();
+            var expectedPat = this.PatToken(
+                authorizationId: new Guid("5045619c-e1b1-46e3-a1e4-ba5f38ddf49b"),
+                token: "Fake Token");
+
+            // The inactivePat is not in the list of active PATs from Azure DevOps.
+            var activePats = new Dictionary<Guid, PatToken> { };
+
+            // The cache is empty and therefore returns `null` for any key.
+            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(inactivePat);
+            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+
+            // The client will return a new PatToken upon creation request.
+            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+            this.client.Setup(c => c.CreatePatAsync(
+                It.IsAny<PatTokenCreateRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedPat);
+
+            var manager = new PatManager(
+                this.cache.Object,
+                this.client.Object,
+                now: () => this.unixEpoch);
+
+            // Act
+            var pat = await manager.GetPatAsync(PatOptions);
+
+            // Assert
+            pat.Should().BeEquivalentTo(expectedPat);
+        }
+    }
+}

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             };
 
             // The cache should contain our target PAT.
-            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(expectedPat);
+            this.cache.Setup(c => c.Get(It.IsAny<string>())).Returns(expectedPat);
 
             // The client needs to be injected into the manager, but should be unused.
             this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
@@ -115,8 +115,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             var expectedPat = this.PatToken();
 
             // The cache is empty and therefore returns `null` for any key.
-            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns<PatToken>(null);
-            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+            this.cache.Setup(c => c.Get(It.IsAny<string>())).Returns<PatToken>(null);
+            this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
             this.client.Setup(c => c.CreatePatAsync(
@@ -153,8 +153,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             };
 
             // The PAT is found within the cache, but it has expired.
-            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(expiringPat);
-            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+            this.cache.Setup(c => c.Get(It.IsAny<string>())).Returns(expiringPat);
+            this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
             this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
@@ -190,8 +190,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             var activePats = new Dictionary<Guid, PatToken> { };
 
             // The cache is empty and therefore returns `null` for any key.
-            this.cache.Setup(c => c.GetPat(It.IsAny<string>())).Returns(inactivePat);
-            this.cache.Setup(c => c.PutPat(expectedKey, expectedPat));
+            this.cache.Setup(c => c.Get(It.IsAny<string>())).Returns(inactivePat);
+            this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
             this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             this.cache.Setup(c => c.Get(It.IsAny<string>())).Returns(expectedPat);
 
             // The client needs to be injected into the manager, but should be unused.
-            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+            this.client.Setup(c => c.ListActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
 
             var manager = new PatManager(
                 this.cache.Object,
@@ -116,7 +116,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
-            this.client.Setup(c => c.CreatePatAsync(
+            this.client.Setup(c => c.CreateAsync(
                 It.IsAny<PatTokenCreateRequest>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedPat);
@@ -154,8 +154,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
-            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
-            this.client.Setup(c => c.RegeneratePatAsync(
+            this.client.Setup(c => c.ListActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+            this.client.Setup(c => c.RegenerateAsync(
                 It.IsAny<PatToken>(),
                 It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
@@ -191,8 +191,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             this.cache.Setup(c => c.Put(expectedKey, expectedPat));
 
             // The client will return a new PatToken upon creation request.
-            this.client.Setup(c => c.GetActivePatsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
-            this.client.Setup(c => c.CreatePatAsync(
+            this.client.Setup(c => c.ListActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
+            this.client.Setup(c => c.CreateAsync(
                 It.IsAny<PatTokenCreateRequest>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedPat);

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Authentication.AdoPat.Test
         // This is a test token. A real value would be a much longer string.
         private const string Token = "Test Token";
 
-        // The Unix Epoch is used as an obviously fake test time which occurs in the past and cannot accidentally be valid.
-        private readonly DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         // This list of accounts uses dummy data, not real accounts.
         private readonly List<Guid> targetAccounts = new List<Guid> { new Guid("b7b59161-cd70-46e9-aca5-883f24060eb1") };
 
@@ -72,8 +69,8 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = displayName ?? DisplayName,
                 Scope = scope ?? Scope,
                 TargetAccounts = targetAccounts ?? this.targetAccounts,
-                ValidTo = validTo ?? this.unixEpoch.AddDays(7),
-                ValidFrom = validFrom ?? this.unixEpoch,
+                ValidTo = validTo ?? DateTime.UnixEpoch.AddDays(7),
+                ValidFrom = validFrom ?? DateTime.UnixEpoch,
                 AuthorizationId = authorizationId ?? this.authorizationId,
                 Token = token ?? Token,
             };
@@ -98,7 +95,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var manager = new PatManager(
                 this.cache.Object,
                 this.client.Object,
-                now: () => this.unixEpoch);
+                now: () => DateTime.UnixEpoch);
 
             // Act
             var pat = await manager.GetPatAsync(PatOptions);
@@ -127,7 +124,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var manager = new PatManager(
                 this.cache.Object,
                 this.client.Object,
-                now: () => this.unixEpoch);
+                now: () => DateTime.UnixEpoch);
 
             // Act
             var pat = await manager.GetPatAsync(PatOptions);
@@ -142,8 +139,8 @@ namespace Microsoft.Authentication.AdoPat.Test
             // Arrange
             var expectedKey = $"{Organization} {DisplayName} {Scope}";
             var expiringPat = this.PatToken(
-                validTo: this.unixEpoch,
-                validFrom: this.unixEpoch.AddDays(-7));
+                validTo: DateTime.UnixEpoch,
+                validFrom: DateTime.UnixEpoch.AddDays(-7));
             var expectedPat = this.PatToken(
                 authorizationId: new Guid("6135c9a4-d08c-467f-9902-6ff439651657"),
                 token: "Fake Token");
@@ -167,7 +164,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var manager = new PatManager(
                 this.cache.Object,
                 this.client.Object,
-                now: () => this.unixEpoch);
+                now: () => DateTime.UnixEpoch);
 
             // Act
             var pat = await manager.GetPatAsync(PatOptions);
@@ -203,7 +200,7 @@ namespace Microsoft.Authentication.AdoPat.Test
             var manager = new PatManager(
                 this.cache.Object,
                 this.client.Object,
-                now: () => this.unixEpoch);
+                now: () => DateTime.UnixEpoch);
 
             // Act
             var pat = await manager.GetPatAsync(PatOptions);

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -117,7 +117,9 @@ namespace Microsoft.Authentication.AdoPat.Test
 
             // The client will return a new PatToken upon creation request.
             this.client.Setup(c => c.CreateAsync(
-                It.IsAny<PatTokenCreateRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedPat);
 
@@ -193,7 +195,9 @@ namespace Microsoft.Authentication.AdoPat.Test
             // The client will return a new PatToken upon creation request.
             this.client.Setup(c => c.ListActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync(activePats);
             this.client.Setup(c => c.CreateAsync(
-                It.IsAny<PatTokenCreateRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedPat);
 

--- a/src/AdoPat/IPatCache.cs
+++ b/src/AdoPat/IPatCache.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Authentication.AdoPat
         /// </summary>
         /// <param name="key">The key for the target entry.</param>
         /// <returns>The target value.</returns>
-        PatToken GetPat(string key);
+        PatToken Get(string key);
 
         /// <summary>
         /// Put a <see cref="PatToken"/> into the cache. May overwrite existing values.
         /// </summary>
         /// <param name="key">The key for this entry.</param>
         /// <param name="patToken">The value for this entry.</param>
-        void PutPat(string key, PatToken patToken);
+        void Put(string key, PatToken patToken);
     }
 }

--- a/src/AdoPat/IPatCache.cs
+++ b/src/AdoPat/IPatCache.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+    /// <summary>
+    /// A simple cache mapping <see cref="string"/> to <see cref="PatToken"/> backed by secure storage.
+    /// </summary>
+    public interface IPatCache
+    {
+        /// <summary>
+        /// Get a <see cref="PatToken"/> from the cache.
+        /// </summary>
+        /// <param name="key">The key for the target entry.</param>
+        /// <returns>The target value.</returns>
+        PatToken GetPat(string key);
+
+        /// <summary>
+        /// Put a <see cref="PatToken"/> into the cache. May overwrite existing values.
+        /// </summary>
+        /// <param name="key">The key for this entry.</param>
+        /// <param name="patToken">The value for this entry.</param>
+        void PutPat(string key, PatToken patToken);
+    }
+}

--- a/src/AdoPat/IPatClient.cs
+++ b/src/AdoPat/IPatClient.cs
@@ -17,10 +17,12 @@ namespace Microsoft.Authentication.AdoPat
         /// <summary>
         /// Creates a new PAT.
         /// </summary>
-        /// <param name="patTokenCreateRequest">The PAT creation request.</param>
+        /// <param name="displayName">The token name.</param>
+        /// <param name="scope">The token scopes for accessing Azure DevOps resources.</param>
+        /// <param name="validTo">The token expiration date.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
-        Task<PatToken> CreateAsync(PatTokenCreateRequest patTokenCreateRequest, CancellationToken cancellationToken = default);
+        Task<PatToken> CreateAsync(string displayName, string scope, DateTime validTo, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets all active PATs.

--- a/src/AdoPat/IPatClient.cs
+++ b/src/AdoPat/IPatClient.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+    /// <summary>
+    /// An abstraction over common operations with the Azure DevOps PAT Lifecycle Management REST API.
+    /// </summary>
+    public interface IPatClient
+    {
+        /// <summary>
+        /// Creates a new PAT.
+        /// </summary>
+        /// <param name="patTokenCreateRequest">The PAT creation request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
+        Task<PatToken> CreatePatAsync(PatTokenCreateRequest patTokenCreateRequest, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets all active PATs.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A mapping of authorization ID to active PATs.</returns>
+        Task<IDictionary<Guid, PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new PAT with a new 'valid to' date by replicating an existing one.
+        /// </summary>
+        /// <param name="patToken">An existing <see cref="PatToken"/>.</param>
+        /// <param name="validTo">The new expiration date for the regenerated token.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A <see cref="Task"/> returning a <see cref="PatToken"/>.</returns>
+        Task<PatToken> RegeneratePatAsync(PatToken patToken, DateTime validTo, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/AdoPat/IPatClient.cs
+++ b/src/AdoPat/IPatClient.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Authentication.AdoPat
         /// <param name="patTokenCreateRequest">The PAT creation request.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
-        Task<PatToken> CreatePatAsync(PatTokenCreateRequest patTokenCreateRequest, CancellationToken cancellationToken = default);
+        Task<PatToken> CreateAsync(PatTokenCreateRequest patTokenCreateRequest, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets all active PATs.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A mapping of authorization ID to active PATs.</returns>
-        Task<IDictionary<Guid, PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default);
+        Task<IDictionary<Guid, PatToken>> ListActiveAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new PAT with a new 'valid to' date by replicating an existing one.
@@ -36,6 +36,6 @@ namespace Microsoft.Authentication.AdoPat
         /// <param name="validTo">The new expiration date for the regenerated token.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="Task"/> returning a <see cref="PatToken"/>.</returns>
-        Task<PatToken> RegeneratePatAsync(PatToken patToken, DateTime validTo, CancellationToken cancellationToken = default);
+        Task<PatToken> RegenerateAsync(PatToken patToken, DateTime validTo, CancellationToken cancellationToken = default);
     }
 }

--- a/src/AdoPat/PatCache.cs
+++ b/src/AdoPat/PatCache.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Authentication.AdoPat
     /// <summary>
     /// A simple cache mapping <see cref="string"/> to <see cref="PatToken"/> backed by secure storage.
     /// </summary>
+    /// <remarks>
+    /// This class and its methods are not threadsafe. Locking must be handled externally.
+    /// </remarks>
     public class PatCache : IPatCache
     {
         private IStorageWrapper storage;

--- a/src/AdoPat/PatCache.cs
+++ b/src/AdoPat/PatCache.cs
@@ -36,8 +36,7 @@ namespace Microsoft.Authentication.AdoPat
         /// <inheritdoc/>
         public PatToken GetPat(string key)
         {
-            PatToken token = null;
-            this.cache.Value.TryGetValue(key, out token);
+            this.cache.Value.TryGetValue(key, out PatToken token);
             return token;
         }
 

--- a/src/AdoPat/PatCache.cs
+++ b/src/AdoPat/PatCache.cs
@@ -37,14 +37,14 @@ namespace Microsoft.Authentication.AdoPat
         }
 
         /// <inheritdoc/>
-        public PatToken GetPat(string key)
+        public PatToken Get(string key)
         {
             this.cache.Value.TryGetValue(key, out PatToken token);
             return token;
         }
 
         /// <inheritdoc/>
-        public void PutPat(string key, PatToken patToken)
+        public void Put(string key, PatToken patToken)
         {
             // Insert or overwrite the key with the given PatToken. Skip
             // intermediate string serialization by serializing directly to

--- a/src/AdoPat/PatCache.cs
+++ b/src/AdoPat/PatCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Authentication.AdoPat
     /// <summary>
     /// A simple cache mapping <see cref="string"/> to <see cref="PatToken"/> backed by secure storage.
     /// </summary>
-    public class PatCache
+    public class PatCache : IPatCache
     {
         private IStorageWrapper storage;
 
@@ -33,11 +33,7 @@ namespace Microsoft.Authentication.AdoPat
             this.cache = new Lazy<Dictionary<string, PatToken>>(() => this.ReadStorage());
         }
 
-        /// <summary>
-        /// Get a <see cref="PatToken"/> from the cache.
-        /// </summary>
-        /// <param name="key">The key for the target entry.</param>
-        /// <returns>The target value.</returns>
+        /// <inheritdoc/>
         public PatToken GetPat(string key)
         {
             PatToken token = null;
@@ -45,11 +41,7 @@ namespace Microsoft.Authentication.AdoPat
             return token;
         }
 
-        /// <summary>
-        /// Put a <see cref="PatToken"/> into the cache. May overwrite existing values.
-        /// </summary>
-        /// <param name="key">The key for this entry.</param>
-        /// <param name="patToken">The value for this entry.</param>
+        /// <inheritdoc/>
         public void PutPat(string key, PatToken patToken)
         {
             // Insert or overwrite the key with the given PatToken. Skip

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Authentication.AdoPat
     /// <summary>
     /// An abstraction over common operations with the Azure DevOps PAT Lifecycle Management REST API.
     /// </summary>
-    public class PatClient
+    public class PatClient : IPatClient
     {
         private const int PageSize = 100; // Using the maximum allowable page size allows us to reduce HTTP calls.
 
@@ -32,12 +32,7 @@ namespace Microsoft.Authentication.AdoPat
             this.client = client;
         }
 
-        /// <summary>
-        /// Creates a new PAT.
-        /// </summary>
-        /// <param name="patTokenCreateRequest">The PAT creation request.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>A <see cref="Task"/> returning a <see cref="PatTokenResult"/>.</returns>
+        /// <inheritdoc/>
         public async Task<PatToken> CreatePatAsync(
             PatTokenCreateRequest patTokenCreateRequest,
             CancellationToken cancellationToken = default)
@@ -55,11 +50,7 @@ namespace Microsoft.Authentication.AdoPat
             return patTokenResult.PatToken;
         }
 
-        /// <summary>
-        /// Gets all active PATs.
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>A mapping of authorization ID to active PATs.</returns>
+        /// <inheritdoc/>
         public async Task<IDictionary<Guid, PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
         {
             // Initialize a PagedPatTokens so that we can use the continuation token
@@ -87,13 +78,7 @@ namespace Microsoft.Authentication.AdoPat
             return pats;
         }
 
-        /// <summary>
-        /// Creates a new PAT with a new 'valid to' date by replicating an existing one.
-        /// </summary>
-        /// <param name="patToken">An existing <see cref="PatToken"/>.</param>
-        /// <param name="validTo">The new expiration date for the regenerated token.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>A <see cref="Task"/> returning a <see cref="PatToken"/>.</returns>
+        /// <inheritdoc/>
         public async Task<PatToken> RegeneratePatAsync(
             PatToken patToken,
             DateTime validTo,

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Authentication.AdoPat
     /// <summary>
     /// An abstraction over common operations with the Azure DevOps PAT Lifecycle Management REST API.
     /// </summary>
+    /// <remarks>
+    /// This class and its methods are not threadsafe. Locking must be handled externally.
+    /// </remarks>
     public class PatClient : IPatClient
     {
         private const int PageSize = 100; // Using the maximum allowable page size allows us to reduce HTTP calls.

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -37,9 +37,18 @@ namespace Microsoft.Authentication.AdoPat
 
         /// <inheritdoc/>
         public async Task<PatToken> CreateAsync(
-            PatTokenCreateRequest patTokenCreateRequest,
+            string displayName,
+            string scope,
+            DateTime validTo,
             CancellationToken cancellationToken = default)
         {
+            var patTokenCreateRequest = new PatTokenCreateRequest
+            {
+                DisplayName = displayName,
+                Scope = scope,
+                ValidTo = validTo,
+                AllOrgs = AllOrgs,
+            };
             var patTokenResult = await this.client.CreatePatAsync(
                 patTokenCreateRequest,
                 cancellationToken: cancellationToken)
@@ -100,16 +109,10 @@ namespace Microsoft.Authentication.AdoPat
             //
             // For more info see:
             // https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/manage-personal-access-tokens-via-api?view=azure-devops#q-how-can-i-regeneraterotate-pats-through-the-api-i-saw-that-option-in-the-ui-but-i-dont-see-a-similar-method-in-the-api
-            PatTokenCreateRequest patTokenCreateRequest = new PatTokenCreateRequest
-            {
-                DisplayName = patToken.DisplayName,
-                Scope = patToken.Scope,
-                ValidTo = validTo,
-                AllOrgs = AllOrgs,
-            };
-
             var renewedPatToken = await this.CreateAsync(
-                patTokenCreateRequest,
+                patToken.DisplayName,
+                patToken.Scope,
+                validTo: validTo,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/AdoPat/PatClient.cs
+++ b/src/AdoPat/PatClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Authentication.AdoPat
         }
 
         /// <inheritdoc/>
-        public async Task<PatToken> CreatePatAsync(
+        public async Task<PatToken> CreateAsync(
             PatTokenCreateRequest patTokenCreateRequest,
             CancellationToken cancellationToken = default)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.Authentication.AdoPat
         }
 
         /// <inheritdoc/>
-        public async Task<IDictionary<Guid, PatToken>> GetActivePatsAsync(CancellationToken cancellationToken = default)
+        public async Task<IDictionary<Guid, PatToken>> ListActiveAsync(CancellationToken cancellationToken = default)
         {
             // Initialize a PagedPatTokens so that we can use the continuation token
             // in the scope of the conditional of the do while loop below. Azure
@@ -82,7 +82,7 @@ namespace Microsoft.Authentication.AdoPat
         }
 
         /// <inheritdoc/>
-        public async Task<PatToken> RegeneratePatAsync(
+        public async Task<PatToken> RegenerateAsync(
             PatToken patToken,
             DateTime validTo,
             CancellationToken cancellationToken = default)
@@ -108,7 +108,7 @@ namespace Microsoft.Authentication.AdoPat
                 AllOrgs = AllOrgs,
             };
 
-            var renewedPatToken = await this.CreatePatAsync(
+            var renewedPatToken = await this.CreateAsync(
                 patTokenCreateRequest,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -59,13 +59,13 @@ namespace Microsoft.Authentication.AdoPat
                     ValidTo = this.now().AddDays(ValidToExtensionDays),
                     AllOrgs = default,
                 };
-                pat = await this.client.CreatePatAsync(patTokencreateRequest, cancellationToken).ConfigureAwait(false);
+                pat = await this.client.CreateAsync(patTokencreateRequest, cancellationToken).ConfigureAwait(false);
                 writeBack = true;
             }
 
             if (this.ExpiringSoon(pat))
             {
-                pat = await this.client.RegeneratePatAsync(
+                pat = await this.client.RegenerateAsync(
                     pat,
                     this.now().AddDays(ValidToExtensionDays),
                     cancellationToken)
@@ -84,7 +84,7 @@ namespace Microsoft.Authentication.AdoPat
         // Whether the given PAT is still considered active by Azure DevOps.
         private async Task<bool> Inactive(PatToken pat, CancellationToken cancellationToken = default)
         {
-            var activePats = await this.client.GetActivePatsAsync(cancellationToken).ConfigureAwait(false);
+            var activePats = await this.client.ListActiveAsync(cancellationToken).ConfigureAwait(false);
             return !activePats.ContainsKey(pat.AuthorizationId);
         }
 

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -51,14 +51,12 @@ namespace Microsoft.Authentication.AdoPat
 
             if (pat == null || await this.Inactive(pat, cancellationToken).ConfigureAwait(false))
             {
-                var patTokencreateRequest = new PatTokenCreateRequest
-                {
-                    DisplayName = options.DisplayName,
-                    Scope = string.Join(" ", options.Scopes),
-                    ValidTo = this.now().AddDays(ValidToExtensionDays),
-                    AllOrgs = default,
-                };
-                pat = await this.client.CreateAsync(patTokencreateRequest, cancellationToken).ConfigureAwait(false);
+                pat = await this.client.CreateAsync(
+                    displayName: options.DisplayName,
+                    scope: string.Join(" ", options.Scopes),
+                    validTo: this.now().AddDays(ValidToExtensionDays),
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
                 this.cache.Put(options.CacheKey(), pat);
             }
             else if (this.ExpiringSoon(pat))

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+    /// <summary>
+    /// Manage the interaction between the PAT cache and Azure DevOps.
+    /// </summary>
+    public class PatManager
+    {
+        private const int ValidToExtensionDays = 7;
+        private const int NearingExpirationDays = 2;
+
+        private IPatCache cache;
+        private IPatClient client;
+        private Func<DateTime> now;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatManager"/> class.
+        /// </summary>
+        /// <param name="cache">Any class that implements the <see cref="IPatCache"/> interface.</param>
+        /// <param name="client">Any class that implements the <see cref="IPatClient"/> interface.</param>
+        /// <param name="now">A function for computing the current moment. Defaults to null, which
+        /// uses <see cref="DateTime.UtcNow"/>. Overriding this should only be necessary in testing.</param>
+        public PatManager(IPatCache cache, IPatClient client, Func<DateTime> now = null)
+        {
+            this.cache = cache;
+            this.client = client;
+            this.now = now ?? new Func<DateTime>(() => DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Fetches a PAT matching the given options from the cache, creating or regenerating a new PAT as necessary.
+        /// </summary>
+        /// <param name="options">Options used to match the PAT in the cache or when creating/regenerating a new one.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>An Azure DevOps Personal Access Token.</returns>
+        public async Task<PatToken> GetPatAsync(
+            PatOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            bool writeBack = false;
+            var pat = this.cache.GetPat(options.ToString());
+
+            if (pat == null || await this.Inactive(pat, cancellationToken).ConfigureAwait(false))
+            {
+                var patTokencreateRequest = new PatTokenCreateRequest
+                {
+                    DisplayName = options.DisplayName,
+                    Scope = string.Join(" ", options.Scopes),
+                    ValidTo = this.now().AddDays(ValidToExtensionDays),
+                    AllOrgs = default,
+                };
+                pat = await this.client.CreatePatAsync(patTokencreateRequest, cancellationToken).ConfigureAwait(false);
+                writeBack = true;
+            }
+
+            if (this.ExpiringSoon(pat))
+            {
+                pat = await this.client.RegeneratePatAsync(
+                    pat,
+                    this.now().AddDays(ValidToExtensionDays),
+                    cancellationToken)
+                .ConfigureAwait(false);
+                writeBack = true;
+            }
+
+            if (writeBack)
+            {
+                this.cache.PutPat(options.ToString(), pat);
+            }
+
+            return pat;
+        }
+
+        // Whether the given PAT is still considered active by Azure DevOps.
+        private async Task<bool> Inactive(PatToken pat, CancellationToken cancellationToken = default)
+        {
+            var activePats = await this.client.GetActivePatsAsync(cancellationToken).ConfigureAwait(false);
+            return !activePats.ContainsKey(pat.AuthorizationId);
+        }
+
+        // Whether the given PAT will expire before `NearingExpirationDays`.
+        private bool ExpiringSoon(PatToken pat)
+        {
+            return pat.ValidTo < this.now().AddDays(NearingExpirationDays);
+        }
+    }
+}

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Authentication.AdoPat
             CancellationToken cancellationToken = default)
         {
             bool writeBack = false;
-            var pat = this.cache.GetPat(options.ToString());
+            var pat = this.cache.Get(options.ToString());
 
             if (pat == null || await this.Inactive(pat, cancellationToken).ConfigureAwait(false))
             {
@@ -75,7 +75,7 @@ namespace Microsoft.Authentication.AdoPat
 
             if (writeBack)
             {
-                this.cache.PutPat(options.ToString(), pat);
+                this.cache.Put(options.ToString(), pat);
             }
 
             return pat;

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Authentication.AdoPat
     /// <summary>
     /// Manage the interaction between the PAT cache and Azure DevOps.
     /// </summary>
+    /// <remarks>
+    /// This class and its methods are not threadsafe. Locking must be handled externally.
+    /// </remarks>
     public class PatManager
     {
         private const int ValidToExtensionDays = 7;

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Authentication.AdoPat
             CancellationToken cancellationToken = default)
         {
             bool writeBack = false;
-            var pat = this.cache.Get(options.ToString());
+            var pat = this.cache.Get(options.CacheKey());
 
             if (pat == null || await this.Inactive(pat, cancellationToken).ConfigureAwait(false))
             {
@@ -75,7 +75,7 @@ namespace Microsoft.Authentication.AdoPat
 
             if (writeBack)
             {
-                this.cache.Put(options.ToString(), pat);
+                this.cache.Put(options.CacheKey(), pat);
             }
 
             return pat;

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Authentication.AdoPat
         {
             var pat = this.cache.Get(options.CacheKey());
 
+            // If the PAT is null it means it wasn't present in the cache, so we must create one.
+            // If the PAT was present in the cache, but is inactive we must also create a new one.
+            // If the PAT was present in the cache, but will expire soon we must regenerate it.
+            // Otherwise we can simply return the PAT as is.
             if (pat == null || await this.Inactive(pat, cancellationToken).ConfigureAwait(false))
             {
                 pat = await this.client.CreateAsync(

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Authentication.AdoPat
 
         /// <summary>
         /// Fetches a PAT matching the given options from the cache, creating or regenerating a new PAT as necessary.
+        /// The cache controlled by this PatManager is not a shared cache and is *only* updated by this method.
         /// </summary>
         /// <param name="options">Options used to match the PAT in the cache or when creating/regenerating a new one.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Authentication.AdoPat
         public string[] Scopes { get; init; } = default;
 
         /// <summary>
-        /// Gets the string representation of these PAT options.
+        /// Gets the string used as a cache key which corresponds to these options.
         /// </summary>
-        /// <returns>The string representation of these PAT options.</returns>
-        public override string ToString()
+        /// <returns>The cache key.</returns>
+        public string CacheKey()
         {
             var strings = new List<string> { this.Organization, this.DisplayName };
             strings.AddRange(this.Scopes);

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.Authentication.AdoPat
 {
     /// <summary>
@@ -30,14 +33,9 @@ namespace Microsoft.Authentication.AdoPat
         /// <returns>The string representation of these PAT options.</returns>
         public override string ToString()
         {
-            string output = $"{this.Organization} {this.DisplayName}";
-
-            foreach (var scope in this.Scopes)
-            {
-                output += $" {scope.ToString()}";
-            }
-
-            return output;
+            var strings = new List<string> { this.Organization, this.DisplayName };
+            strings.AddRange(this.Scopes);
+            return string.Join(" ", strings);
         }
     }
 }

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    /// <summary>
+    /// A grouping of common options necessary to create or renew a PAT.
+    /// Used as a key for the PAT cache.
+    /// </summary>
+    public record PatOptions
+    {
+        /// <summary>
+        /// Gets the PAT organization.
+        /// </summary>
+        public string Organization { get; init; } = default;
+
+        /// <summary>
+        /// Gets the PAT display name.
+        /// </summary>
+        public string DisplayName { get; init; } = default;
+
+        /// <summary>
+        /// Gets the PAT scopes.
+        /// </summary>
+        public string[] Scopes { get; init; } = default;
+
+        /// <summary>
+        /// Gets the string representation of these PAT options.
+        /// </summary>
+        /// <returns>The string representation of these PAT options.</returns>
+        public override string ToString()
+        {
+            string output = $"{this.Organization} {this.DisplayName}";
+
+            foreach (var scope in this.Scopes)
+            {
+                output += $" {scope.ToString()}";
+            }
+
+            return output;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `PatManager` class to the `Microsoft.Authentication.AdoPat` namespace. It also add supporting interfaces and classes, namely

- A `PatOption` record for collecting common options used when fetching or creating PATs.
- An `IPatCache` interface to make testing easier.
- An `IPatClient` interface to make testing easier.
- Corresponding tests in the `Microsoft.Authentication.AdoPat.Test` namespace.

As in #176 and #183, this entity relationship diagram shows the rough layout of parts needed to make this work.

```mermaid
erDiagram
    CLI ||..|| PatManager : uses
    PatManager ||..|{ PatCache : uses
    PatManager ||..|{ PatClient : uses
    PatCache }|..|{ StorageWrapper : uses
    PatClient }|..|{ TokensHttpClientWrapper : uses
```

This is phase 3 of 4, where the cache and API client are tied together and orchestrated in the `PatManager`. A subsequent PR will utilize this class in `Program.Main` of the `azureauth ado pat` subcommand. Until that final phase this code is still "unlit" and should not factor into a public release.