### PR TITLE
[1/n] 📦 Move TokenFetcher method behind interface.

### DIFF
--- a/src/AzureAuth/Ado/TokenFetcher.cs
+++ b/src/AzureAuth/Ado/TokenFetcher.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Authentication.AzureAuth.Ado
             string prompt,
             TimeSpan timeout)
         {
-            return AADTokenFetcher.AccessToken(
+            return new AADTokenFetcher().AccessToken(
                 logger: logger,
                 client: new Guid(Constants.Client.VisualStudio),
                 tenant: new Guid(Constants.Tenant.Microsoft),

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -381,7 +381,7 @@ Allowed values: [all, web, devicecode]";
         {
             try
             {
-                var results = TokenFetcher.AccessToken(
+                var results = new TokenFetcher().AccessToken(
                     logger: this.logger,
                     client: new Guid(this.authSettings.Client),
                     tenant: new Guid(this.authSettings.Tenant),

--- a/src/MSALWrapper/ITokenFetcher.cs
+++ b/src/MSALWrapper/ITokenFetcher.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Authentication.MSALWrapper.AuthFlow;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// An interface for acquiring an AAT Access Token.
+    /// </summary>
+    public interface ITokenFetcher
+    {
+        /// <summary>
+        /// Run the authentication process using a global lock around the client, tenant, scopes trio to prevent multiple
+        /// auth prompts for the same tokens.
+        /// </summary>
+        /// <param name="logger">A <see cref="ILogger"/> to use.</param>
+        /// <param name="client">The client ID to authenticate as.</param>
+        /// <param name="tenant">The Azure tenant containing the client.</param>
+        /// <param name="scopes">The list of scopes to request access for.</param>
+        /// <param name="mode">The <see cref="AuthMode"/>. Controls which <see cref="IAuthFlow"/>s should be used.</param>
+        /// <param name="domain">The domain (account suffix) to filter cached accounts with.</param>
+        /// <param name="prompt">A prompt hint to display to the user if needed.</param>
+        /// <param name="timeout">The max <see cref="TimeSpan"/> we should spend attempting token acquisition for.</param>
+        /// <returns>A <see cref="TokenFetcher.Result"/> representing the result of the asynchronous operation.</returns>
+        TokenFetcher.Result AccessToken(
+            ILogger logger,
+            Guid client,
+            Guid tenant,
+            IEnumerable<string> scopes,
+            AuthMode mode,
+            string domain,
+            string prompt,
+            TimeSpan timeout);
+    }
+}

--- a/src/MSALWrapper/ITokenFetcher.cs
+++ b/src/MSALWrapper/ITokenFetcher.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Authentication.MSALWrapper
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    /// An interface for acquiring an AAT Access Token.
+    /// An interface for acquiring an AAD Access Token.
     /// </summary>
     public interface ITokenFetcher
     {

--- a/src/MSALWrapper/TokenFetcher.cs
+++ b/src/MSALWrapper/TokenFetcher.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Authentication.MSALWrapper
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
 
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
     using Microsoft.Extensions.Logging;
@@ -15,10 +14,8 @@ namespace Microsoft.Authentication.MSALWrapper
     /// A functional orchestrator of doing auth using the building blocks
     /// of <see cref="AuthFlowFactory"/> and <see cref="AuthFlowExecutor"/>.
     /// </summary>
-    public static class TokenFetcher
+    public class TokenFetcher : ITokenFetcher
     {
-        private static readonly TimeSpan MaxLockWaitTime = TimeSpan.FromMinutes(15);
-
         /// <summary>
         /// The result of running <see cref="TokenFetcher"/>.
         /// </summary>
@@ -35,20 +32,17 @@ namespace Microsoft.Authentication.MSALWrapper
             public List<AuthFlowResult> Attempts { get; init; }
         }
 
+        private static readonly TimeSpan MaxLockWaitTime = TimeSpan.FromMinutes(15);
+
         /// <summary>
-        /// Run the authentication process using a global lock around the client, tenant, scopes trio to prevent multiple
-        /// auth prompts for the same tokens.
+        /// Initializes a new instance of the <see cref="TokenFetcher"/> class.
         /// </summary>
-        /// <param name="logger">A <see cref="ILogger"/> to use.</param>
-        /// <param name="client">The client ID to authenticate as.</param>
-        /// <param name="tenant">The Azure tenant containing the client.</param>
-        /// <param name="scopes">The list of scopes to request access for.</param>
-        /// <param name="mode">The <see cref="AuthMode"/>. Controls which <see cref="IAuthFlow"/>s should be used.</param>
-        /// <param name="domain">The domain (account suffix) to filter cached accounts with.</param>
-        /// <param name="prompt">A prompt hint to display to the user if needed.</param>
-        /// <param name="timeout">The max <see cref="TimeSpan"/> we should spend attempting token acquisition for.</param>
-        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public static Result AccessToken(
+        public TokenFetcher()
+        {
+        }
+
+        /// <inheritdoc/>
+        public Result AccessToken(
             ILogger logger,
             Guid client,
             Guid tenant,


### PR DESCRIPTION
When re-creating this `TokenFetcher` as a static class, there wasn't a clear use case for mocking it's usage. We now have a clear use case for mocking it's usage in wanting to TDD the common orchestrator in the AzureAuth project into existence, asserting that the right logging, and telemetry calls are made.

This change keeps the logic exactly the same, but puts it behind an instance method so that a mock object can be created for it. Note that we specifically avoid state though! We can get the benefits of a static function by not maintaining any state.

## How is this going to get used?
in AzureAuth[.Test], we can now create the token orchestrator (call it a `melon` for now). The `melon` will take an `ITokenFetcher`, an `ILogger`, and an `ITelemetryService`. We will be able to register `TokenFetcher` in the main DI service collection as well as the `melon`, and allow top-level commands to have these components auto-injected into them, also making them more testable.
