### PR TITLE
Release 0.7.2 with Lasso patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
 
+## [0.7.2] - 2023-03-08
+### Fixed
+- Upgrade to a new version of Lasso which patches a concurrency bug.
+
 ## [0.7.1] - 2023-03-03
 ### Fixed
 - Upgrade to a new version of Lasso which patches a concurrency bug.

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.2.3" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.8.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Lasso 0.7.1 contains a mutex issue which is the same problem described in #222.
This PR contains a patched Lasso version.

After this PR merged, we will release 0.7.2.