### PR TITLE
Implement azureauth ado pat subcommand

### DIFF
--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Authentication.AzureAuth.Ado
     /// </summary>
     internal static class Constants
     {
+        /// <summary>The base URL for Azure DevOps.</summary>
+        public const string BaseUrl = "https://dev.azure.com";
+
+        /// <summary>The PAT lockfile name. The containing directory is platform specific, thus configured at runtime.</summary>
+        public const string PatLockfileName = "azureauth-ado-pat.lock";
+
         /// <summary>
         /// ADO pipeline id.
         /// This is defined by ADO pipelines. See https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables.

--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Authentication.AzureAuth.Ado
     /// </summary>
     internal static class Constants
     {
+        /// <summary>The default preferred domain used when retrieving cached accounts.</summary>
+        public const string PreferredDomain = "microsoft.com";
+
         /// <summary>The base URL for Azure DevOps.</summary>
         public const string BaseUrl = "https://dev.azure.com";
 

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -43,6 +43,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
+    <ProjectReference Include="..\AdoPat\AdoPat.csproj" />
   </ItemGroup>
 
   <!-- Assemblies we need to manually mark as roots so they are not trimmed. -->

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -155,7 +155,7 @@ You can use any combination with multiple instances of the --mode flag.
                 var pat = manager.GetPatAsync(this.PatOptions()).Result;
 
                 // Do not use logger to avoid printing PATs into log files.
-                Console.WriteLine(FormatPat(pat, this.Output));
+                Console.Write(FormatPat(pat, this.Output));
             }
 
             return 0;
@@ -164,12 +164,12 @@ You can use any combination with multiple instances of the --mode flag.
         private static string FormatPat(PatToken pat, OutputMode output) => output switch
         {
             OutputMode.None => string.Empty,
-            OutputMode.Status => $"\"{pat.DisplayName}\" valid until {pat.ValidTo:O}",
-            OutputMode.Token => pat.Token,
-            OutputMode.Base64 => pat.Token.Base64(),
-            OutputMode.Header => pat.Token.AsHeader(AzureAuth.Ado.Authorization.Basic),
-            OutputMode.HeaderValue => pat.Token.AsHeaderValue(AzureAuth.Ado.Authorization.Basic),
-            OutputMode.Json => pat.AsJson(),
+            OutputMode.Status => $"\"{pat.DisplayName}\" valid until {pat.ValidTo:O}\n",
+            OutputMode.Token => $"{pat.Token}\n",
+            OutputMode.Base64 => $"{pat.Token.Base64()}\n",
+            OutputMode.Header => $"{pat.Token.AsHeader(AzureAuth.Ado.Authorization.Basic)}\n",
+            OutputMode.HeaderValue => $"{pat.Token.AsHeaderValue(AzureAuth.Ado.Authorization.Basic)}\n",
+            OutputMode.Json => $"{pat.AsJson()}\n",
             _ => throw new ArgumentOutOfRangeException(nameof(output)),
         };
 

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -117,20 +117,13 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
                 return 1;
             }
 
-            var patOptions = new PatOptions
-            {
-                Organization = this.Organization,
-                DisplayName = this.DisplayName,
-                Scopes = this.Scopes,
-            };
-
             var cache = this.Cache();
             var client = this.Client(accessToken.Token);
             var manager = new PatManager(cache, client);
 
             using (new CrossPlatLock(LockfilePath))
             {
-                var pat = manager.GetPatAsync(patOptions).Result;
+                var pat = manager.GetPatAsync(this.PatOptions()).Result;
 
                 // Do not use logger to avoid printing PATs into log files.
                 Console.WriteLine(FormatPat(pat, this.Output));
@@ -160,6 +153,16 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
                 AccessTokenPrompt,
                 AccessTokenTimeout,
                 eventData);
