### PR TITLE
Break apart AuthMode Extensions

### DIFF
--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -75,7 +75,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.Combined().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.None);
+            subject.Combine().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.None);
         }
 #endif
     }

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -39,7 +39,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker };
 
             // Act + Assert
-            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.Default);
+            subject.Combine().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.Default);
         }
 
         [TestCase("AZUREAUTH_NO_USER")]
@@ -51,7 +51,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.IWA);
+            subject.Combine().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.IWA);
         }
 #else
         public void CombinedAuthMode_Allowed()
@@ -63,7 +63,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.CombinedAuthMode(this.envMock.Object).Should().Be(AuthMode.Default);
+            subject.Combine().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.Default);
         }
 
         [TestCase("AZUREAUTH_NO_USER")]
@@ -75,7 +75,7 @@ namespace AzureAuth.Test
             var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
 
             // Act + Assert
-            subject.CombinedAuthMode(this.envMock.Object).Should().Be((AuthMode)0);
+            subject.Combined().PreventInteractionIfNeeded(this.envMock.Object).Should().Be(AuthMode.None);
         }
 #endif
     }

--- a/src/AzureAuth/AuthModeExtensions.cs
+++ b/src/AzureAuth/AuthModeExtensions.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Authentication.AzureAuth
         /// <summary>
         /// Filters a list of <see cref="AuthMode"/> for interaction returning a single aggregate <see cref="AuthMode"/>.
         /// </summary>
-        /// <param name="authModes"><see cref="AuthMode"/>s to aggregate and filter.</param>
+        /// <param name="authMode">Starting <see cref="AuthMode"/>to filter.</param>
         /// <param name="env">An <see cref="IEnv"/> to use.</param>
-        /// <returns>A single aggregate <see cref="AuthMode"/> filtered for interactivity.</returns>
-        public static AuthMode CombinedAuthMode(this IEnumerable<AuthMode> authModes, IEnv env)
+        /// <returns>An <see cref="AuthMode"/> with only non-interactive auth modes allowed, if specificed by the environment.</returns>
+        public static AuthMode PreventInteractionIfNeeded(this AuthMode authMode, IEnv env)
         {
             if (env.InteractiveAuthDisabled())
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Authentication.AzureAuth
 #endif
             }
 
-            return authModes.Aggregate((a1, a2) => a1 | a2);
+            return authMode;
         }
     }
 }

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     using System.IO.Abstractions;
     using System.Linq;
     using System.Threading;
-    using System.Threading.Tasks;
 
     using McMaster.Extensions.CommandLineUtils;
 
@@ -21,12 +20,10 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     using Microsoft.Office.Lasso.Interfaces;
     using Microsoft.Office.Lasso.Telemetry;
 
-    using ModeExtensions = Microsoft.Authentication.AzureAuth.AuthModeExtensions;
-
     /// <summary>
     /// Command class for authenticating with AAD.
     /// </summary>
-    [Command("aad", Description = "todo")]
+    [Command("aad", Description = "Acquire an Azure Access Token")]
     public class CommandAad
     {
         /// <summary>

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -488,7 +488,7 @@ Allowed values: [all, web, devicecode]";
                 // Normal production flow
                 authFlows = AuthFlowFactory.Create(
                 this.logger,
-                this.AuthModes.CombinedAuthMode(this.env),
+                this.AuthModes.Combine().PreventInteractionIfNeeded(this.env),
                 new Guid(this.authSettings.Client),
                 new Guid(this.authSettings.Tenant),
                 scopes,

--- a/src/MSALWrapper/AuthMode.cs
+++ b/src/MSALWrapper/AuthMode.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Authentication.MSALWrapper
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Auth modes.
@@ -11,6 +13,11 @@ namespace Microsoft.Authentication.MSALWrapper
     [Flags]
     public enum AuthMode : short
     {
+        /// <summary>
+        /// No auth modes are enabled.
+        /// </summary>
+        None = 0,
+
         /// <summary>
         /// Web auth mode (Embedded Web View for Windows and System Web Browser for OSX).
         /// </summary>
@@ -105,6 +112,17 @@ namespace Microsoft.Authentication.MSALWrapper
 #else
             return false;
 #endif
+        }
+
+        /// <summary>
+        /// Combine multiple AuthModes into a single AuthMode.
+        /// This does not lose any information because <see cref="AuthMode"/> is a bit flag.
+        /// </summary>
+        /// <param name="authModes">AuthModes to combine.</param>
+        /// <returns>A single <see cref="AuthMode"/> computed by applying bit-wise OR to the auth modes given.</returns>
+        public static AuthMode Combine(this IEnumerable<AuthMode> authModes)
+        {
+            return authModes.Aggregate((a1, a2) => a1 | a2);
         }
     }
 }


### PR DESCRIPTION
The AuthMode extension `CombinenAuthMode` felt a little awkward so we pulled apart the combining and the interaction filtering.

The argument type also changed from an `IEnumerable<AuthMode>` to singule `AuthMode` - this forces callers to call `Combine` first, and then `PreventInteractionIfNeeded` making it more clear what is going on.