### PR TITLE
Revert "Update release workflow to release Linux binaries"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
@@ -39,8 +39,11 @@ jobs:
     needs: [validate]
     strategy:
       matrix:
-        runtime: [osx-x64, osx-arm64, win10-x64]
+        # We build on Linux, but don't yet ship Linux because we can't easily sign those releases.
+        runtime: [linux-x64, osx-x64, osx-arm64, win10-x64]
         include:
+          - runtime: linux-x64
+            os: ubuntu-latest
           - runtime: osx-x64
             os: macos-latest
           - runtime: osx-arm64
@@ -49,7 +52,7 @@ jobs:
             os: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -90,7 +93,7 @@ jobs:
         runtime: [osx-x64, osx-arm64, win10-x64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
@@ -143,39 +146,7 @@ jobs:
         with:
           name: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
           path: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
-  
-  # Build and sign Linux binaries on Azure DevOps and publish them to GitHub and packages.microsoft.com.
-  linux_release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    env:
-      ADO_LINUX_ARTIFACT_DOWNLOAD_PATH: dist/linux-x64
-      ADO_LINUX_ARTIFACT_NAME: ${{ secrets.ADO_LINUX_ARTIFACT_NAME }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Build, Sign and Download Linux Binaries
-      run: |
-        pip install -r bin/requirements.txt
-        python ./bin/trigger_azure_pipelines.py
-      env:
-        AZURE_DEVOPS_BUILD_PAT: ${{ secrets.AZURE_DEVOPS_BUILD_PAT }}
-        ADO_ORGANIZATION: ${{ secrets.ADO_ORGANIZATION }}
-        ADO_PROJECT: ${{ secrets.ADO_PROJECT}}
-        ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
-        VERSION: ${{ github.event.inputs.version }}
-    - name: Upload ubuntu-amd64 artifact
-      uses: actions/upload-artifact@v3
-      env:
-        DEBIAN_REVISION: 1
-      with:
-        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
-        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
-        
+
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
     runs-on: ubuntu-latest
@@ -217,15 +188,13 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [package, linux_release]
+    needs: [package]
     # The 'release' environment is what requires reviews before creating the release.
     environment:
       name: release
     # These permissions are required in order to use `softprops/action-gh-release` to upload.
     permissions:
       contents: write
-    env:
-        DEBIAN_REVISION: 1
     steps:
     - name: Download win10-x64 artifact
       uses: actions/download-artifact@v3
@@ -239,10 +208,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
-    - name: Download ubuntu-amd64 artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -254,4 +219,3 @@ jobs:
           azureauth-${{ github.event.inputs.version }}-win10-x64.zip
           azureauth-${{ github.event.inputs.version }}-osx-x64.tar.gz
           azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
-          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb


### PR DESCRIPTION
Linux build is failing because of a bug on PMC.

https://github.com/microsoft/linux-package-repositories/issues/34 