### PR TITLE
Unflight ado parent command

### DIFF
--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         "\n\n\u001b[31m-- azureauth [options]\u001b[0m" +
         "\n\u001b[32m++ azureauth aad [options]\u001b[0m\n")]
     [Subcommand(typeof(CommandAad))]
-    [Subcommand(typeof(CommandAdo))]
+    //[Subcommand(typeof(CommandAdo))] // TODO: Enable Ado commands
     [Subcommand(typeof(CommandInfo))]
     public class CommandAzureAuth : CommandAad
     {


### PR DESCRIPTION
I had enabled the ado token command with the intent of releasing it this week, but we're not ready to do that, so we are unflighting to allow for release 0.7.4 to go in.