### PR TITLE
[5/n] 🛠️ Address data clump with class. 

### DIFF
--- a/src/AzureAuth.Test/PublicClientAuthTest.cs
+++ b/src/AzureAuth.Test/PublicClientAuthTest.cs
@@ -24,7 +24,7 @@ namespace AzureAuth.Test
 
     internal class PublicClientAuthTest
     {
-        private readonly AuthParams authParams = new AuthParams(
+        private readonly AuthParameters authParams = new AuthParameters(
             Fake.Client,
             Fake.Tenant,
             Fake.Scopes);

--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Authentication.AzureAuth.Ado
         /// <summary>
         /// The default auth params for AzureDevops.
         /// </summary>
-        public static readonly AuthParams AdoParams = new AuthParams(Client.VisualStudio, Tenant.Microsoft, new[] { Scope.AzureDevOpsDefault });
+        public static readonly AuthParameters AdoParams = new AuthParameters(Client.VisualStudio, Tenant.Microsoft, new[] { Scope.AzureDevOpsDefault });
 
         /// <summary>
         /// Azure tenant IDs.

--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Authentication.AzureAuth.Ado
 {
+    using Microsoft.Authentication.MSALWrapper;
+
     /// <summary>
     /// Azure DevOps constant values.
     /// </summary>
@@ -13,6 +15,11 @@ namespace Microsoft.Authentication.AzureAuth.Ado
         /// This is defined by ADO pipelines. See https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables.
         /// </summary>
         public const string SystemDefinitionId = "SYSTEM_DEFINITIONID";
+
+        /// <summary>
+        /// The default auth params for AzureDevops.
+        /// </summary>
+        public static readonly AuthParams AdoParams = new AuthParams(Client.VisualStudio, Tenant.Microsoft, new[] { Scope.AzureDevOpsDefault });
 
         /// <summary>
         /// Azure tenant IDs.

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -98,9 +98,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
 
             // If no PAT then use AAD AT.
             TokenResult token = publicClientAuth.Token(
-                client: new Guid(AzureAuth.Ado.Constants.Client.VisualStudio),
-                tenant: new Guid(AzureAuth.Ado.Constants.Tenant.Microsoft),
-                scopes: new[] { AzureAuth.Ado.Constants.Scope.AzureDevOpsDefault },
+                authParams: AzureAuth.Ado.Constants.AdoParams,
                 authModes: this.AuthModes,
                 domain: this.Domain,
                 prompt: this.PromptHint,

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -371,9 +371,7 @@ Allowed values: [all, web, devicecode]";
             try
             {
                 TokenResult tokenResult = publicClientAuth.Token(
-                    client: new Guid(this.authSettings.Client),
-                    tenant: new Guid(this.authSettings.Tenant),
-                    scopes: this.authSettings.Scopes,
+                    authParams: new AuthParams(this.authSettings.Client, this.authSettings.Tenant, this.authSettings.Scopes),
                     authModes: this.AuthModes,
                     domain: this.authSettings.Domain,
                     prompt: this.authSettings.PromptHint,

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -371,7 +371,7 @@ Allowed values: [all, web, devicecode]";
             try
             {
                 TokenResult tokenResult = publicClientAuth.Token(
-                    authParams: new AuthParams(this.authSettings.Client, this.authSettings.Tenant, this.authSettings.Scopes),
+                    authParams: new AuthParameters(this.authSettings.Client, this.authSettings.Tenant, this.authSettings.Scopes),
                     authModes: this.AuthModes,
                     domain: this.authSettings.Domain,
                     prompt: this.authSettings.PromptHint,

--- a/src/AzureAuth/IPublicClientAuth.cs
+++ b/src/AzureAuth/IPublicClientAuth.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Authentication.AzureAuth
     /// </summary>
     public interface IPublicClientAuth
     {
-        TokenResult Token(AuthParams authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData);
+        TokenResult Token(AuthParameters authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData);
     }
 }

--- a/src/AzureAuth/IPublicClientAuth.cs
+++ b/src/AzureAuth/IPublicClientAuth.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Authentication.AzureAuth
     /// </summary>
     public interface IPublicClientAuth
     {
-        TokenResult Token(Guid client, Guid tenant, IEnumerable<string> scopes, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData);
+        TokenResult Token(AuthParams authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData);
     }
 }

--- a/src/AzureAuth/PublicClientAuth.cs
+++ b/src/AzureAuth/PublicClientAuth.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Authentication.AzureAuth
         private readonly ILogger logger;
         private readonly IEnv env;
         private readonly ITelemetryService telemetryService;
-        private readonly IMsalWrapper tokenFetcher;
+        private readonly IMsalWrapper msalWrapper;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PublicClientAuth"/> class.
@@ -30,24 +30,22 @@ namespace Microsoft.Authentication.AzureAuth
         /// <param name="logger">An <see cref="ILogger"/>.</param>
         /// <param name="env">An <see cref="IEnv"/>.</param>
         /// <param name="telemetryService">An <see cref="ITelemetryService"/>.</param>
-        /// <param name="tokenFetcher">An <see cref="IMsalWrapper"/>.</param>
+        /// <param name="msalWrapper">An <see cref="IMsalWrapper"/>.</param>
         /// <exception cref="ArgumentNullException">All parameters must not be null.</exception>
-        public PublicClientAuth(ILogger logger, IEnv env, ITelemetryService telemetryService, IMsalWrapper tokenFetcher)
+        public PublicClientAuth(ILogger logger, IEnv env, ITelemetryService telemetryService, IMsalWrapper msalWrapper)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.env = env ?? throw new ArgumentNullException(nameof(env));
             this.telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-            this.tokenFetcher = tokenFetcher ?? throw new ArgumentNullException(nameof(tokenFetcher));
+            this.msalWrapper = msalWrapper ?? throw new ArgumentNullException(nameof(msalWrapper));
         }
 
         /// <inheritdoc/>
-        public TokenResult Token(Guid client, Guid tenant, IEnumerable<string> scopes, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData)
+        public TokenResult Token(AuthParams authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData)
         {
-            var result = this.tokenFetcher.AccessToken(
+            var result = this.msalWrapper.AccessToken(
                 this.logger,
-                client,
-                tenant,
-                scopes,
+                authParams,
                 authModes.Combine().PreventInteractionIfNeeded(this.env, this.logger),
                 domain,
                 PromptHint.Prefixed(prompt),

--- a/src/AzureAuth/PublicClientAuth.cs
+++ b/src/AzureAuth/PublicClientAuth.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Authentication.AzureAuth
         }
 
         /// <inheritdoc/>
-        public TokenResult Token(AuthParams authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData)
+        public TokenResult Token(MSALWrapper.AuthParameters authParams, IEnumerable<AuthMode> authModes, string domain, string prompt, TimeSpan timeout, EventData eventData)
         {
             var result = this.msalWrapper.AccessToken(
                 this.logger,

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
     internal class AuthFlowFactoryTest
     {
-        private readonly AuthParams authParams = new AuthParams(
+        private readonly AuthParameters authParams = new AuthParameters(
             "5af6def2-05ec-4cab-b9aa-323d75b5df40",
             "8254f6f7-a09f-4752-8bd6-391adc3b912e",
             new[] { "6e979987-a7c8-4604-9b37-e51f06f08f1a/.default" });

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -12,27 +11,25 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
     using Microsoft.Authentication.TestHelper;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
     using Moq;
 
-    using NLog.Extensions.Logging;
     using NLog.Targets;
 
     using NUnit.Framework;
 
     internal class AuthFlowFactoryTest
     {
-        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
-        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
-        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+        private readonly AuthParams authParams = new AuthParams(
+            "5af6def2-05ec-4cab-b9aa-323d75b5df40",
+            "8254f6f7-a09f-4752-8bd6-391adc3b912e",
+            new[] { "6e979987-a7c8-4604-9b37-e51f06f08f1a/.default" });
 
         private MemoryTarget logTarget;
         private ILogger logger;
         private Mock<IPCAWrapper> pcaWrapperMock;
         private Mock<IPlatformUtils> platformUtilsMock;
-        private IEnumerable<string> scopes;
         private string preferredDomain;
         private string promptHint;
 
@@ -47,7 +44,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
             this.platformUtilsMock = new Mock<IPlatformUtils>(MockBehavior.Strict);
 
-            this.scopes = new[] { $"{ResourceId}/.default" };
             this.preferredDomain = "contoso.com";
             this.promptHint = "Log into Contoso!";
         }
@@ -64,10 +60,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         public IEnumerable<IAuthFlow> Subject(AuthMode mode) => AuthFlowFactory.Create(
                 this.logger,
+                this.authParams,
                 mode,
-                ClientId,
-                TenantId,
-                this.scopes,
                 this.preferredDomain,
                 this.promptHint,
                 pcaWrapper: this.pcaWrapperMock.Object,

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Create a list of <see cref="IAuthFlow"/> instances based on the given settings.
         /// </summary>
         /// <param name="logger">An <see cref="ILogger"/>.</param>
-        /// <param name="authParams">The <see cref="AuthParams"/>.</param>
+        /// <param name="authParams">The <see cref="AuthParameters"/>.</param>
         /// <param name="authMode">The desired <see cref="AuthMode"/>.</param>
         /// <param name="preferredDomain">Preferred domain to use when filtering cached accounts.</param>
         /// <param name="promptHint">A prompt hint to contextualize an auth prompt if given.</param>
@@ -25,7 +25,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IAuthFlow"/> instances.</returns>
         public static IEnumerable<IAuthFlow> Create(
             ILogger logger,
-            AuthParams authParams,
+            AuthParameters authParams,
             AuthMode authMode,
             string preferredDomain,
             string promptHint,

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -16,10 +16,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Create a list of <see cref="IAuthFlow"/> instances based on the given settings.
         /// </summary>
         /// <param name="logger">An <see cref="ILogger"/>.</param>
+        /// <param name="authParams">The <see cref="AuthParams"/>.</param>
         /// <param name="authMode">The desired <see cref="AuthMode"/>.</param>
-        /// <param name="clientId">The client id.</param>
-        /// <param name="tenantId">The tenant id.</param>
-        /// <param name="scopes">The scopes.</param>
         /// <param name="preferredDomain">Preferred domain to use when filtering cached accounts.</param>
         /// <param name="promptHint">A prompt hint to contextualize an auth prompt if given.</param>
         /// <param name="pcaWrapper">An optional injected <see cref="IPCAWrapper"/> to use.</param>
@@ -27,10 +25,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IAuthFlow"/> instances.</returns>
         public static IEnumerable<IAuthFlow> Create(
             ILogger logger,
+            AuthParams authParams,
             AuthMode authMode,
-            Guid clientId,
-            Guid tenantId,
-            IEnumerable<string> scopes,
             string preferredDomain,
             string promptHint,
             IPCAWrapper pcaWrapper = null,
@@ -47,7 +43,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // and tries to auth silently.
             if (authMode.IsIWA() && platformUtils.IsWindows())
             {
-                flows.Add(new IntegratedWindowsAuthentication(logger, clientId, tenantId, scopes, preferredDomain, pcaWrapper));
+                flows.Add(new IntegratedWindowsAuthentication(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain, pcaWrapper));
             }
 
             // This check silently fails on winserver if broker has been requested.
@@ -55,17 +51,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // https://github.com/AzureAD/microsoft-authentication-cli/issues/55
             if (authMode.IsBroker() && platformUtils.IsWindows10Or11())
             {
-                flows.Add(new Broker(logger, clientId, tenantId, scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
+                flows.Add(new Broker(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
             }
 
             if (authMode.IsWeb())
             {
-                flows.Add(new Web(logger, clientId, tenantId, scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
+                flows.Add(new Web(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
             }
 
             if (authMode.IsDeviceCode())
             {
-                flows.Add(new DeviceCode(logger, clientId, tenantId, scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
+                flows.Add(new DeviceCode(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
             }
 
             return flows;

--- a/src/MSALWrapper/AuthParameters.cs
+++ b/src/MSALWrapper/AuthParameters.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Authentication.MSALWrapper
     /// <summary>
     /// Core authentication parameters needed 
     /// </summary>
-    public record AuthParams
+    public record AuthParameters
     {
         /// <summary>Gets the Client Id.</summary>
         public Guid Client { get; init; }
@@ -21,12 +21,12 @@ namespace Microsoft.Authentication.MSALWrapper
         public IEnumerable<string> Scopes { get; init; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthParams"/> class.
+        /// Initializes a new instance of the <see cref="AuthParameters"/> class.
         /// </summary>
         /// <param name="client">Client Id.</param>
         /// <param name="tenant">Tenant Id.</param>
         /// <param name="scopes">Scopes.</param>
-        public AuthParams(string client, string tenant, IEnumerable<string> scopes)
+        public AuthParameters(string client, string tenant, IEnumerable<string> scopes)
         {
             this.Client = new Guid(client);
             this.Tenant = new Guid(tenant);
@@ -34,12 +34,12 @@ namespace Microsoft.Authentication.MSALWrapper
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthParams"/> class.
+        /// Initializes a new instance of the <see cref="AuthParameters"/> class.
         /// </summary>
         /// <param name="client">Client Id.</param>
         /// <param name="tenant">Tenant Id.</param>
         /// <param name="scopes">Scopes.</param>
-        public AuthParams(Guid client, Guid tenant, IEnumerable<string> scopes)
+        public AuthParameters(Guid client, Guid tenant, IEnumerable<string> scopes)
         {
             this.Client = client;
             this.Tenant = tenant;

--- a/src/MSALWrapper/AuthParams.cs
+++ b/src/MSALWrapper/AuthParams.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Core authentication parameters needed 
+    /// </summary>
+    public record AuthParams
+    {
+        /// <summary>Gets the Client Id.</summary>
+        public Guid Client { get; init; }
+
+        /// <summary>Gets the Tenant Id.</summary>
+        public Guid Tenant { get; init; }
+
+        /// <summary>Gets the Scopes.</summary>
+        public IEnumerable<string> Scopes { get; init; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthParams"/> class.
+        /// </summary>
+        /// <param name="client">Client Id.</param>
+        /// <param name="tenant">Tenant Id.</param>
+        /// <param name="scopes">Scopes.</param>
+        public AuthParams(string client, string tenant, IEnumerable<string> scopes)
+        {
+            this.Client = new Guid(client);
+            this.Tenant = new Guid(tenant);
+            this.Scopes = scopes;
+        }
+    }
+}

--- a/src/MSALWrapper/AuthParams.cs
+++ b/src/MSALWrapper/AuthParams.cs
@@ -32,5 +32,18 @@ namespace Microsoft.Authentication.MSALWrapper
             this.Tenant = new Guid(tenant);
             this.Scopes = scopes;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthParams"/> class.
+        /// </summary>
+        /// <param name="client">Client Id.</param>
+        /// <param name="tenant">Tenant Id.</param>
+        /// <param name="scopes">Scopes.</param>
+        public AuthParams(Guid client, Guid tenant, IEnumerable<string> scopes)
+        {
+            this.Client = client;
+            this.Tenant = tenant;
+            this.Scopes = scopes;
+        }
     }
 }

--- a/src/MSALWrapper/IMsalWrapper.cs
+++ b/src/MSALWrapper/IMsalWrapper.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// auth prompts for the same tokens.
         /// </summary>
         /// <param name="logger">A <see cref="ILogger"/> to use.</param>
-        /// <param name="client">The client ID to authenticate as.</param>
-        /// <param name="tenant">The Azure tenant containing the client.</param>
-        /// <param name="scopes">The list of scopes to request access for.</param>
+        /// <param name="authParams">The <see cref="AuthParams"/>.</param>
         /// <param name="mode">The <see cref="AuthMode"/>. Controls which <see cref="IAuthFlow"/>s should be used.</param>
         /// <param name="domain">The domain (account suffix) to filter cached accounts with.</param>
         /// <param name="prompt">A prompt hint to display to the user if needed.</param>
@@ -28,9 +26,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <returns>A <see cref="MsalWrapper.Result"/> representing the result of the asynchronous operation.</returns>
         MsalWrapper.Result AccessToken(
             ILogger logger,
-            Guid client,
-            Guid tenant,
-            IEnumerable<string> scopes,
+            AuthParams authParams,
             AuthMode mode,
             string domain,
             string prompt,

--- a/src/MSALWrapper/IMsalWrapper.cs
+++ b/src/MSALWrapper/IMsalWrapper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// auth prompts for the same tokens.
         /// </summary>
         /// <param name="logger">A <see cref="ILogger"/> to use.</param>
-        /// <param name="authParams">The <see cref="AuthParams"/>.</param>
+        /// <param name="authParams">The <see cref="AuthParameters"/>.</param>
         /// <param name="mode">The <see cref="AuthMode"/>. Controls which <see cref="IAuthFlow"/>s should be used.</param>
         /// <param name="domain">The domain (account suffix) to filter cached accounts with.</param>
         /// <param name="prompt">A prompt hint to display to the user if needed.</param>
@@ -26,7 +26,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <returns>A <see cref="MsalWrapper.Result"/> representing the result of the asynchronous operation.</returns>
         MsalWrapper.Result AccessToken(
             ILogger logger,
-            AuthParams authParams,
+            AuthParameters authParams,
             AuthMode mode,
             string domain,
             string prompt,

--- a/src/MSALWrapper/MsalWrapper.cs
+++ b/src/MSALWrapper/MsalWrapper.cs
@@ -44,9 +44,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <inheritdoc/>
         public Result AccessToken(
             ILogger logger,
-            Guid client,
-            Guid tenant,
-            IEnumerable<string> scopes,
+            AuthParams authParams,
             AuthMode mode,
             string domain,
             string prompt,
@@ -55,9 +53,7 @@ namespace Microsoft.Authentication.MSALWrapper
             var authFlows = AuthFlowFactory.Create(
                 logger: logger,
                 authMode: mode,
-                clientId: client,
-                tenantId: tenant,
-                scopes: scopes,
+                authParams: authParams,
                 preferredDomain: domain,
                 promptHint: prompt);
 
@@ -65,7 +61,7 @@ namespace Microsoft.Authentication.MSALWrapper
             var executor = new AuthFlowExecutor(logger, authFlows, new StopwatchTracker(timeout));
 
             // Prevent multiple calls to AzureAuth for the same client and tenant from prompting at the same time.
-            string lockName = $"Local\\{tenant}_{client}";
+            string lockName = $"Local\\{authParams.Tenant}_{authParams.Client}";
 
             results.AddRange(Locked.Execute(logger, lockName, MaxLockWaitTime, async () => await executor.GetTokenAsync()));
 

--- a/src/MSALWrapper/MsalWrapper.cs
+++ b/src/MSALWrapper/MsalWrapper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <inheritdoc/>
         public Result AccessToken(
             ILogger logger,
-            AuthParams authParams,
+            AuthParameters authParams,
             AuthMode mode,
             string domain,
             string prompt,


### PR DESCRIPTION
## Address [Data Clump](https://refactoring.guru/smells/data-clumps) with Extract Class

Throughout MSALWrapper and AzureAuth, 3 pieces of data go _everywhere_ together. The Client Id, Tenant Id, and Scopes, that are core required parameters for doing public client auth, and even confidential client auth.

This could be left alone - but it's also not bad to address it now that's it has really established itself, it makes the signatures a little cleaner and easier to read.

I've also fixed a variable rename from tokenFetcher -> msalWrapper missed from an earlier PR.