+        }
+
+        private PatOptions PatOptions()
+        {
+            return new PatOptions
+            {
+                Organization = this.Organization,
+                DisplayName = this.DisplayName,
+                Scopes = this.Scopes,
+            };
         }
 
         private IPatClient Client(string accessToken)

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
-        [Option(CommandAad.DomainOption, $"{CommandAad.DomainHelpText}\n[default: microsoft.com]", CommandOptionType.SingleValue)]
+        [Option(CommandAad.DomainOption, $"{CommandAad.DomainHelpText}\n[default: {AzureAuth.Ado.Constants.PreferredDomain}]", CommandOptionType.SingleValue)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         /// <summary>

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -159,11 +159,11 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         {
             OutputMode.None => string.Empty,
             OutputMode.Status => $"\"{pat.DisplayName}\" valid until {pat.ValidTo:O}\n",
-            OutputMode.Token => $"{pat.Token}\n",
-            OutputMode.Base64 => $"{pat.Token.Base64()}\n",
-            OutputMode.Header => $"{pat.Token.AsHeader(AzureAuth.Ado.Authorization.Basic)}\n",
-            OutputMode.HeaderValue => $"{pat.Token.AsHeaderValue(AzureAuth.Ado.Authorization.Basic)}\n",
-            OutputMode.Json => $"{pat.AsJson()}\n",
+            OutputMode.Token => pat.Token,
+            OutputMode.Base64 => pat.Token.Base64(),
+            OutputMode.Header => pat.Token.AsHeader(AzureAuth.Ado.Authorization.Basic),
+            OutputMode.HeaderValue => pat.Token.AsHeaderValue(AzureAuth.Ado.Authorization.Basic),
+            OutputMode.Json => pat.AsJson(),
             _ => throw new ArgumentOutOfRangeException(nameof(output)),
         };
 

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private OutputMode Output { get; set; } = OutputMode.Token;
 
         [Option(DomainOption, DomainHelp, CommandOptionType.SingleValue)]
-        private string Domain { get; set; } = "microsoft.com";
+        private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -115,6 +115,11 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         /// <returns>An integer status code. 0 for success and non-zero for failure.</returns>
         public int OnExecute(ILogger<CommandPat> logger, IPublicClientAuth publicClientAuth, CommandExecuteEventData eventData)
         {
+            if (!this.ValidOptions(logger))
+            {
+                return 1;
+            }
+
             var accessToken = this.AccessToken(publicClientAuth, eventData);
             if (accessToken == null)
             {
@@ -148,6 +153,40 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
             OutputMode.Json => pat.AsJson(),
             _ => throw new ArgumentOutOfRangeException(nameof(output)),
         };
+
+        // This option validation could also be handled by using a [Required] attribute,
+        // but for the best user experience we'd like to report multiple issues at once.
+        private bool ValidOptions(ILogger logger)
+        {
+            bool validOptions = true;
+            int scopesCount = this.Scopes?.Length ?? 0;
+
+            if (scopesCount == 0)
+            {
+                logger.LogError($"The {ScopeOption} field is required.");
+                validOptions = false;
+            }
+
+            if (string.IsNullOrEmpty(this.Organization))
+            {
+                logger.LogError($"The {OrganizationOption} field is required.");
+                validOptions = false;
+            }
+
+            if (string.IsNullOrEmpty(this.DisplayName))
+            {
+                logger.LogError($"The {DisplayNameOption} field is required.");
+                validOptions = false;
+            }
+
+            if (string.IsNullOrEmpty(this.PromptHint))
+            {
+                logger.LogError($"The {PromptHintOption} field is required.");
+                validOptions = false;
+            }
+
+            return validOptions;
+        }
 
         private TokenResult AccessToken(IPublicClientAuth publicClientAuth, CommandExecuteEventData eventData)
         {

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private static readonly string LockfilePath = Path.Combine(Path.GetTempPath(), AzureAuth.Ado.Constants.PatLockfileName);
 
         // On all platforms the PAT cache should be in the same directory as a typical AzureAuth installation.
-        //   - On Windows this is usually `%LOCALAPPDATA%\Programs\AzureAuth`.
-        //   - On Unix-like platforms this is usually `~/.azureauth`.
+        //   - On Windows this is `%LOCALAPPDATA%\Programs\AzureAuth`.
+        //   - On Unix-like platforms this is `~/.azureauth`.
 #if PlatformWindows
         private static readonly string CacheDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -35,29 +35,8 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string ScopeOption = "--scope";
         private const string ScopeHelp = "A token scope for accessing Azure DevOps resources. Repeated invocations allowed.";
 
-        private const string PromptHintOption = "--prompt-hint";
-        private const string PromptHintHelp = "A prompt hint to contextualize prompts and identify uses in telemetry, when captured.";
-
         private const string OutputOption = "--output";
         private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";
-
-        private const string ModeOption = "--mode";
-#if PlatformWindows
-        /// <summary>
-        /// The help text for the <see cref="ModeOption"/> option.
-        /// </summary>
-        private const string ModeHelp = @"Authentication mode. Repeated invocations allowed. [default: iwa (Integrated Windows Auth), then broker, then web]
-[possible values: all, iwa, broker, web, devicecode]";
-#else
-        /// <summary>
-        /// The help text for the <see cref="ModeOption"/> option.
-        /// </summary>
-        private const string ModeHelp = @"Authentication mode. Repeated invocations allowed. [default: web]
-[possible values: all, web, devicecode]";
-#endif
-
-        private const string DomainOption = "--domain";
-        private const string DomainHelp = "The preferred domain used when acquiring Azure Active Directory access tokens. [default: microsoft.com]";
 
         private static readonly TimeSpan AccessTokenTimeout = TimeSpan.FromMinutes(15);
 
@@ -97,16 +76,16 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         [Option(ScopeOption, ScopeHelp, CommandOptionType.MultipleValue)]
         private string[] Scopes { get; set; } = null;
 
-        [Option(PromptHintOption, PromptHintHelp, CommandOptionType.SingleValue)]
-        private string PromptHint { get; set; } = null;
-
         [Option(OutputOption, OutputHelp, CommandOptionType.SingleValue)]
         private OutputMode Output { get; set; } = OutputMode.Token;
 
-        [Option(ModeOption, ModeHelp, CommandOptionType.MultipleValue)]
+        [Option(CommandAad.PromptHintOption, CommandAad.PromptHintHelpText, CommandOptionType.SingleValue)]
+        private string PromptHint { get; set; } = null;
+
+        [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
-        [Option(DomainOption, DomainHelp, CommandOptionType.SingleValue)]
+        [Option(CommandAad.DomainOption, CommandAad.DomainHelpText, CommandOptionType.SingleValue)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         /// <summary>
@@ -194,7 +173,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
             if (string.IsNullOrEmpty(this.PromptHint))
             {
-                logger.LogError($"The {PromptHintOption} field is required.");
+                logger.LogError($"The {CommandAad.PromptHintOption} field is required.");
                 validOptions = false;
             }
 

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -35,13 +35,15 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string ScopeOption = "--scope";
         private const string ScopeHelp = "A token scope for accessing Azure DevOps resources. Repeated invocations allowed.";
 
+        private const string PromptHintOption = "--prompt-hint";
+        private const string PromptHintHelp = "A prompt hint to contextualize prompts and identify uses in telemetry, when captured.";
+
         private const string OutputOption = "--output";
         private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";
 
         private const string DomainOption = "--domain";
         private const string DomainHelp = "The preferred domain used when acquiring Azure Active Directory access tokens. [default: microsoft.com]";
 
-        private const string AccessTokenPrompt = "AzureAuth ADO PAT";
         private static readonly IEnumerable<AuthMode> AccessTokenAuthModes = new[] { AuthMode.Default };
         private static readonly TimeSpan AccessTokenTimeout = TimeSpan.FromMinutes(15);
 
@@ -94,6 +96,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         [Option(ScopeOption, ScopeHelp, CommandOptionType.MultipleValue)]
         private string[] Scopes { get; set; } = null;
+
+        [Option(PromptHintOption, PromptHintHelp, CommandOptionType.SingleValue)]
+        private string PromptHint { get; set; } = null;
 
         [Option(OutputOption, OutputHelp, CommandOptionType.SingleValue)]
         private OutputMode Output { get; set; } = OutputMode.Token;
@@ -150,7 +155,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
                 AzureAuth.Ado.Constants.AdoParams,
                 AccessTokenAuthModes,
                 this.Domain,
-                AccessTokenPrompt,
+                this.PromptHint,
                 AccessTokenTimeout,
                 eventData);
         }

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
-        [Option(CommandAad.DomainOption, CommandAad.DomainHelpText, CommandOptionType.SingleValue)]
+        [Option(CommandAad.DomainOption, $"{CommandAad.DomainHelpText}\n[default: microsoft.com]", CommandOptionType.SingleValue)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         /// <summary>

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -109,17 +109,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
                 return 1;
             }
 
-            IPatCache cache = null;
-            try
-            {
-                cache = this.Cache();
-            }
-            catch (MsalCachePersistenceException e)
-            {
-                logger.LogError($"Failed to validate cache persistence: {e.Message}");
-                return 1;
-            }
-
+            var cache = this.Cache();
             var client = this.Client(accessToken.Token);
             var manager = new PatManager(cache, client);
 
@@ -227,8 +217,6 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
             .Build();
 
             var storage = Storage.Create(storageProperties);
-            storage.VerifyPersistence();
-
             var storageWrapper = new StorageWrapper(storage);
             return new PatCache(storageWrapper);
         }

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string OutputOption = "--output";
         private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";
 
-        private static readonly TimeSpan AccessTokenTimeout = TimeSpan.FromMinutes(15);
-
         private static readonly string LockfilePath = Path.Combine(Path.GetTempPath(), AzureAuth.Ado.Constants.PatLockfileName);
 
         // The possible PAT output modes.
@@ -87,6 +85,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         [Option(CommandAad.DomainOption, $"{CommandAad.DomainHelpText}\n[default: {AzureAuth.Ado.Constants.PreferredDomain}]", CommandOptionType.SingleValue)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
+
+        [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]
+        private double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
 
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
@@ -177,7 +178,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
                 this.AuthModes,
                 this.Domain,
                 this.PromptHint,
-                AccessTokenTimeout,
+                TimeSpan.FromMinutes(this.Timeout),
                 eventData);
         }
 

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -63,20 +63,6 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         private static readonly string LockfilePath = Path.Combine(Path.GetTempPath(), AzureAuth.Ado.Constants.PatLockfileName);
 
-        // On all platforms the PAT cache should be in the same directory as a typical AzureAuth installation.
-        //   - On Windows this is `%LOCALAPPDATA%\Programs\AzureAuth`.
-        //   - On Unix-like platforms this is `~/.azureauth`.
-#if PlatformWindows
-        private static readonly string CacheDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Programs",
-            "AzureAuth");
-#else
-        private static readonly string CacheDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".azureauth");
-#endif
-
         // The possible PAT output modes.
         private enum OutputMode
         {
@@ -249,7 +235,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         {
             var storageProperties = new StorageCreationPropertiesBuilder(
                 PatStorageParameters.CacheFileName,
-                CacheDirectory)
+                AzureAuth.Constants.AppDirectory)
             .WithMacKeyChain(
                 PatStorageParameters.MacOSServiceName,
                 PatStorageParameters.MacOSAccountName)

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -41,10 +41,26 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string OutputOption = "--output";
         private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";
 
+        private const string ModeOption = "--mode";
+#if PlatformWindows
+        /// <summary>
+        /// The help text for the <see cref="ModeOption"/> option.
+        /// </summary>
+        private const string ModeHelp = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
+You can use any combination of modes with multiple instances of the --mode flag.
+[possible values: all, iwa, broker, web, devicecode]";
+#else
+        /// <summary>
+        /// The help text for the <see cref="ModeOption"/> option.
+        /// </summary>
+        private const string ModeHelp = @"Authentication mode. Default: web.
+You can use any combination with multiple instances of the --mode flag.
+[possible values: all, web, devicecode]";
+#endif
+
         private const string DomainOption = "--domain";
         private const string DomainHelp = "The preferred domain used when acquiring Azure Active Directory access tokens. [default: microsoft.com]";
 
-        private static readonly IEnumerable<AuthMode> AccessTokenAuthModes = new[] { AuthMode.Default };
         private static readonly TimeSpan AccessTokenTimeout = TimeSpan.FromMinutes(15);
 
         private static readonly string LockfilePath = Path.Combine(Path.GetTempPath(), AzureAuth.Ado.Constants.PatLockfileName);
@@ -102,6 +118,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         [Option(OutputOption, OutputHelp, CommandOptionType.SingleValue)]
         private OutputMode Output { get; set; } = OutputMode.Token;
+
+        [Option(ModeOption, ModeHelp, CommandOptionType.MultipleValue)]
+        private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
         [Option(DomainOption, DomainHelp, CommandOptionType.SingleValue)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
@@ -192,7 +211,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         {
             return publicClientAuth.Token(
                 AzureAuth.Ado.Constants.AdoParams,
-                AccessTokenAuthModes,
+                this.AuthModes,
                 this.Domain,
                 this.PromptHint,
                 AccessTokenTimeout,

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         private IPatClient Client(string accessToken)
         {
-            var baseUrl = new Uri($"{AzureAuth.Ado.Constants.BaseUrl}/{this.Organization}");
+            var baseUrl = new Uri(string.Join('/', AzureAuth.Ado.Constants.BaseUrl, this.Organization));
             var credentials = new VssOAuthAccessTokenCredential(accessToken);
             var connection = new VssConnection(baseUrl, credentials);
             var tokensHttpClientWrapper = new TokensHttpClientWrapper(connection);

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -47,11 +47,19 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         private static readonly string LockfilePath = Path.Combine(Path.GetTempPath(), AzureAuth.Ado.Constants.PatLockfileName);
 
-        // TODO: This is currently Windows-specific. We should probably define this directory conditionally by platform.
+        // On all platforms the PAT cache should be in the same directory as a typical AzureAuth installation.
+        //   - On Windows this is usually `%LOCALAPPDATA%\Programs\AzureAuth`.
+        //   - On Unix-like platforms this is usually `~/.azureauth`.
+#if PlatformWindows
         private static readonly string CacheDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Programs",
             "AzureAuth");
+#else
+        private static readonly string CacheDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".azureauth");
+#endif
 
         // The possible PAT output modes.
         private enum OutputMode

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -54,28 +54,24 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// <summary>
         /// The Prompt Hint help text.
         /// </summary>
-        public const string PromptHintHelpText = "A prompt hint to contextualize prompts and identify uses in telemetry";
+        public const string PromptHintHelpText = "A prompt hint to contextualize prompts and identify uses in telemetry, when captured.";
 
+        /// <summary>
+        /// The help text for the <see cref="ModeOption"/> option.
+        /// </summary>
 #if PlatformWindows
-        /// <summary>
-        /// The help text for the <see cref="ModeOption"/> option.
-        /// </summary>
-        public const string AuthModeHelperText = @"Authentication mode. Default: iwa (Integrated Windows Auth), then broker, then web.
-You can use any combination of modes with multiple instances of the --mode flag.
-Allowed values: [all, iwa, broker, web, devicecode]";
+        public const string AuthModeHelperText = @"Authentication mode. Repeated invocations allowed.
+[default: iwa (Integrated Windows Auth), then broker, then web]
+[possible values: all, iwa, broker, web, devicecode]";
 #else
-        /// <summary>
-        /// The help text for the <see cref="ModeOption"/> option.
-        /// </summary>
-        public const string AuthModeHelperText = @"Authentication mode. Default: web.
-You can use any combination with multiple instances of the --mode flag.
-Allowed values: [all, web, devicecode]";
+        public const string AuthModeHelperText = @"Authentication mode. Repeated invocations allowed. [default: web]
+[possible values: all, web, devicecode]";
 #endif
 
         /// <summary>
         /// The help text for the <see cref="DomainOption"/> option.
         /// </summary>
-        public const string DomainHelpText = "Preferred domain to filter cached accounts by. If a single account matching the preferred domain is in the cache it is used, otherwise an account picker will be launched.\n";
+        public const string DomainHelpText = "Preferred domain for filtering cached accounts.\nSkips launching an account picker if only one cached account matches the preferred domain.";
 
         /// <summary>
         /// The help text for the <see cref="TimeoutOption"/> option.

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// <summary>
         /// The help text for the <see cref="TimeoutOption"/> option.
         /// </summary>
-        public const string TimeoutHelpText = "The number of minutes before authentication times out.\nDefault: 15 minutes.";
+        public const string TimeoutHelpText = "The number of minutes before authentication times out.\n[default: 15 minutes]";
 
         /// <summary>
         /// The default number of minutes CLI is allowed to run.

--- a/src/AzureAuth/Commands/CommandAdo.cs
+++ b/src/AzureAuth/Commands/CommandAdo.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     /// Parent command for Azure Devops specific commands.
     /// </summary>
     [Command("ado", Description = "A collection of Azure Devops (ADO) specific authentication commands.")]
-
-    // [Subcommand(typeof(Ado.CommandPat))] // TODO: Enable Pat command
+    [Subcommand(typeof(Ado.CommandPat))]
     [Subcommand(typeof(Ado.CommandToken))]
     public class CommandAdo
     {

--- a/src/AzureAuth/Constants.cs
+++ b/src/AzureAuth/Constants.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AzureAuth
+{
+    using System;
+    using System.IO;
+
+    /// <summary>AzureAuth constant values.</summary>
+    internal static class Constants
+    {
+        /// <summary>
+        /// The default application directory for AzureAuth.
+        /// On Windows this is <c>%LOCALAPPDATA%\Programs\AzureAuth</c>.
+        /// On Unix-like platforms this is <c>~/.azureauth</c>.
+        /// </summary>
+#if PlatformWindows
+        public static readonly string AppDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Programs",
+            "AzureAuth");
+#else
+        public static readonly string AppDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".azureauth");
+#endif
+    }
+}


### PR DESCRIPTION
This PR adds a functional version of the `azureauth ado pat` subcommand with a few caveats.

- The logging is insufficient and will be addressed in a subsequent PR.
- The telemetry is insufficient and will be addressed in a subsequent PR.
- ~I haven't addressed a cross-platform cache location, but I _think_ I want to put it alongside the AzureAuth installation itself.~
  - [x] Unix: `~/.azureauth/azureauth-pat.cache`
  - [x] Windows: `C:\Users\<user>\AppData\Local\Programs\AzureAuth\azureauth-pat.cache`
- We probably want to do a persistence check before trying to use the cache, but I'm still reading up on how to do that.
- There are basically no tests for this code, but with few exceptions there aren't any conditional paths and most places in `CommandPat.cs` are just configuring and then calling into well-tested components.

The basic workflow here is
1. Get an Azure AD access token.
2. Create a [`PatCache`](https://github.com/AzureAD/microsoft-authentication-cli/blob/9c029269ce30a6d72d87d4be55a77d52b80e3f56/src/AdoPat/PatCache.cs), [`PatClient`](https://github.com/AzureAD/microsoft-authentication-cli/blob/9c029269ce30a6d72d87d4be55a77d52b80e3f56/src/AdoPat/PatClient.cs), and use them to create a [`PatManager`](https://github.com/AzureAD/microsoft-authentication-cli/blob/9c029269ce30a6d72d87d4be55a77d52b80e3f56/src/AdoPat/PatManager.cs).
3. Acquire a lock ensuring no other applications can use the cache.
4. Use the `PatManager` to get a PAT.
5. Display said PAT.

This is a draft PR while I search for answers to the few remaining `TODO`s, but I want to get early feedback while I'm working on that. I will update the draft PR to a full PR when the `TODO`s are resolved.