### PR TITLE
Ensure PAT cache keys are deterministic regardless of scope order

### DIFF
--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -15,8 +15,11 @@ namespace Microsoft.Authentication.AdoPat.Test
     public class PatManagerTest
     {
         private const string Organization = "contoso";
+        private const string OrganizationHash = "11f0b04eda61baebd5646fde72b0058e9713c30e950d2f3457bbbc1c3c68b31a";
         private const string DisplayName = "Test PAT";
+        private const string DisplayNameHash = "c27c517aad4237d8e221d8f52a438cb24f7f8078582d6cb025c238a25b2460f7";
         private const string Scope = "test.scope";
+        private const string ScopeHash = "c403db29c2175b51cfe6fd672b336e5171ff4e7a326a916edca508fd3be018f9";
 
         // This is a test token. A real value would be a much longer string.
         private const string Token = "Test Token";
@@ -108,7 +111,7 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task GetPatAsync_CreatesNewPatWhenCacheIsMissingPat()
         {
             // Arrange
-            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var expectedKey = $"{OrganizationHash}-{DisplayNameHash}-{ScopeHash}";
             var expectedPat = this.PatToken();
 
             // The cache is empty and therefore returns `null` for any key.
@@ -139,7 +142,7 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task GetPatAsync_RegeneratesPatWhenPatHasExpired()
         {
             // Arrange
-            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var expectedKey = $"{OrganizationHash}-{DisplayNameHash}-{ScopeHash}";
             var expiringPat = this.PatToken(
                 validTo: DateTime.UnixEpoch,
                 validFrom: DateTime.UnixEpoch.AddDays(-7));
@@ -179,7 +182,7 @@ namespace Microsoft.Authentication.AdoPat.Test
         public async Task GetPatAsync_CreatesNewPatWhenPatIsInactive()
         {
             // Arrange
-            var expectedKey = $"{Organization} {DisplayName} {Scope}";
+            var expectedKey = $"{OrganizationHash}-{DisplayNameHash}-{ScopeHash}";
             var inactivePat = this.PatToken();
             var expectedPat = this.PatToken(
                 authorizationId: new Guid("5045619c-e1b1-46e3-a1e4-ba5f38ddf49b"),

--- a/src/AdoPat.Test/PatOptionsTest.cs
+++ b/src/AdoPat.Test/PatOptionsTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat.Test
+{
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class PatOptionsTest
+    {
+        private const string Organization = "contoso";
+        private const string DisplayName = "Test PAT";
+
+        [Test]
+        public void CacheKey_Uses_Organization_DisplayName_And_Scopes()
+        {
+            var patOptions = new PatOptions
+            {
+                Organization = Organization,
+                DisplayName = DisplayName,
+                Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
+            };
+            var expected = $"{Organization} {DisplayName} test.scope.a test.scope.b test.scope.c";
+
+            patOptions.CacheKey().Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void CacheKey_Scope_Order_Is_Deterministic()
+        {
+            // These two PAT options have the same organization, display name,
+            // and scopes, but the scopes are in different orders. They should
+            // still be considered to have the same PAT cache key.
+            var patOptions1 = new PatOptions
+            {
+                Organization = Organization,
+                DisplayName = DisplayName,
+                Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
+            };
+            var patOptions2 = new PatOptions
+            {
+                Organization = Organization,
+                DisplayName = DisplayName,
+                Scopes = new[] { "test.scope.b", "test.scope.a", "test.scope.c" },
+            };
+
+            patOptions1.CacheKey().Should().BeEquivalentTo(patOptions2.CacheKey());
+        }
+    }
+}

--- a/src/AdoPat.Test/PatOptionsTest.cs
+++ b/src/AdoPat.Test/PatOptionsTest.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
             };
-            var expected = $"{Organization} {DisplayName} test.scope.a test.scope.b test.scope.c";
+            var expected = "11f0b04eda61baebd5646fde72b0058e9713c30e950d2f3457bbbc1c3c68b31a-c27c517aad4237d8e221d8f52a438cb24f7f8078582d6cb025c238a25b2460f7-eb52c21ad04b684f72bb1cef51e7f4ca58ce5a753744123a5df8f4e1781f831d";
 
-            patOptions.CacheKey().Should().BeEquivalentTo(expected);
+            patOptions.CacheKey().Should().Be(expected);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace Microsoft.Authentication.AdoPat.Test
                 Scopes = new[] { "test.scope.b", "test.scope.a", "test.scope.c" },
             };
 
-            patOptions1.CacheKey().Should().BeEquivalentTo(patOptions2.CacheKey());
+            patOptions1.CacheKey().Should().Be(patOptions2.CacheKey());
         }
     }
 }

--- a/src/AdoPat.Test/PatOptionsTest.cs
+++ b/src/AdoPat.Test/PatOptionsTest.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Authentication.AdoPat.Test
     public class PatOptionsTest
     {
         private const string Organization = "contoso";
+        private const string OrganizationHash = "11f0b04eda61baebd5646fde72b0058e9713c30e950d2f3457bbbc1c3c68b31a";
         private const string DisplayName = "Test PAT";
+        private const string DisplayNameHash = "c27c517aad4237d8e221d8f52a438cb24f7f8078582d6cb025c238a25b2460f7";
 
         [Test]
         public void CacheKey_Uses_Organization_DisplayName_And_Scopes()
@@ -20,7 +22,7 @@ namespace Microsoft.Authentication.AdoPat.Test
                 DisplayName = DisplayName,
                 Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
             };
-            var expected = "11f0b04eda61baebd5646fde72b0058e9713c30e950d2f3457bbbc1c3c68b31a-c27c517aad4237d8e221d8f52a438cb24f7f8078582d6cb025c238a25b2460f7-eb52c21ad04b684f72bb1cef51e7f4ca58ce5a753744123a5df8f4e1781f831d";
+            var expected = $"{OrganizationHash}-{DisplayNameHash}-eb52c21ad04b684f72bb1cef51e7f4ca58ce5a753744123a5df8f4e1781f831d";
 
             patOptions.CacheKey().Should().Be(expected);
         }

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Authentication.AdoPat
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
 
     /// <summary>
     /// A grouping of common options necessary to create or renew a PAT.
