### PR TITLE
[2/n] Use 🔒 `Locked.Execute` from `TokenFetcher`

### DIFF
--- a/bin/win/azureauth.cmd
+++ b/bin/win/azureauth.cmd
@@ -1,4 +1,4 @@
 :: Copyright (c) Microsoft Corporation.
 :: Licensed under the MIT License.
 
-dotnet run --project %~dp0\..\src\AzureAuth -- %* --debug
+dotnet run --project %~dp0\..\..\src\AzureAuth -- %* --debug


### PR DESCRIPTION
Now that we have an isolated `Locked` that is 100% unit tested, we can more reliably use the same locking logic here in `TokenFetcher`, which itself is not unit tested.