### PR TITLE
Release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
 
-## [0.7.44] - 2023-04-05
+## [0.7.4] - 2023-04-05
 ### Added
 - When the environment variable `AZUREAUTH_APPLICATION_INSIGHTS_INGESTION_TOKEN` is not configured,
  regkey `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth\ApplicationInsightsIngestionToken` will be a back up on Windows for telemetry ingestion token config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `azureauth ado` : Prints the help for Azure Devops commands.
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
+
+## [0.7.44] - 2023-04-05
+### Added
 - When the environment variable `AZUREAUTH_APPLICATION_INSIGHTS_INGESTION_TOKEN` is not configured,
  regkey `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\AzureAuth\ApplicationInsightsIngestionToken` will be a back up on Windows for telemetry ingestion token config.
 
@@ -136,7 +139,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.1...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.4...HEAD
+[0.7.4]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.3...0.7.4
+[0.7.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.2...0.7.3
+[0.7.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.5.4...0.6.0


### PR DESCRIPTION
This version is to enable MDM policy, and it is only for plain AzureAuth use and won't be merged to AzureAuth-lib or OMR.