### PR TITLE
[1/n] 📜 Move common in memory logger setup to shared method.

### DIFF
--- a/AzureAuth.sln
+++ b/AzureAuth.sln
@@ -22,9 +22,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{8ECA01
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSALWrapper.Benchmark", "src\MSALWrapper.Benchmark\MSALWrapper.Benchmark.csproj", "{22778DA9-2246-42D8-A6C4-6DA8E0D7638E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdoPat", "src\AdoPat\AdoPat.csproj", "{4FDAE313-5BBD-4727-B67E-386A55C80C43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdoPat", "src\AdoPat\AdoPat.csproj", "{4FDAE313-5BBD-4727-B67E-386A55C80C43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdoPat.Test", "src\AdoPat.Test\AdoPat.Test.csproj", "{D49B2FCE-2112-4071-A2AD-8979499B1D4D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdoPat.Test", "src\AdoPat.Test\AdoPat.Test.csproj", "{D49B2FCE-2112-4071-A2AD-8979499B1D4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHelper", "TestHelper\TestHelper.csproj", "{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -120,6 +122,18 @@ Global
 		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x64.Build.0 = Release|Any CPU
 		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x86.ActiveCfg = Release|Any CPU
 		{D49B2FCE-2112-4071-A2AD-8979499B1D4D}.Release|x86.Build.0 = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|x64.Build.0 = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Debug|x86.Build.0 = Debug|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|x64.ActiveCfg = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|x64.Build.0 = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|x86.ActiveCfg = Release|Any CPU
+		{E39BA4B8-4124-45D9-9B2C-CB1A55032B2E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestHelper/MemoryLogger.cs
+++ b/TestHelper/MemoryLogger.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.TestHelper
+{
+    using Microsoft.Extensions.Logging;
+
+    using NLog;
+    using NLog.Config;
+    using NLog.Targets;
+
+    public static class MemoryLogger
+    {
+        public static (ILogger<T> logger, MemoryTarget logTarget) Create<T>()
+        {
+            var loggerFactory = new NLog.Extensions.Logging.NLogLoggerFactory();
+            var logger = loggerFactory.CreateLogger<T>();
+
+            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggingConfig = new LoggingConfiguration();
+            var logTarget = new MemoryTarget("memory_target");
+            logTarget.Layout = "${message}";
+            loggingConfig.AddTarget(logTarget);
+            loggingConfig.AddRuleForAllLevels(logTarget);
+
+            // Set the Config
+            LogManager.Configuration = loggingConfig;
+            return (logger, logTarget);
+        }
+    }
+}

--- a/TestHelper/MemoryLogger.cs
+++ b/TestHelper/MemoryLogger.cs
@@ -3,20 +3,26 @@
 
 namespace Microsoft.Authentication.TestHelper
 {
-    using Microsoft.Extensions.Logging;
-
     using NLog;
     using NLog.Config;
     using NLog.Targets;
 
+    using System.Diagnostics;
+
     public static class MemoryLogger
     {
-        public static (ILogger<T> logger, MemoryTarget logTarget) Create<T>()
+        public static (Extensions.Logging.ILogger logger, MemoryTarget logTarget) Create()
         {
-            var loggerFactory = new NLog.Extensions.Logging.NLogLoggerFactory();
-            var logger = loggerFactory.CreateLogger<T>();
+            // Use reflection to get the name of the class which declares our caller.
+            // Expected to be the name of a Test class.
+            StackFrame frame = new StackFrame(1);
+            var method = frame.GetMethod();
+            var type = method.DeclaringType;
 
-            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
+            var loggerFactory = new NLog.Extensions.Logging.NLogLoggerFactory();
+            var logger = loggerFactory.CreateLogger(type.FullName);
+
+            // Setup in memory logging target with NLog
             var loggingConfig = new LoggingConfiguration();
             var logTarget = new MemoryTarget("memory_target");
             logTarget.Layout = "${message}";
@@ -25,6 +31,7 @@ namespace Microsoft.Authentication.TestHelper
 
             // Set the Config
             LogManager.Configuration = loggingConfig;
+
             return (logger, logTarget);
         }
     }

--- a/TestHelper/TestHelper.csproj
+++ b/TestHelper/TestHelper.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -6,52 +6,35 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
+
     using FluentAssertions;
     using FluentAssertions.Equivalency;
+
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
-    using Microsoft.Authentication.MSALWrapper.Test;
-    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Authentication.TestHelper;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Identity.Client;
     using Microsoft.IdentityModel.JsonWebTokens;
+
     using Moq;
-    using NLog.Extensions.Logging;
-    using NLog.Targets;
+
     using NUnit.Framework;
 
     public class AuthFlowExecutorTest
     {
         private const string NullAuthFlowResultExceptionMessage = "Auth flow 'IAuthFlowProxy' returned a null AuthFlowResult.";
 
-        private IServiceProvider serviceProvider;
-        private MemoryTarget logTarget;
+        private ILogger logger;
         private TokenResult tokenResult;
-        private IEnumerable<IAuthFlow> authFlows;
         private IStopwatch stopwatch;
+        private Guid client = Guid.NewGuid();
+        private Guid tenant = Guid.NewGuid();
 
         [SetUp]
         public void Setup()
         {
-            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
-            var loggingConfig = new NLog.Config.LoggingConfiguration();
-            this.logTarget = new MemoryTarget("memory_target");
-            loggingConfig.AddTarget(this.logTarget);
-            loggingConfig.AddRuleForAllLevels(this.logTarget);
-            this.authFlows = new List<IAuthFlow>();
-
-            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
-            this.serviceProvider = new ServiceCollection()
-             .AddLogging(loggingBuilder =>
-             {
-                 // configure Logging with NLog
-                 loggingBuilder.ClearProviders();
-                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
-                 loggingBuilder.AddNLog(loggingConfig);
-             })
-             .BuildServiceProvider();
+            (this.logger, _) = MemoryLogger.Create();
 
             // Mock successful token result
             this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
@@ -70,17 +53,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWith_Null_Logger()
         {
-            Action authFlowExecutor = () => new AuthFlowExecutor(null, this.authFlows, this.stopwatch);
+            Action authFlowExecutor = () => new AuthFlowExecutor(null, null, this.stopwatch);
 
             // Assert
-            authFlowExecutor.Should().Throw<ArgumentNullException>();
+            authFlowExecutor.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'logger')");
         }
 
         [Test]
         public void ConstructorWith_Null_AuthFlows()
         {
-            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            Action authFlowExecutor = () => new AuthFlowExecutor(logger, null, this.stopwatch);
+            Action authFlowExecutor = () => new AuthFlowExecutor(this.logger, null, this.stopwatch);
 
             // Assert
             authFlowExecutor.Should().Throw<ArgumentNullException>();
@@ -89,11 +71,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void ConstructorWith_Valid_Arguments()
         {
-            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            Action authFlowExecutor = () => new AuthFlowExecutor(logger, this.authFlows, this.stopwatch);
+            Action authFlowExecutor = () => this.Subject(new List<IAuthFlow>());
 
             // Assert
-            authFlowExecutor.Should().NotThrow<ArgumentNullException>();
+            authFlowExecutor.Should().NotThrow();
         }
 
         [Test]
@@ -846,8 +827,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         private AuthFlowExecutor Subject(IEnumerable<IAuthFlow> authFlows)
         {
-            var logger = this.serviceProvider.GetService<ILogger<AuthFlowExecutor>>();
-            return new AuthFlowExecutor(logger, authFlows, this.stopwatch);
+            return new AuthFlowExecutor(this.logger, authFlows, this.stopwatch);
         }
 
         // This auth flow is for delaying the return and testing timeout.

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using FluentAssertions;
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Authentication.TestHelper;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
@@ -33,8 +34,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         private string promptHint = "test prompt hint";
 
-        private IServiceProvider serviceProvider;
         private MemoryTarget logTarget;
+        private ILogger logger;
 
         // MSAL Specific Mocks
         private Mock<IPCAWrapper> pcaWrapperMock;
@@ -45,38 +46,18 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [SetUp]
         public void Setup()
         {
-            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
-            var loggingConfig = new NLog.Config.LoggingConfiguration();
-            this.logTarget = new MemoryTarget("memory_target");
-            loggingConfig.AddTarget(this.logTarget);
-            loggingConfig.AddRuleForAllLevels(this.logTarget);
+            (this.logger, this.logTarget) = MemoryLogger.Create();
 
             // MSAL Mocks
             this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
             this.testAccount.Setup(a => a.Username).Returns(TestUser);
             this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
 
-            // Setup Dependency Injection container to provide logger and out class under test (the "subject")
-            this.serviceProvider = new ServiceCollection()
-             .AddLogging(loggingBuilder =>
-             {
-                 // configure Logging with NLog
-                 loggingBuilder.ClearProviders();
-                 loggingBuilder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
-                 loggingBuilder.AddNLog(loggingConfig);
-             })
-             .AddTransient<AuthFlow.Web>((provider) =>
-             {
-                 var logger = provider.GetService<ILogger<AuthFlow.Web>>();
-                 return new AuthFlow.Web(logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
-             })
-             .BuildServiceProvider();
-
             // Mock successful token result
             this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
         }
 
-        public AuthFlow.Web Subject() => this.serviceProvider.GetService<AuthFlow.Web>();
+        public AuthFlow.Web Subject() => new AuthFlow.Web(this.logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
 
         [Test]
         public async Task WebAuthFlow_CachedToken()

--- a/src/MSALWrapper.Test/LockedTest.cs
+++ b/src/MSALWrapper.Test/LockedTest.cs
@@ -10,9 +10,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using FluentAssertions;
 
     using Microsoft.Authentication.MSALWrapper;
-    using Microsoft.Extensions.Logging;
+    using Microsoft.Authentication.TestHelper;
 
-    using NLog;
     using NLog.Targets;
 
     using NUnit.Framework;
@@ -21,24 +20,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     {
         private static readonly TimeSpan TenSec = TimeSpan.FromSeconds(10);
 
-        private Microsoft.Extensions.Logging.ILogger logger;
+        private Extensions.Logging.ILogger logger;
         private MemoryTarget logTarget;
 
         [SetUp]
         public void SetUp()
         {
-            var loggerFactory = new NLog.Extensions.Logging.NLogLoggerFactory();
-            this.logger = loggerFactory.CreateLogger<LockedTest>();
-
-            // Setup in memory logging target with NLog - allows making assertions against what has been logged.
-            var loggingConfig = new NLog.Config.LoggingConfiguration();
-            this.logTarget = new MemoryTarget("memory_target");
-            this.logTarget.Layout = "${message}";
-            loggingConfig.AddTarget(this.logTarget);
-            loggingConfig.AddRuleForAllLevels(this.logTarget);
-
-            // Set the Config
-            LogManager.Configuration = loggingConfig;
+            (this.logger, this.logTarget) = MemoryLogger.Create();
         }
 
         [Test]

--- a/src/MSALWrapper.Test/MSALWrapper.Test.csproj
+++ b/src/MSALWrapper.Test/MSALWrapper.Test.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\TestHelper\TestHelper.csproj" />
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
A lot of our tests in MSALWrapper use an `ILogger`. Today, they go through a lot of boilerplate in order to create a simple in-memory logger through a `Microsoft.DependencyInjection.ServiceCollection`. This adds a level of overhead we don't really need or take advantage of in most of our tests.

We can make a fully named `ILogger` by reflecting on the calling class's full name.
*This prevent copy and paste errors* because the same code pasted into another test automatically creates a logger named after that test. We don't currently use this name in our tests anywhere. But now it's always correct 😄 accurate.

Special thanks to @reillysiemens and @shalinikhare27 for having a deep discussion on `ILogger`s and testing with them ❤️ !

This will be a familiar diff in this PR:
![image](https://user-images.githubusercontent.com/126627085/226534372-7c71d6cb-0913-4a13-b841-6392c54090f9.png)
