### PR TITLE
Prepare for Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+## [0.8.0] - 2023-04-07
 ### Added
-- New `ado` commands 
+- New `ado` sub-commands
   - `azureauth ado` : Prints the help for Azure Devops commands.
   - `azureauth ado pat` : Command for creating, and locally caching Azure Devops <abbr title="Personal Access Tokens">PAT</abbr>s.
   - `azureauth ado token` : Command for passing back a <abbr title="Personal Access Tokens">PAT</abbr> from an env var, or authenticating and returning an <abbr title="Azure Active Directory">AAD</abbr> access token.
+
+### Removed
+- The root command `azureauth` no longer acquires AAD tokens. It prints the global help text. Use `azureauth aad` instead.
 
 ## [0.7.4] - 2023-04-05
 ### Added
@@ -139,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.4...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.4...0.8.0
 [0.7.4]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.3...0.7.4
 [0.7.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.2...0.7.3
 [0.7.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.1...0.7.2

--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO.Abstractions;
-
-using McMaster.Extensions.CommandLineUtils;
-
-using Microsoft.Extensions.Logging;
-using Microsoft.Office.Lasso.Interfaces;
-using Microsoft.Office.Lasso.Telemetry;
-
 namespace Microsoft.Authentication.AzureAuth.Commands
 {
+    using System.IO.Abstractions;
+    using McMaster.Extensions.CommandLineUtils;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Office.Lasso.Interfaces;
+    using Microsoft.Office.Lasso.Telemetry;
+
     /// <summary>
     /// The command main class parses commands and dispatches to the corresponding methods.
     /// </summary>

--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -1,34 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IO.Abstractions;
+
+using McMaster.Extensions.CommandLineUtils;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Office.Lasso.Interfaces;
+using Microsoft.Office.Lasso.Telemetry;
+
 namespace Microsoft.Authentication.AzureAuth.Commands
 {
-    using System.IO.Abstractions;
-
-    using McMaster.Extensions.CommandLineUtils;
-
-    using Microsoft.Extensions.Logging;
-    using Microsoft.Office.Lasso.Interfaces;
-    using Microsoft.Office.Lasso.Telemetry;
-
     /// <summary>
     /// The command main class parses commands and dispatches to the corresponding methods.
     /// </summary>
-    [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library)." +
-        "\n\n⚠️ NOTICE: Use `azureauth aad [options]`.\n⚠️ The top-level azureauth command is deprecated and will print help text soon." +
-        "\n\n\u001b[31m-- azureauth [options]\u001b[0m" +
-        "\n\u001b[32m++ azureauth aad [options]\u001b[0m\n")]
+    [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library).")]
     [Subcommand(typeof(CommandAad))]
-    //[Subcommand(typeof(CommandAdo))] // TODO: Enable Ado commands
+    [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]
-    public class CommandAzureAuth : CommandAad
+    public class CommandAzureAuth
     {
-#pragma warning disable SA1648 // inheritdoc should be used with inheriting class
-        /// <inheritdoc/>
-        public CommandAzureAuth(CommandExecuteEventData eventData, ITelemetryService telemetryService, ILogger<CommandAzureAuth> logger, IFileSystem fileSystem, IEnv env)
-#pragma warning restore SA1648 // inheritdoc should be used with inheriting class
-            : base(eventData, telemetryService, logger, fileSystem, env)
+        /// <summary> Execute the command. </summary>
+        /// <param name="app">The current command instance.</param>
+        /// <returns>0.</returns>
+        public int OnExecute(CommandLineApplication app)
         {
+            app.ShowHelp();
+            return 0;
         }
     }
 }

--- a/src/MSALWrapper/AuthParameters.cs
+++ b/src/MSALWrapper/AuthParameters.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Authentication.MSALWrapper
     using System.Collections.Generic;
 
     /// <summary>
-    /// Core authentication parameters needed 
+    /// Core authentication parameters needed
     /// </summary>
     public record AuthParameters
     {


### PR DESCRIPTION
# Prepare for Release `0.8.0`

This includes
* flighting the `ado` sub-commands, `token` and `pat`, and
* Removing the backwards compatibility of the root command, and printing help text instead.