### PR TITLE
Enforce AuthFlow Name usage and improve names for telemetry

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowExecutorTest.cs
@@ -840,6 +840,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 this.delay = delay;
             }
 
+            public string Name() => "delayed_test_auth_flow";
+
             public async Task<AuthFlowResult> GetTokenAsync()
             {
                 var errors = new[]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowResultTest.cs
@@ -18,23 +18,23 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public const string FakeToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsInJoIjoieHh4IiwieDV0IjoieHh4Iiwia2lkIjoieHh4In0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXVkIjoiMTExMTExMTEtMTExMS0xMTExLTExMTEtMTExMTExMTExMTExIiwiaWF0IjoxNjE3NjY0Mjc2LCJuYmYiOjE2MTc2NjQyNzYsImV4cCI6MTYxNzY2ODE3NiwiYWNyIjoiMSIsImFpbyI6IllTQjBiM1JoYkd4NUlHWmhhMlVnYTJWNUlDTWtKVjQ9Iiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwidW5pcXVlX25hbWUiOiJreXJhZGVyQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJreXJhZGVyQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bNc3QlL4zIClzFqH68A4hxsR7K-jabQvzB2EodgujQqc0RND_VLVkk2h3iDy8so3azN-964c2z5AiBGY6PVtWKYB-h0Z_VnzbebhDjzPLspEsANyQxaDX_ugOrf7BerQOtILWT5Vqs-A3745Bh0eTDFZpobmeENpANNhRE-yKwScjU8BDY9RimdrA2Z00V0lSliUQwnovWmtfdlbEpWObSFQAK7wCcNnUesV-jNZAUMrDkmTItPA9Z1Ks3NUbqdqMP3D6n99sy8DxQeFmbNQGYocYqI7QH24oNXODq0XB-2zpvCqy4T2jiBLgN_XEaZ5zTzEOzztpgMIWH1AUvEIyw";
 
         [Test]
-        public void ConstructorWithnullArgs()
-        {
-            var subject = new AuthFlowResult();
-            subject.Success.Should().BeFalse();
-            subject.TokenResult.Should().BeNull();
-            subject.Errors.Should().BeEmpty();
-            subject.AuthFlowName.Should().BeEmpty();
-        }
-
-        [Test]
         public void ConstructorWithNullAuthFlowName_ThrowsNullArgumentException()
         {
             var tokenResult = new TokenResult(new JsonWebToken(FakeToken), Guid.NewGuid());
             var errors = new List<Exception>();
-            Action authFLowResult = () => new AuthFlowResult(tokenResult, errors, null);
+            Action authFlowResult = () => new AuthFlowResult(tokenResult, errors, null);
 
-            authFLowResult.Should().Throw<ArgumentNullException>();
+            authFlowResult.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void AuthFlowName_Cannot_Be_Empty()
+        {
+            var tokenResult = new TokenResult(new JsonWebToken(FakeToken), Guid.NewGuid());
+            var errors = new List<Exception>();
+            Action authFlowResult = () => new AuthFlowResult(tokenResult, errors, string.Empty);
+
+            authFlowResult.Should().Throw<ArgumentException>().WithMessage("Param 'authFlowName' cannot be empty");
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void AddErrors()
         {
-            var subject = new AuthFlowResult();
+            var subject = new AuthFlowResult(null, null, "TestingAddErrors");
             var errors = new List<Exception>
             {
                 new ArgumentException("something can't be null"),

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:20");
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -277,7 +277,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -300,7 +300,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -321,7 +321,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -343,7 +343,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
@@ -367,7 +367,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("Broker");
+            authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/DeviceCodeTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalException));
-            authFlowResult.AuthFlowName.Should().Be("DeviceCode");
+            authFlowResult.AuthFlowName.Should().Be("devicecode");
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -148,7 +148,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
             authFlowResult.Errors[1].Should().BeOfType(typeof(NullTokenResultException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -203,7 +203,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Message.Should().Be("AADSTS50076 MSAL UI Required Exception!");
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Message.Should().Be("MSAL UI Required Exception!");
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -283,7 +283,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         [Test]
@@ -303,7 +303,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalClientException));
-            authFlowResult.AuthFlowName.Should().Be("IntegratedWindowsAuthentication");
+            authFlowResult.AuthFlowName.Should().Be("iwa");
         }
 
         private void CachedAuthResult()

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(this.tokenResult);
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:15");
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -233,7 +233,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -274,7 +274,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -295,7 +295,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -318,7 +318,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -339,7 +339,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -361,7 +361,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         [Test]
@@ -385,7 +385,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("Web");
+            authFlowResult.AuthFlowName.Should().Be("web");
         }
 
         private void SilentAuthResult()

--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
+    /// <summary>
+    /// An abstract class that implements the <see cref="IAuthFlow"/> interface
+    /// and enforces consistent behavior for naming AuthFlows.
+    /// </summary>
     public abstract class AuthFlowBase : IAuthFlow
     {
         /// <inheritdoc/>

--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -7,13 +7,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    internal abstract class AuthFlowBase : IAuthFlow
+    public abstract class AuthFlowBase : IAuthFlow
     {
         /// <inheritdoc/>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            IList<Exception> errors = new List<Exception>();
-            var result = await this.GetTokenInnerAsync(errors);
+            (var result, var errors) = await this.GetTokenInnerAsync();
             return new AuthFlowResult(result, errors, this.Name());
         }
 
@@ -22,7 +21,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Performs token acquisition.
         /// </summary>
         /// <returns>a tuple of <see cref="TokenResult"/> and <see cref="IList{Exception}"/>.</returns>
-        protected abstract Task<TokenResult> GetTokenInnerAsync(IList<Exception> errors);
+        protected abstract Task<(TokenResult result, IList<Exception> errors)> GetTokenInnerAsync();
 
         /// <summary>
         /// The name of this AuthFlow.

--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.AuthFlow
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    internal abstract class AuthFlowBase : IAuthFlow
+    {
+        /// <inheritdoc/>
+        public async Task<AuthFlowResult> GetTokenAsync()
+        {
+            IList<Exception> errors = new List<Exception>();
+            var result = await this.GetTokenInnerAsync(errors);
+            return new AuthFlowResult(result, errors, this.Name());
+        }
+
+        /// <summary>
+        /// The inner method required to be implemented by an AuthFlow.
+        /// Performs token acquisition.
+        /// </summary>
+        /// <returns>a tuple of <see cref="TokenResult"/> and <see cref="IList{Exception}"/>.</returns>
+        protected abstract Task<TokenResult> GetTokenInnerAsync(IList<Exception> errors);
+
+        /// <summary>
+        /// The name of this AuthFlow.
+        /// </summary>
+        /// <returns>The <see cref="string"/> representation of the authflow name.</returns>
+        protected abstract string Name();
+    }
+}

--- a/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowResult.cs
@@ -12,14 +12,6 @@ namespace Microsoft.Authentication.MSALWrapper
     public class AuthFlowResult
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthFlowResult"/> class with a null TokenResult and empty error list.
-        /// </summary>
-        public AuthFlowResult()
-            : this(null, null, string.Empty)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="AuthFlowResult"/> class.
         /// </summary>
         /// <param name="tokenResult">A <see cref="MSALWrapper.TokenResult"/>.</param>
@@ -30,6 +22,10 @@ namespace Microsoft.Authentication.MSALWrapper
             this.TokenResult = tokenResult;
             this.Errors = errors ?? new List<Exception>();
             this.AuthFlowName = authFlowName ?? throw new ArgumentNullException(nameof(authFlowName));
+            if (string.IsNullOrEmpty(authFlowName))
+            {
+                throw new ArgumentException($"Param '{nameof(authFlowName)}' cannot be empty");
+            }
         }
 
         /// <summary>

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class Broker : IAuthFlow
     {
+        private const string NameValue = "broker";
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -74,6 +75,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             /// </summary>
             GetRootOwner = 3,
         }
