### PR TITLE
[1/3] 🏝️ Isolate and test Mutex in standalone class `Locked` 

### DIFF
--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace MSALWrapper.Test
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using FluentAssertions;
+
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    internal class LockedTest
+    {
+        private static readonly TimeSpan TenSec = TimeSpan.FromSeconds(10);
+
+        private Mock<ILogger> mockLogger;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.mockLogger = new Mock<ILogger>(MockBehavior.Strict);
+        }
+
+        [Test]
+        public void Get_Int()
+        {
+            var lockName = "get_an_int";
+            var subject = Locked.Execute(this.mockLogger.Object, lockName, TenSec, () => Task.FromResult(42));
+            subject.Should().Be(42);
+        }
+
+        [Test]
+        public void Get_String()
+        {
+            var lockName = "get_a_string";
+            var subject = Locked.Execute(this.mockLogger.Object, lockName, TenSec, () => Task.FromResult("hi there"));
+            subject.Should().Be("hi there");
+        }
+
+        [Test]
+        public void Execute_TimeOut()
+        {
+            var lockName = "short task times out while long task is running";
+
+            // this int will be used to signal across threads
+            int lockAcquired = 0;
+            var oneMs = TimeSpan.FromMilliseconds(0.25);
+
+            Func<int> longFunc = () => Locked.Execute(this.mockLogger.Object, lockName, TenSec, async () =>
+            {
+                // signal that we have acquired the lock
+                Interlocked.Increment(ref lockAcquired);
+
+                // wait for the signal that our test has made it's assertion
+                while (lockAcquired == 1)
+                {
+                    await Task.Delay(oneMs);
+                }
+
+                return 42;
+            });
+
+            Action subject = () => Locked.Execute(this.mockLogger.Object, lockName, oneMs, () => Task.FromResult(0));
+
+            Task<int> longTask = Task.Run(longFunc);
+
+            // wait for our signal
+            while (lockAcquired == 0)
+            {
+                Thread.Sleep(oneMs);
+            }
+
+            subject.Should().Throw<TimeoutException>();
+
+            // Release the long Task by signaling we've made our assertion.
+            // This prevents us from abandoning the longTask which has the lock and would not actually release
+            // the Mutex correctly. This could be a problem if another test accidentally re-used a lock name.
+            Interlocked.Increment(ref lockAcquired);
+            longTask.Result.Should().Be(42);
+        }
+    }
+}

--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -66,7 +66,7 @@ namespace MSALWrapper.Test
             // Start longFunc, and wait for the lock to be acquired
             Task<int> longTask = Task.Run(longFunc);
             hasLock.WaitOne();
-            subject.Should().Throw<TimeoutException>();
+            subject.Should().Throw<TimeoutException>().WithMessage("The application did not gain access to the lock named 'short task times out while long task is running' in the expected time.");
 
             // Release the long Task by signaling we've made our assertion.
             // This prevents us from abandoning the longTask which has the lock and would not actually release

--- a/src/MSALWrapper/Locked.cs
+++ b/src/MSALWrapper/Locked.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Authentication.MSALWrapper
                     lockAcquired = true;
 
                     // In this case, basically we can just leave a log warning, because the worst side effect is prompting more than once.
-                    logger.LogWarning("The authentication attempt mutex was abandoned. Another thread or process may have exited unexpectedly.");
+                    logger.LogWarning("Another thread or process may have exited unexpectedly, while holding AzureAuth resources.");
                 }
 
                 if (!lockAcquired)

--- a/src/MSALWrapper/Locked.cs
+++ b/src/MSALWrapper/Locked.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// A method for executing a <see cref="Func{T}"/> under an inter-process lock.
+    /// </summary>
+    public static class Locked
+    {
+        /// <summary>
+        /// Execute the given <paramref name="subject"/> under the <paramref name="lockName"/> as a "Local\" inter-process lock.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> you want to return in a locked blocked.</typeparam>
+        /// <param name="logger">An <see cref="ILogger"/> to use for logging.</param>
+        /// <param name="lockName">A lock name. This will be treated like file on *nix systems and will be path sanitized.</param>
+        /// <param name="maxLockWaitTime">The max amount of time to wait to acquire the lock.</param>
+        /// <param name="subject">A <see cref="Func{TResult}"/> representing the action to take while holding the lock.</param>
+        /// <returns>A <typeparamref name="T"/> result.</returns>
+        /// <exception cref="TimeoutException">This lock will attempt to wait for the <paramref name="maxLockWaitTime"/>, and if not acquired throws a <see cref="TimeoutException"/>.</exception>
+        public static T Execute<T>(ILogger logger, string lockName, TimeSpan maxLockWaitTime, Func<Task<T>> subject)
+        {
+            T result = default;
+
+            // The first parameter 'initiallyOwned' indicates whether this lock is owned by current thread.
+            // It should be false otherwise a deadlock could occur.
+            using (Mutex mutex = new Mutex(initiallyOwned: false, name: lockName))
+            {
+                bool lockAcquired = false;
+                try
+                {
+                    // Wait for other sessions to exit.
+                    lockAcquired = mutex.WaitOne(maxLockWaitTime);
+                }
+                catch (AbandonedMutexException)
+                {
+                    // An AbandonedMutexException could be thrown if another process exits without releasing the mutex correctly.
+                    // If another process crashes or exits accidentally, we can still acquire the lock.
+                    lockAcquired = true;
+
+                    // In this case, basically we can just leave a log warning, because the worst side effect is prompting more than once.
+                    logger.LogWarning("The authentication attempt mutex was abandoned. Another thread or process may have exited unexpectedly.");
+                }
+
+                if (!lockAcquired)
+                {
+                    throw new TimeoutException("Authentication failed. The application did not gain access in the expected time, possibly because the resource handler was occupied by another process for a long time.");
+                }
+
+                try
+                {
+                    result = subject().Result;
+                }
+                finally
+                {
+                    mutex.ReleaseMutex();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/MSALWrapper/Locked.cs
+++ b/src/MSALWrapper/Locked.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Authentication.MSALWrapper
 
                 if (!lockAcquired)
                 {
-                    throw new TimeoutException("Authentication failed. The application did not gain access in the expected time, possibly because the resource handler was occupied by another process for a long time.");
+                    throw new TimeoutException($"The application did not gain access to the lock named '{lockName}' in the expected time.");
                 }
 
                 try


### PR DESCRIPTION
Originally, we had this locking code in `CommandAad`, then we moved it into the reincarnated `TokenFetcher`. But even there, it's a static method with no direct ties to token fetching.

Furthermore, it was not unit tested. By pulling that code into it's own public static method, we can more clearly unit test it. 

This PR adds a new `Locked` static class housing the one `Execute` method that takes an action and executes it, safely, while holding a Mutex.

The unit test coverage has gone from 0% to 100% :) Including the "Abandoned Mutex" scenario which ended up being pretty straightforward.

Follow up PRs to come to replace the existing locking code with this.