### PR TITLE
[urgent]Remove scopes in the lock name because scopes may contains `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
 
+## [0.7.3] - 2023-03-14
+### Fixed
+- Fix unusable issues on Unix platforms due to mutexes.
+
 ## [0.7.2] - 2023-03-08
 ### Fixed
 - Upgrade to a new version of Lasso which patches a concurrency bug.

--- a/src/MSALWrapper/TokenFetcher.cs
+++ b/src/MSALWrapper/TokenFetcher.cs
@@ -71,11 +71,10 @@ namespace Microsoft.Authentication.MSALWrapper
             List<AuthFlowResult> results = new List<AuthFlowResult>();
             var executor = new AuthFlowExecutor(logger, authFlows, new StopwatchTracker(timeout));
 
-            // When running multiple AzureAuth processes with the same resource, client, and tenant IDs,
+            // When running multiple AzureAuth processes with the same client, and tenant IDs,
             // They may prompt many times, which is annoying and unexpected.
-            // Use Mutex to ensure that only one process can access the corresponding resource at the same time.
-            string resource = string.Join(' ', scopes);
-            string lockName = $"Local\\{resource}_{client}_{tenant}";
+            // Use Mutex to ensure that only one process can access the corresponding tenant at the same time.
+            string lockName = $"Local\\{tenant}_{client}";
 
             // The first parameter 'initiallyOwned' indicates whether this lock is owned by current thread.
             // It should be false otherwise a deadlock could occur.


### PR DESCRIPTION
# Summary
AzureAuth 0.7.2 can't create the mutex on Mac because of the mutex path contains a `/` which is not allowed on Unix.

# Details
The string concatenation operation causes the concatenated string to contain `/`. This causes it to be recognized as an unavailable folder on the Unix platform, resulting in unavailable services. We need to fix this bug immediately and release version 0.7.3.