### PR TITLE
Extract auth mode interaction filtering into static methods for reuse

### DIFF
--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -69,7 +69,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker };
 
             // Act + Assert
-            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.Default);
+            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.Default);
         }
 
         [TestCase("AZUREAUTH_NO_USER")]
@@ -81,7 +81,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.IWA);
+            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.IWA);
         }
 #else
 

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureAuth.Test
+{
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Microsoft.Authentication.AzureAuth;
+    using Microsoft.Authentication.AzureAuth.Commands;
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Office.Lasso.Interfaces;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ModeExtensions = Microsoft.Authentication.AzureAuth.AuthModeExtensions;
+
+    public class AuthModeExtensionsTest
+    {
+        private Mock<IEnv> envMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.envMock = new Mock<IEnv>();
+        }
+
+        [TestCase("1", true)]
+        [TestCase("non-empty-string", false)]
+        [TestCase("true", false)]
+        [TestCase("", false)]
+        public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
+
+            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
+        }
+
+        [TestCase("1", true)]
+        [TestCase("non-empty-string", true)]
+        [TestCase("true", true)]
+        [TestCase("", false)]
+        public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
+            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
+        }
+
+        [Test]
+        public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().BeFalse();
+        }
+
+#if PlatformWindows
+        [Test]
+        public void FilterInteraction_Allowed()
+        {
+            // Arrange
+            this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
+            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(string.Empty);
+
+            var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker };
+
+            // Act + Assert
+            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.Default);
+        }
+
+        [TestCase("AZUREAUTH_NO_USER")]
+        [TestCase("Corext_NonInteractive")]
+        public void Filterinteraction_Interactive_Auth_Disabled(string envVar)
+        {
+            // Arrange
+            this.envMock.Setup(e => e.Get(envVar)).Returns("1");
+            var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker, AuthMode.DeviceCode };
+
+            // Act + Assert
+            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.IWA);
+        }
+#else
+
+        public void FilterInteraction_Allowed()
+        {
+            // Arrange
+            this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
+            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(string.Empty);
+
+            var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
+
+            // Act + Assert
+            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.Default);
+        }
+
+        [TestCase("AZUREAUTH_NO_USER")]
+        [TestCase("Corext_NonInteractive")]
+        public void Filterinteraction_Interactive_Auth_Disabled(string envVar)
+        {
+            // Arrange
+            this.envMock.Setup(e => e.Get(envVar)).Returns("1");
+            var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
+
+            // Act + Assert
+            subject.FilterInteraction(this.envMock.Object).Should().Be((AuthMode)0);
+        }
+#endif
+    }
+}

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace AzureAuth.Test
 
 #if PlatformWindows
         [Test]
-        public void FilterInteraction_Allowed()
+        public void CombinedAuthMode_Allowed()
         {
             // Arrange
             this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
@@ -54,8 +54,7 @@ namespace AzureAuth.Test
             subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.IWA);
         }
 #else
-
-        public void FilterInteraction_Allowed()
+        public void CombinedAuthMode_Allowed()
         {
             // Arrange
             this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
@@ -64,7 +63,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.FilterInteraction(this.envMock.Object).Should().Be(AuthMode.Default);
+            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.Default);
         }
 
         [TestCase("AZUREAUTH_NO_USER")]
@@ -76,7 +75,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.FilterInteraction(this.envMock.Object).Should().Be((AuthMode)0);
+            subject.CombinedAuthMode(this.envMock.Object).Should().Be((AuthMode)0);
         }
 #endif
     }

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -28,36 +28,6 @@ namespace AzureAuth.Test
             this.envMock = new Mock<IEnv>();
         }
 
-        [TestCase("1", true)]
-        [TestCase("non-empty-string", false)]
-        [TestCase("true", false)]
-        [TestCase("", false)]
-        public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
-        {
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
-
-            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
-        }
-
-        [TestCase("1", true)]
-        [TestCase("non-empty-string", true)]
-        [TestCase("true", true)]
-        [TestCase("", false)]
-        public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
-        {
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
-            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
-        }
-
-        [Test]
-        public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
-        {
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            ModeExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().BeFalse();
-        }
-
 #if PlatformWindows
         [Test]
         public void FilterInteraction_Allowed()

--- a/src/AzureAuth.Test/CommandAadTest.cs
+++ b/src/AzureAuth.Test/CommandAadTest.cs
@@ -478,66 +478,6 @@ invalid_key = ""this is not a valid alias key""
             this.telemetryServiceMock.VerifyAll();
         }
 
