### PR TITLE
Set CodeQL in another job

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -44,7 +44,6 @@ jobs:
     strategy:
       matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]
-          language: [ 'csharp' ]
       fail-fast: false
 
     steps:
@@ -55,7 +54,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
+        languages: csharp
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
@@ -67,4 +66,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:csharp"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -27,12 +27,6 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: csharp
-
       - name: Restore dependencies
         run: dotnet restore
         env:
@@ -43,8 +37,39 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build --verbosity normal
-      
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        with:
-          category: "/language:csharp"
+
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      statuses: write
+    strategy:
+      matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+          language: [ 'csharp' ]
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+      env:
+        ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -41,11 +41,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-      statuses: write
     strategy:
       matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
CodeQL makes our PR build time doubles, which can significantly slow our small and quick fixes. Split CodeQL in another job so that we can run them in parallel.