### PR TITLE
Initial work to get `ado token` command working. 

### DIFF
--- a/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
+++ b/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
@@ -11,8 +11,8 @@ namespace AzureAuth.Test.Commands.Ado
     internal class CommandTokenTest
     {
         [TestCase("foobar", CommandToken.OutputMode.Token, "foobar")]
-        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Basic :Zm9vYmFy")]
-        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Basic :Zm9vYmFy")]
+        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Basic OmZvb2Jhcg==")]
+        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Basic OmZvb2Jhcg==")]
         public void FormatToken_Basic(string input, CommandToken.OutputMode mode, string expected)
         {
             CommandToken.FormatToken(input, mode, Authorization.Basic).Should().Be(expected);

--- a/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
+++ b/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureAuth.Test.Commands.Ado
+{
+    using FluentAssertions;
+    using Microsoft.Authentication.AzureAuth.Commands.Ado;
+    using NUnit.Framework;
+
+    internal class CommandTokenTest
+    {
+        [Test]
+        public void FormatPat_Token()
+        {
+            CommandToken.FormatPat("foobar", CommandToken.OutputMode.Token).Should().Be("foobar");
+        }
+
+        [Test]
+        public void FormatPat_HeaderValue()
+        {
+            CommandToken.FormatPat("foobar", CommandToken.OutputMode.HeaderValue).Should().Be("Basic Zm9vYmFy");
+        }
+
+        [Test]
+        public void FormatPat_Header()
+        {
+            CommandToken.FormatPat("foobar", CommandToken.OutputMode.Header).Should().Be("Authorization: Basic Zm9vYmFy");
+        }
+    }
+}

--- a/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
+++ b/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
@@ -4,27 +4,26 @@
 namespace AzureAuth.Test.Commands.Ado
 {
     using FluentAssertions;
+    using Microsoft.Authentication.AzureAuth.Ado;
     using Microsoft.Authentication.AzureAuth.Commands.Ado;
     using NUnit.Framework;
 
     internal class CommandTokenTest
     {
-        [Test]
-        public void FormatPat_Token()
+        [TestCase("foobar", CommandToken.OutputMode.Token, "foobar")]
+        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Basic Zm9vYmFy")]
+        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Basic Zm9vYmFy")]
+        public void FormatToken_Basic(string input, CommandToken.OutputMode mode, string expected)
         {
-            CommandToken.FormatPat("foobar", CommandToken.OutputMode.Token).Should().Be("foobar");
+            CommandToken.FormatToken(input, mode, Authorization.Basic).Should().Be(expected);
         }
 
-        [Test]
-        public void FormatPat_HeaderValue()
+        [TestCase("foobar", CommandToken.OutputMode.Token, "foobar")]
+        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Bearer foobar")]
+        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Bearer foobar")]
+        public void FormatToken_Bearer(string input, CommandToken.OutputMode mode, string expected)
         {
-            CommandToken.FormatPat("foobar", CommandToken.OutputMode.HeaderValue).Should().Be("Basic Zm9vYmFy");
-        }
-
-        [Test]
-        public void FormatPat_Header()
-        {
-            CommandToken.FormatPat("foobar", CommandToken.OutputMode.Header).Should().Be("Authorization: Basic Zm9vYmFy");
+            CommandToken.FormatToken(input, mode, Authorization.Bearer).Should().Be(expected);
         }
     }
 }

--- a/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
+++ b/src/AzureAuth.Test/Commands/Ado/CommandTokenTest.cs
@@ -11,8 +11,8 @@ namespace AzureAuth.Test.Commands.Ado
     internal class CommandTokenTest
     {
         [TestCase("foobar", CommandToken.OutputMode.Token, "foobar")]
-        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Basic Zm9vYmFy")]
-        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Basic Zm9vYmFy")]
+        [TestCase("foobar", CommandToken.OutputMode.HeaderValue, "Basic :Zm9vYmFy")]
+        [TestCase("foobar", CommandToken.OutputMode.Header, "Authorization: Basic :Zm9vYmFy")]
         public void FormatToken_Basic(string input, CommandToken.OutputMode mode, string expected)
         {
             CommandToken.FormatToken(input, mode, Authorization.Basic).Should().Be(expected);

--- a/src/AzureAuth/Ado/TokenFormattingExtensions.cs
+++ b/src/AzureAuth/Ado/TokenFormattingExtensions.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Authentication.AzureAuth.Ado
     public static class TokenFormattingExtensions
     {
         private const string AuthorizationHeader = "Authorization:";
-        private const string Basic = "Basic";
-        private const string Bearer = "Bearer";
 
         /// <summary>
         /// Base64 encode <paramref name="value"/> adding padding (=) characters as needed.
@@ -34,7 +32,7 @@ namespace Microsoft.Authentication.AzureAuth.Ado
         /// <returns>A full Authorization header using the Basic scheme.</returns>
         public static string AsHeader(this string value, Authorization scheme)
         {
-            return string.Join(' ', new[] { AuthorizationHeader, scheme.ToString(), scheme.FormatValue(value) });
+            return string.Join(' ', AuthorizationHeader, scheme.ToString(), scheme.FormatValue(value));
         }
 
         /// <summary>
@@ -46,7 +44,7 @@ namespace Microsoft.Authentication.AzureAuth.Ado
         /// <returns>The Authorization header value.</returns>
         public static string AsHeaderValue(this string value, Authorization scheme)
         {
-            return string.Join(' ', new[] { scheme.ToString(), scheme.FormatValue(value) });
+            return string.Join(' ', scheme.ToString(), scheme.FormatValue(value));
         }
 
         /// <summary>

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -28,7 +28,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         private const string OutputOptionDescription = "How to print the token. One of [token, header, headervalue].\nDefault: token";
 
         /// <summary>
-        /// Format a PAT based on <see cref="OutputMode"/>.
+        /// Format a PAT based on <paramref name="output"/>.
         /// </summary>
         /// <param name="value">The PAT value.</param>
         /// <param name="output">The output mode.</param>
@@ -38,6 +38,19 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
             OutputMode.Token => value,
             OutputMode.Header => TokenFormatter.HeaderBasic(value),
             OutputMode.HeaderValue => TokenFormatter.HeaderBasicValue(value),
+        };
+
+        /// <summary>
+        /// Format an Access Token based on <paramref name="output"/>.
+        /// </summary>
+        /// <param name="value">The access token.</param>
+        /// <param name="output">The output mode.</param>
+        /// <returns>The formatted Access Toekn ready for printing.</returns>
+        public static string FormatAccessToken(string value, OutputMode output) => output switch
+        {
+            OutputMode.Token => value,
+            OutputMode.Header => TokenFormatter.HeaderBearer(value),
+            OutputMode.HeaderValue => TokenFormatter.HeaderBearerValue(value),
         };
 
         /// <summary>
@@ -103,11 +116,12 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
                 prompt: AzureAuth.PromptHint.Prefixed(this.PromptHint),
                 timeout: TimeSpan.FromMinutes(this.Timeout));
 
+
             var authflow = authResult.Success;
             if (authflow != null)
             {
                 logger.LogDebug($"Acquired AAD AT via {authflow.AuthFlowName} in {authflow.Duration.TotalSeconds:0.00} sec");
-                //PrintToken(logger, this.Output, authflow.TokenResult.Token, Bearer);
+                logger.LogInformation(FormatAccessToken(authflow.TokenResult.Token, this.Output));
                 return 0;
             }
 

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -46,19 +46,6 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
             HeaderValue,
         }
 
-        /// <summary>
-        /// Format a PAT based on <paramref name="output"/>.
-        /// </summary>
-        /// <param name="value">The PAT value.</param>
-        /// <param name="output">The output mode.</param>
-        /// <returns>The formatted PAT value ready for printing.</returns>
-        public static string FormatToken(string value, OutputMode output, Authorization scheme) => output switch
-        {
-            OutputMode.Token => value,
-            OutputMode.Header => value.AsHeader(scheme),
-            OutputMode.HeaderValue => value.AsHeaderValue(scheme),
-        };
-
         [Option(OutputOption, OutputOptionDescription, CommandOptionType.SingleValue)]
         private OutputMode Output { get; set; } = OutputMode.Token;
 
@@ -76,6 +63,21 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
 
         [Option(CommandAad.PromptHintOption, CommandAad.PromptHintHelpText, CommandOptionType.SingleValue)]
         private string PromptHint { get; set; }
+
+        /// <summary>
+        /// Format a PAT based on <paramref name="output"/>.
+        /// </summary>
+        /// <param name="value">The PAT value.</param>
+        /// <param name="output">The output mode.</param>
+        /// <param name="scheme">The <see cref="Authorization"/> scheme to use.</param>
+        /// <returns>The formatted PAT value ready for printing.</returns>
+        public static string FormatToken(string value, OutputMode output, Authorization scheme) => output switch
+        {
+            OutputMode.Token => value,
+            OutputMode.Header => value.AsHeader(scheme),
+            OutputMode.HeaderValue => value.AsHeaderValue(scheme),
+            _ => throw new ArgumentOutOfRangeException(nameof(scheme)),
+        };
 
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -38,11 +38,11 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
             Token,
 
             /// <summary>
-            /// Authorization http header value.
+            /// Authorization http header.
             /// </summary>
             Header,
 
-            /// <summary> TODO </summary>
+            /// <summary> Authorization http header - Value Only </summary>
             HeaderValue,
         }
 

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -3,11 +3,19 @@
 
 namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 {
+    using System;
     using System.Collections.Generic;
+    using System.IO;
+
     using McMaster.Extensions.CommandLineUtils;
+
+    using Microsoft.Authentication.AzureAuth.Ado;
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Office.Lasso.Interfaces;
     using Microsoft.Office.Lasso.Telemetry;
+
+    using NLog;
 
     /// <summary>
     /// ADO Command for using either an ADO PAT or acquiring an AAD Access Token.
@@ -16,46 +24,104 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
     public class CommandToken
     {
+        private const string OutputOption = "--output";
+        private const string OutputOptionDescription = "How to print the token. One of [token, header, headervalue].\nDefault: token";
+
         /// <summary>
-        /// Gets or sets the Azure Tenant ID to use for authentication.
+        /// Format a PAT based on <see cref="OutputMode"/>.
         /// </summary>
+        /// <param name="value">The PAT value.</param>
+        /// <param name="output">The output mode.</param>
+        /// <returns>The formatted PAT value ready for printing.</returns>
+        public static string FormatPat(string value, OutputMode output) => output switch
+        {
+            OutputMode.Token => value,
+            OutputMode.Header => TokenFormatter.HeaderBasic(value),
+            OutputMode.HeaderValue => TokenFormatter.HeaderBasicValue(value),
+        };
+
+        /// <summary>
+        /// The available Token Formats.
+        /// </summary>
+        public enum OutputMode
+        {
+            /// <summary>
+            /// Raw Token
+            /// </summary>
+            Token,
+
+            /// <summary>
+            /// Authorization http header value.
+            /// </summary>
+            Header,
+
+            /// <summary> TODO </summary>
+            HeaderValue,
+        }
+
+        [Option(OutputOption, OutputOptionDescription, CommandOptionType.SingleValue)]
+        private OutputMode Output { get; set; } = OutputMode.Token;
+
         [Option(CommandAad.TenantOption, Description = "The Azure Tenant ID to use for authentication. Defaults to Microsoft.")]
-        public string Tenant { get; set; } = AzureAuth.Ado.Constants.Tenant.Microsoft;
+        private string Tenant { get; set; } = AzureAuth.Ado.Constants.Tenant.Microsoft;
 
-        /// <summary>
-        /// Gets or sets the auth modes.
-        /// </summary>
         [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
-        public IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
+        private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
-        /// <summary>
-        /// Gets or sets domain suffix to filter on.
-        /// </summary>
         [Option(CommandAad.DomainOption, Description = CommandAad.DomainHelpText)]
-        public string Domain { get; set; }
+        private string Domain { get; set; }
 
-        /// <summary>
-        /// Gets or sets the global timeout option.
-        /// </summary>
         [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]
-        public double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
+        private double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
 
-        /// <summary>
-        /// Gets or sets the prompt hint.
-        /// </summary>
         [Option(CommandAad.PromptHintOption, CommandAad.PromptHintHelpText, CommandOptionType.SingleValue)]
-        public string PromptHint { get; set; }
+        private string PromptHint { get; set; }
 
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{T}"/> instance that is used for logging.</param>
+        /// <param name="env">An <see cref="IEnv"/> to use.</param>
         /// <param name="eventData">Lasso injected command event data.</param>
         /// <returns>An integer status code. 0 for success and non-zero for failure.</returns>
-        public int OnExecute(ILogger<CommandToken> logger, CommandExecuteEventData eventData)
+        public int OnExecute(ILogger<CommandToken> logger, IEnv env, CommandExecuteEventData eventData)
         {
-            logger.LogInformation("coming soon");
-            return 0;
+            // First attempt using a PAT.
+            var pat = PatFromEnv.Get(env);
+            if (pat.Exists)
+            {
+                logger.LogDebug($"Using PAT from env var {pat.EnvVarSource}");
+                logger.LogInformation(FormatPat(pat.Value, this.Output));
+                return 0;
+            }
+
+            // If no PAT then use AAD AT.
+            var authResult = AzureAuth.Ado.TokenFetcher.AccessToken(
+                logger: logger,
+                mode: this.AuthModes.Combine().PreventInteractionIfNeeded(env),
+                domain: this.Domain,
+                prompt: AzureAuth.PromptHint.Prefixed(this.PromptHint),
+                timeout: TimeSpan.FromMinutes(this.Timeout));
+
+            var authflow = authResult.Success;
+            if (authflow != null)
+            {
+                logger.LogDebug($"Acquired AAD AT via {authflow.AuthFlowName} in {authflow.Duration.TotalSeconds:0.00} sec");
+                //PrintToken(logger, this.Output, authflow.TokenResult.Token, Bearer);
+                return 0;
+            }
+
+            logger.LogError($"Failed to find a PAT and authenticate to ADO.");
+            foreach (var attempt in authResult.Attempts)
+            {
+                logger.LogError($"{attempt.AuthFlowName} failed after {attempt.Duration.TotalSeconds:0.00} sec. Error count: {attempt.Errors.Count}");
+                foreach (var e in attempt.Errors)
+                {
+                    logger.LogError($"  {e.Message}");
+                }
+            }
+
+            return 1;
         }
     }
 }

--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -4,7 +4,9 @@
 namespace Microsoft.Authentication.AzureAuth.Commands
 {
     using System.IO.Abstractions;
+
     using McMaster.Extensions.CommandLineUtils;
+
     using Microsoft.Extensions.Logging;
     using Microsoft.Office.Lasso.Interfaces;
     using Microsoft.Office.Lasso.Telemetry;
@@ -17,7 +19,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         "\n\n\u001b[31m-- azureauth [options]\u001b[0m" +
         "\n\u001b[32m++ azureauth aad [options]\u001b[0m\n")]
     [Subcommand(typeof(CommandAad))]
-    // [Subcommand(typeof(CommandAdo))] // TODO: uncomment when ADO commands are ready
+    [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]
     public class CommandAzureAuth : CommandAad
     {


### PR DESCRIPTION
This adds a functioning version of the `ado token` command.

There is refactoring cleanup work that will come after this to extract the common logic into a more testable flow that's re-usable by the `ado pat` and `aad` commands.