### PR TITLE
[Urgent] Fix GitHub workflow.

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -12,7 +12,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
+      statuses: write
+      
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   test:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
It is very likely the previous PR integrating CodeQL breaks our build and test workflow on main branch.
According to [Error: 403 "Resource not accessible by integration" when using Dependabot](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow?learn=code_security_actions#error-403-resource-not-accessible-by-integration-when-using-dependabot), we need to add `security_events: write` scope to the job.