-        [TestCase("1", true)]
-        [TestCase("non-empty-string", false)]
-        [TestCase("true", false)]
-        [TestCase("", false)]
-        public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
-            subject.InteractiveAuthDisabled().Should().Be(expected);
-        }
-
-        [TestCase("1", true)]
-        [TestCase("non-empty-string", true)]
-        [TestCase("true", true)]
-        [TestCase("", false)]
-        public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
-            subject.InteractiveAuthDisabled().Should().Be(expected);
-        }
-
-        [Test]
-        public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
-            subject.InteractiveAuthDisabled().Should().BeFalse();
-        }
-
-#if PlatformWindows
-        [TestCase("non-empty-string")]
-        public void GetCombinedAuthMode_withInteractiveAuthDisabled(string noUser)
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
-            subject.CombinedAuthMode.Should().Be(AuthMode.IWA);
-        }
-
-        public void GetCombinedAuthMode_withInteractiveAuthEnabled()
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            var authModes = new List<AuthMode>();
-            authModes.Add(AuthMode.Broker);
-            subject.AuthModes = authModes;
-            subject.CombinedAuthMode.Should().Be(AuthMode.Broker);
-        }
-#endif
-
-        public void GetCombinedAuthMode_withInteractiveAuthEnabled_NonWindowsPlatform()
-        {
-            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
-            var authModes = new List<AuthMode>();
-            authModes.Add(AuthMode.Web);
-            subject.AuthModes = authModes;
-            subject.CombinedAuthMode.Should().Be(AuthMode.Web);
-        }
-
         /// <summary>
         /// The root path.
         /// </summary>

--- a/src/AzureAuth.Test/IEnvExtensionsTest.cs
+++ b/src/AzureAuth.Test/IEnvExtensionsTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureAuth.Test
+{
+    using FluentAssertions;
+
+    using Microsoft.Authentication.AzureAuth;
+    using Microsoft.Office.Lasso.Interfaces;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    public class IEnvExtensionsTest
+    {
+        private Mock<IEnv> envMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.envMock = new Mock<IEnv>();
+        }
+
+        [TestCase("1", true)]
+        [TestCase("non-empty-string", false)]
+        [TestCase("true", false)]
+        [TestCase("", false)]
+        public void InteractiveAuth_IsDisabledOnCorextEnvVar(string corextNonInteractive, bool expected)
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(corextNonInteractive);
+
+            IEnvExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
+        }
+
+        [TestCase("1", true)]
+        [TestCase("non-empty-string", true)]
+        [TestCase("true", true)]
+        [TestCase("", false)]
+        public void InteractiveAuth_IsDisabledOnNoUserEnvVar(string noUser, bool expected)
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            this.envMock.Setup(e => e.Get("AZUREAUTH_NO_USER")).Returns(noUser);
+            IEnvExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().Be(expected);
+        }
+
+        [Test]
+        public void InteractiveAuth_IsEnabledIfEnvVarsAreNotSet()
+        {
+            this.envMock.Setup(env => env.Get(It.IsAny<string>())).Returns((string)null);
+            IEnvExtensions.InteractiveAuthDisabled(this.envMock.Object).Should().BeFalse();
+        }
+    }
+}

--- a/src/AzureAuth/Ado/PatFromEnv.cs
+++ b/src/AzureAuth/Ado/PatFromEnv.cs
@@ -73,6 +73,5 @@ namespace Microsoft.Authentication.AzureAuth.Ado
                 Exists = false,
             };
         }
-
     }
 }

--- a/src/AzureAuth/AuthModeExtensions.cs
+++ b/src/AzureAuth/AuthModeExtensions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AzureAuth
+{
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Office.Lasso.Interfaces;
+
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Extensions to <see cref="AuthMode"/>s.
+    /// </summary>
+    public static class AuthModeExtensions
+    {
+        /// <summary>
+        /// Filters a list of <see cref="AuthMode"/> for interaction returning a single aggregate <see cref="AuthMode"/>.
+        /// </summary>
+        /// <param name="authModes"><see cref="AuthMode"/>s to aggregate and filter.</param>
+        /// <param name="env">An <see cref="IEnv"/> to use.</param>
+        /// <returns>A single aggregate <see cref="AuthMode"/> filtered for interactivity.</returns>
+        public static AuthMode FilterInteraction(this IEnumerable<AuthMode> authModes, IEnv env)
+        {
+            if (InteractiveAuthDisabled(env))
+            {
+#if PlatformWindows
+                return AuthMode.IWA;
+#else
+                return 0;
+#endif
+            }
+
+            return authModes.Aggregate((a1, a2) => a1 | a2);
+        }
+
+        /// <summary>
+        /// Determines whether interactive auth is allowed or not.
+        /// </summary>
+        /// <param name="env">An <see cref="IEnv"/> to use.</param>
+        /// <returns>A boolean to indicate PCA is disabled.</returns>
+        public static bool InteractiveAuthDisabled(IEnv env)
+        {
+            return !string.IsNullOrEmpty(env.Get(EnvVars.NoUser)) ||
+                string.Equals("1", env.Get(EnvVars.CorextNonInteractive));
+        }
+    }
+}

