### PR TITLE
Scaffold the ado pat subcommand

### DIFF
--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -5,17 +5,64 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 {
     using McMaster.Extensions.CommandLineUtils;
 
-    using Microsoft.Applications.Events;
     using Microsoft.Extensions.Logging;
-
     using Microsoft.Office.Lasso.Telemetry;
 
     /// <summary>
-    /// Command class for creating or fetching, and returning Azure Devops PATs.
+    /// An ADO Command for creating or fetching, and returning Azure Devops PATs.
     /// </summary>
-    [Command("pat", Description = "Create and locally cache Azure Devops Personal Access Tokens (PATs) using encrypted local storage.")]
+    [Command("pat", Description = "Create and cache Azure Devops Personal Access Tokens (PATs) using encrypted local storage.")]
     public class CommandPat
     {
+        private const string OrganizationOption = "--organization";
+        private const string OrganizationHelp = "The name of the Azure DevOps organization.";
+
+        private const string DisplayNameOption = "--display-name";
+        private const string DisplayNameHelp = "The Personal Access Token name.";
+
+        private const string ScopeOption = "--scope";
+        private const string ScopeHelp = "A token scope for accessing Azure DevOps resources. Repeated invocations allowed.";
+
+        private const string OutputOption = "--output";
+        private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";
+
+        // The possible PAT output modes.
+        private enum OutputMode
+        {
+            // No output whatsoever.
+            None,
+
+            // Text indicating that a PAT was created/fetched and cached.
+            Status,
+
+            // Just the PAT, nothing more.
+            Token,
+
+            // A Base64-encoded version of the PAT.
+            Base64,
+
+            // The full `Authorization Basic` HTTP header.
+            Header,
+
+            // Just the value of the `Authorization Basic` header.
+            HeaderValue,
+
+            // The JSON value for the PAT, exactly as it was returned by the Azure DevOps API.
+            Json,
+        }
+
+        [Option(OrganizationOption, OrganizationHelp, CommandOptionType.SingleValue)]
+        private string Organization { get; set; } = null;
+
+        [Option(DisplayNameOption, DisplayNameHelp, CommandOptionType.SingleValue)]
+        private string DisplayName { get; set; } = null;
+
+        [Option(ScopeOption, ScopeHelp, CommandOptionType.MultipleValue)]
+        private string[] Scopes { get; set; } = null;
+
+        [Option(OutputOption, OutputHelp, CommandOptionType.SingleValue)]
+        private OutputMode Output { get; set; } = OutputMode.Token;
+
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
         /// </summary>

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string OrganizationHelp = "The name of the Azure DevOps organization.";
 
         private const string DisplayNameOption = "--display-name";
-        private const string DisplayNameHelp = "The Personal Access Token name.";
+        private const string DisplayNameHelp = "The PAT name.";
 
         private const string ScopeOption = "--scope";
         private const string ScopeHelp = "A token scope for accessing Azure DevOps resources. Repeated invocations allowed.";


### PR DESCRIPTION
This PR just adds flags and help text to the `azureauth ado pat` subcommand. The code remains unlit, but when active it generates help text which looks like this.

```
$ azureauth ado pat --help
1.0.0.0

Create and cache Azure Devops Personal Access Tokens (PATs) using encrypted local storage.

Usage: azureauth ado pat [options]

Options:
  --organization  The name of the Azure DevOps organization.
  --display-name  The Personal Access Token name.
  --scope         A token scope for accessing Azure DevOps resources. Repeated invocations allowed.
  --output        How PAT information is displayed. [default: token]
                  [possible values: none, status, token, base64, header, headervalue, json]
  -?|-h|--help    Show help information.
  --version       Show version information.
  --debug         Turn off telemetry reporting and enable trace logging
  --verbosity     Configure the minimum log level to show.
                  Allowed values are: trace, debug, info, information, warn, warning, error, critical, fatal, none, off.
```