### PR TITLE
Download ADO artifacts after triggering ADO pipeline

### DIFF
--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -74,7 +74,7 @@ def trigger_azure_pipeline_and_wait_until_its_completed(
     return run_id
 
 
-def download_callback(chunk) -> None:
+def download_callback(chunk, response) -> None:
     print(f"Downloaded chunk of size: {str(len(chunk))}")
 
 

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -138,7 +138,6 @@ def main() -> None:
         organization,
         project,
         pipeline_id,
-        ado_pat,
         version,
         commit_hash,
     )

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -83,7 +83,7 @@ def download_artifact(
     project: str,
     run_id: str,
     ado_artifact_name: str,
-    artifact_download_path: str,
+    download_path: str,
 ) -> None:
     """Download the ADO artifact to the given download path"""
     build_client = ado_client.get_build_client()
@@ -98,7 +98,7 @@ def download_artifact(
     for chunk in artifact:
         content += bytearray(chunk)
     zf = zipfile.ZipFile(io.BytesIO(content), "r")
-    zf.extractall(artifact_download_path)
+    zf.extractall(download_path)
 
 
 def main() -> None:


### PR DESCRIPTION
### Changes:
Currently, we trigger and wait for the ADO pipeline to build, sign and publish Linux binaries. We exit once the ADO pipeline completes the run.

But since we are planning to release Linux signed binaries on GitHub, changed the script to download the ADO artifacts once the pipeline run is completed.