--- a/src/AzureAuth/AuthModeExtensions.cs
+++ b/src/AzureAuth/AuthModeExtensions.cs
@@ -3,11 +3,11 @@
 
 namespace Microsoft.Authentication.AzureAuth
 {
-    using Microsoft.Authentication.MSALWrapper;
-    using Microsoft.Office.Lasso.Interfaces;
-
     using System.Collections.Generic;
     using System.Linq;
+
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Office.Lasso.Interfaces;
 
     /// <summary>
     /// Extensions to <see cref="AuthMode"/>s.
@@ -20,7 +20,7 @@ namespace Microsoft.Authentication.AzureAuth
         /// <param name="authModes"><see cref="AuthMode"/>s to aggregate and filter.</param>
         /// <param name="env">An <see cref="IEnv"/> to use.</param>
         /// <returns>A single aggregate <see cref="AuthMode"/> filtered for interactivity.</returns>
-        public static AuthMode FilterInteraction(this IEnumerable<AuthMode> authModes, IEnv env)
+        public static AuthMode CombinedAuthMode(this IEnumerable<AuthMode> authModes, IEnv env)
         {
             if (InteractiveAuthDisabled(env))
             {

--- a/src/AzureAuth/AuthModeExtensions.cs
+++ b/src/AzureAuth/AuthModeExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Authentication.AzureAuth
         /// <returns>A single aggregate <see cref="AuthMode"/> filtered for interactivity.</returns>
         public static AuthMode CombinedAuthMode(this IEnumerable<AuthMode> authModes, IEnv env)
         {
-            if (InteractiveAuthDisabled(env))
+            if (env.InteractiveAuthDisabled())
             {
 #if PlatformWindows
                 return AuthMode.IWA;
@@ -32,17 +32,6 @@ namespace Microsoft.Authentication.AzureAuth
             }
 
             return authModes.Aggregate((a1, a2) => a1 | a2);
-        }
-
-        /// <summary>
-        /// Determines whether interactive auth is allowed or not.
-        /// </summary>
-        /// <param name="env">An <see cref="IEnv"/> to use.</param>
-        /// <returns>A boolean to indicate PCA is disabled.</returns>
-        public static bool InteractiveAuthDisabled(IEnv env)
-        {
-            return !string.IsNullOrEmpty(env.Get(EnvVars.NoUser)) ||
-                string.Equals("1", env.Get(EnvVars.CorextNonInteractive));
         }
     }
 }

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -488,7 +488,7 @@ Allowed values: [all, web, devicecode]";
                 // Normal production flow
                 authFlows = AuthFlowFactory.Create(
                 this.logger,
-                this.AuthModes.FilterInteraction(this.env),
+                this.AuthModes.CombinedAuthMode(this.env),
                 new Guid(this.authSettings.Client),
                 new Guid(this.authSettings.Tenant),
                 scopes,

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -316,7 +316,7 @@ Allowed values: [all, web, devicecode]";
             // Small bug in Lasso - Add does not accept a null IEnumerable here.
             this.eventData.Add("settings_scopes", this.authSettings.Scopes ?? new List<string>());
 
-            if (ModeExtensions.InteractiveAuthDisabled(this.env))
+            if (this.env.InteractiveAuthDisabled())
             {
                 this.eventData.Add(EnvVars.CorextNonInteractive, this.env.Get(EnvVars.CorextNonInteractive));
                 this.eventData.Add(EnvVars.NoUser, this.env.Get(EnvVars.NoUser));

--- a/src/AzureAuth/EnvVars.cs
+++ b/src/AzureAuth/EnvVars.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Authentication.AzureAuth
     /// <summary>
     /// A static class to hold env var names.
     /// </summary>
-    internal static class EnvVars
+    public static class EnvVars
     {
         /// <summary>
         /// Holds the name of the env var to get an application insights ingestion token.

--- a/src/AzureAuth/IEnvExtensions.cs
+++ b/src/AzureAuth/IEnvExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AzureAuth
+{
+    using Microsoft.Office.Lasso.Interfaces;
+
+    /// <summary>
+    /// Extension methods to Lasso's <see cref="IEnv"/> interface.
+    /// </summary>
+    public static class IEnvExtensions
+    {
+        private const string CorextPositiveValue = "1";
+
+        /// <summary>
+        /// Determines whether interactive auth is disabled or not.
+        /// </summary>
+        /// <param name="env">The <see cref="IEnv"/> to use to get environment variables.</param>
+        /// <returns>A boolean to indicate if interactive auth modes should be disabled.</returns>
+        public static bool InteractiveAuthDisabled(this IEnv env)
+        {
+            return !string.IsNullOrEmpty(env.Get(EnvVars.NoUser)) ||
+                string.Equals(CorextPositiveValue, env.Get(EnvVars.CorextNonInteractive));
+        }
+    }
+}


### PR DESCRIPTION
Each Command that auths will need to respect our current logic around disabling interactive auth, so we migrate that business logic to it's own extenion on `IEnv` and the lopgic for how that choice impacts the `AuthMode` we want to use, we extract to `AuthModeExtensions`