### PR TITLE
[2/3] 🦺 Assert lock names are safe

### DIFF
--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -96,5 +96,28 @@ namespace MSALWrapper.Test
             int subject = Locked.Execute(this.mockLogger.Object, lockName, tenSeconds, () => Task.FromResult(13));
             subject.Should().Be(13);
         }
+
+        // https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
+        [TestCase("bad_on_mac/.default")]
+        [TestCase("c99d8886-3cf5-4d44-b04c-6789bec9e1c8\\.default")]
+        [TestCase("Local\\c99d8886-3cf5-4d44-b04c-6789bec9e1c8/.default")]
+        [TestCase("LPT1.txt")]
+        [TestCase("Local\\LPT1.txt")]
+        [TestCase("bad_windows_<")]
+        [TestCase("bad_windows_>")]
+        [TestCase("bad_windows_\"")]
+        [TestCase("bad_windows_|")]
+        [TestCase("bad_windows_?")]
+        [TestCase("bad_windows_*")]
+        [TestCase("bad_windows_ ")]
+        [TestCase("bad_mac_n_win_:")]
+        [TestCase("CON")]
+        [TestCase("CON.txt")]
+        public void LockNames_Are_Made_Safe(string lockName, Locked.Visibility visibility = Locked.Visibility.Local)
+        {
+            var timeout = TimeSpan.FromMilliseconds(10);
+            var subject = Locked.Execute(this.mockLogger.Object, lockName, timeout, () => Task.FromResult(0));
+            subject.Should().Be(0);
+        }
     }
 }

--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -82,7 +82,7 @@ namespace MSALWrapper.Test
             var tenSeconds = TimeSpan.FromMilliseconds(10_000);
 
             AutoResetEvent hasLock = new AutoResetEvent(false);
-            Mutex m = new Mutex(false, lockName);
+            Mutex m = new Mutex(false, "Local\\01227a9099bf1b9710459a351eac7e58dbd85f6e855ee421dde7d8b86f7c4879");
 
             // acquire the same mutex that our Subject will attempt to acquire.
             new Thread(() =>

--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -98,7 +98,6 @@ namespace MSALWrapper.Test
         }
 
         // https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
-        [TestCase("bad_on_mac/.default")]
         [TestCase("c99d8886-3cf5-4d44-b04c-6789bec9e1c8\\.default")]
         [TestCase("Local\\c99d8886-3cf5-4d44-b04c-6789bec9e1c8/.default")]
         [TestCase("LPT1.txt")]
@@ -111,6 +110,7 @@ namespace MSALWrapper.Test
         [TestCase("bad_windows_*")]
         [TestCase("bad_windows_ ")]
         [TestCase("bad_mac_n_win_:")]
+        [TestCase("bad_on_nix/.default")]
         [TestCase("CON")]
         [TestCase("CON.txt")]
         public void LockNames_Are_Made_Safe(string lockName, Locked.Visibility visibility = Locked.Visibility.Local)
@@ -118,6 +118,13 @@ namespace MSALWrapper.Test
             var timeout = TimeSpan.FromMilliseconds(10);
             var subject = Locked.Execute(this.mockLogger.Object, lockName, timeout, () => Task.FromResult(0));
             subject.Should().Be(0);
+        }
+
+        [TestCase("foobar", Locked.Visibility.Local, "Local\\c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2")]
+        [TestCase("foobar", Locked.Visibility.Global, "Global\\c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2")]
+        public void LockName_Contains_Visibility(string lockName, Locked.Visibility visibility, string expected)
+        {
+            Locked.LockName(lockName, visibility).Should().Be(expected);
         }
     }
 }

--- a/src/MSALWrapper/Locked.cs
+++ b/src/MSALWrapper/Locked.cs
@@ -4,11 +4,9 @@
 namespace Microsoft.Authentication.MSALWrapper
 {
     using System;
-    using System.IO;
     using System.Linq;
     using System.Security.Cryptography;
     using System.Text;
-    using System.Text.Unicode;
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/src/MSALWrapper/Locked.cs
+++ b/src/MSALWrapper/Locked.cs
@@ -14,6 +14,15 @@ namespace Microsoft.Authentication.MSALWrapper
     public static class Locked
     {
         /// <summary>
+        /// <see cref="Mutex"/> visibility levels between terminal server sessions.
+        /// </summary>
+        public enum Visibility
+        {
+            Local,
+            Global,
+        }
+
+        /// <summary>
         /// Execute the given <paramref name="subject"/> under the <paramref name="lockName"/> as a "Local\" inter-process lock.
         /// </summary>
         /// <typeparam name="T">The <see cref="Type"/> you want to return in a locked blocked.</typeparam>
@@ -21,9 +30,10 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <param name="lockName">A lock name. This will be treated like file on *nix systems and will be path sanitized.</param>
         /// <param name="maxLockWaitTime">The max amount of time to wait to acquire the lock.</param>
         /// <param name="subject">A <see cref="Func{TResult}"/> representing the action to take while holding the lock.</param>
+        /// <param name="visibility">The <see cref="Visibility"/> of the <see cref="Mutex"/>.</param>
         /// <returns>A <typeparamref name="T"/> result.</returns>
         /// <exception cref="TimeoutException">This lock will attempt to wait for the <paramref name="maxLockWaitTime"/>, and if not acquired throws a <see cref="TimeoutException"/>.</exception>
-        public static T Execute<T>(ILogger logger, string lockName, TimeSpan maxLockWaitTime, Func<Task<T>> subject)
+        public static T Execute<T>(ILogger logger, string lockName, TimeSpan maxLockWaitTime, Func<Task<T>> subject, Visibility visibility = Visibility.Local)
         {
             T result = default;
 


### PR DESCRIPTION
Add tests to `Locked` to cover the scenario that caused one of the extra releases we had to ship (AzureAuth failed on mac using an invalid character in the lock name).