### PR TITLE
Read registry key for application insights token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado` : Prints the help for Azure Devops commands.
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
-- Now supports reading data from the registry when the environment variable is not configured.
+- When the environment variable `AZUREAUTH_APPLICATION_INSIGHTS_INGESTION_TOKEN` is not configured,
+ regkey `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth\ApplicationInsightsIngestionToken` will be a back up on Windows for telemetry service.
 
 ## [0.7.3] - 2023-03-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado` : Prints the help for Azure Devops commands.
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
+- Now supports reading data from the registry when the environment variable is not configured.
 
 ## [0.7.3] - 2023-03-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
 - When the environment variable `AZUREAUTH_APPLICATION_INSIGHTS_INGESTION_TOKEN` is not configured,
- regkey `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth\ApplicationInsightsIngestionToken` will be a back up on Windows for telemetry service.
+ regkey `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth\ApplicationInsightsIngestionToken` will be a back up on Windows for telemetry ingestion token config.
 
 ## [0.7.3] - 2023-03-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Instructions on using AzureAuth CLI in your applications are available [here](do
 
 # Data Collection Is Off By Default
 No telemetry will be collected unless you set the `AZUREAUTH_APPLICATION_INSIGHTS_INGESTION_TOKEN` environment variable
+or the registry key `ApplicationInsightsIngestionToken` under `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth`
 to a valid [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
 ingestion token.
 

--- a/src/AzureAuth/EnvVars.cs
+++ b/src/AzureAuth/EnvVars.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Authentication.AzureAuth
         /// <summary>
         /// Holds the name of the registry key to get an application insights ingestion token.
         /// </summary>
-        public static readonly string ApplicationInsightsIngestionTokenRegKeyName = "ApplicationInsightsKey";
+        public static readonly string ApplicationInsightsIngestionTokenRegKeyName = "ApplicationInsightsIngestionToken";
 
         /// <summary>
         /// Holds the name of the env var to get a config file from.

--- a/src/AzureAuth/EnvVars.cs
+++ b/src/AzureAuth/EnvVars.cs
@@ -17,6 +17,16 @@ namespace Microsoft.Authentication.AzureAuth
         public static readonly string ApplicationInsightsIngestionTokenEnvVar = $"{EnvVarPrefix}_APPLICATION_INSIGHTS_INGESTION_TOKEN";
 
         /// <summary>
+        /// Holds the path of the registry key to get an application insights ingestion token.
+        /// </summary>
+        public static readonly string ApplicationInsightsIngestionTokenRegKeyPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth";
+
+        /// <summary>
+        /// Holds the name of the registry key to get an application insights ingestion token.
+        /// </summary>
+        public static readonly string ApplicationInsightsIngestionTokenRegKeyName = "ApplicationInsightsKey";
+
+        /// <summary>
         /// Holds the name of the env var to get a config file from.
         /// </summary>
         public static readonly string Config = $"{EnvVarPrefix}_CONFIG";


### PR DESCRIPTION
# Summary
This PR will enable AzureAuth to read registry key `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth` with name `ApplicationInsightsIngestionToken` for Application Insights token.

# Order
AzureAuth will try to read env var first. If it is not set, AzureAuth will try to read the reg key on Windows Platform.

# Test
Tested on my Windows 11 laptop.

No unit tests available.