+
+        /// <inheritdoc/>
+        public string Name() => NameValue;
 
         /// <summary>
         /// Get a jwt token for a resource.

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             .ConfigureAwait(false);
                         tokenResult.SetSilent();
 
-                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
+                        return this.Result(tokenResult, this.errors);
                     }
                     catch (MsalUiRequiredException ex)
                     {
@@ -120,7 +120,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                             this.errors)
                             .ConfigureAwait(false);
 
-                        return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
+                        return this.Result(tokenResult, this.errors);
                     }
                 }
                 catch (MsalUiRequiredException ex)
@@ -137,7 +137,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.errors)
                         .ConfigureAwait(false);
 
-                    return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
+                    return this.Result(tokenResult, this.errors);
                 }
             }
             catch (MsalServiceException ex)
@@ -156,7 +156,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return new AuthFlowResult(null, this.errors, this.GetType().Name);
+            return this.Result(null, this.errors);
+        }
+
+        private AuthFlowResult Result(TokenResult tokenResult, IList<Exception> errors)
+        {
+            return new AuthFlowResult(tokenResult, errors, this.Name());
         }
 
         [DllImport("kernel32.dll")]

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class DeviceCode : IAuthFlow
     {
+        private const string NameValue = "device_code";
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -36,6 +37,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private TimeSpan deviceCodeFlowTimeout = TimeSpan.FromMinutes(15);
         #endregion
 
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceCode"/> class.
         /// </summary>
@@ -55,6 +57,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId);
         }