@@ -34,9 +36,23 @@ namespace Microsoft.Authentication.AdoPat
         /// <returns>The cache key.</returns>
         public string CacheKey()
         {
-            var strings = new List<string> { this.Organization, this.DisplayName };
-            strings.AddRange(this.Scopes.ToImmutableSortedSet());
-            return string.Join(" ", strings);
+            // We concatenate scopes with the empty string after sorting and
+            // deduplicating them to ensure the cache key is always the same.
+            var sortedScopes = string.Concat(this.Scopes.ToImmutableSortedSet());
+
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                var organization = sha256.ComputeHash(Encoding.UTF8.GetBytes(this.Organization));
+                var displayName = sha256.ComputeHash(Encoding.UTF8.GetBytes(this.DisplayName));
+                var scopes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sortedScopes));
+
+                var hashBytes = new[] { organization, displayName, scopes };
+                var hashes = hashBytes
+                    .Select(bytes => bytes.Select(b => b.ToString("x2")))
+                    .Select(bytes => string.Concat(bytes));
+
+                return string.Join('-', hashes);
+            }
         }
     }
 }

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Authentication.AdoPat
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
 
     /// <summary>
@@ -34,7 +35,7 @@ namespace Microsoft.Authentication.AdoPat
         public string CacheKey()
         {
             var strings = new List<string> { this.Organization, this.DisplayName };
-            strings.AddRange(this.Scopes);
+            strings.AddRange(this.Scopes.ToImmutableSortedSet());
             return string.Join(" ", strings);
         }
     }


### PR DESCRIPTION
Before this PR, it's possible that `PatOptions` with a different ordering of `Scopes` could result in different cache keys. This is not desirable, so we now sort the scopes before generating a cache key.