+
+        /// <inheritdoc/>
+        public string Name() => NameValue;
 
         /// <summary>
         /// Get a token for a resource.

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private TimeSpan deviceCodeFlowTimeout = TimeSpan.FromMinutes(15);
         #endregion
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceCode"/> class.
         /// </summary>

--- a/src/MSALWrapper/AuthFlow/IAuthFlow.cs
+++ b/src/MSALWrapper/AuthFlow/IAuthFlow.cs
@@ -11,12 +11,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     public interface IAuthFlow
     {
         /// <summary>
-        /// Get the name of the auth flow.
-        /// </summary>
-        /// <returns>The name of the auth flow.</returns>
-        string Name();
-
-        /// <summary>
         /// Get a token for a resource.
         /// </summary>
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>

--- a/src/MSALWrapper/AuthFlow/IAuthFlow.cs
+++ b/src/MSALWrapper/AuthFlow/IAuthFlow.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     public interface IAuthFlow
     {
         /// <summary>
+        /// Get the name of the auth flow.
+        /// </summary>
+        /// <returns>The name of the auth flow.</returns>
+        string Name();
+
+        /// <summary>
         /// Get a token for a resource.
         /// </summary>
         /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// <summary>
     /// The broker auth flow.
     /// </summary>
-    public class IntegratedWindowsAuthentication : IAuthFlow
+    public class IntegratedWindowsAuthentication : AuthFlowBase
     {
         private const string NameValue = "iwa";
         private readonly ILogger logger;
@@ -48,13 +48,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         }
 
         /// <inheritdoc/>
-        public string Name() => NameValue;
+        protected override string Name() => NameValue;
 
-        /// <summary>
-        /// Get a jwt token for a resource.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> of <see cref="TokenResult"/>.</returns>
-        public async Task<AuthFlowResult> GetTokenAsync()
+        /// <inheritdoc/>
+        protected override async Task<(TokenResult, IList<Exception>)> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain) ?? null;
             this.logger.LogDebug($"Using cached account '{account?.Username}'");
@@ -123,7 +120,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return new AuthFlowResult(tokenResult, this.errors, this.GetType().Name);
+            return (tokenResult, this.errors);
         }
 
         private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId)

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class IntegratedWindowsAuthentication : IAuthFlow
     {
+        private const string NameValue = "iwa";
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -45,6 +46,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId);
         }
+
+        /// <inheritdoc/>
+        public string Name() => NameValue;
 
         /// <summary>
         /// Get a jwt token for a resource.

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class Web : IAuthFlow
     {
+        private const string NameValue = "web";
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -55,6 +56,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.promptHint = promptHint;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId);
         }
+
+        /// <inheritdoc/>
+        public string Name() => NameValue;
 
         /// <summary>
         /// Get a token for a resource.


### PR DESCRIPTION
This change does 2 primary things
1. Sets friendlier names for each auth flow to use in telemetry.
2. We create a small base class for auth flows, that enforces an AuthFlow implement a name and use it in the method which implements the `IAuthFlow` interface, helping ensure all auth flows are name themselves intentionally and that those names be used in a consistent way.
