### PR TITLE
Remove uploading codeql result in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
 
-    - name: Upload CodeQL Analysis Results
-      uses: actions/upload-artifact@v3
-      with:
-        name: azureauth-static-code-analysis-${{ matrix.runtime }}.sarif
-        path: results/csharp.sarif
-
     - name: Build artifacts
       run: dotnet publish src/AzureAuth/AzureAuth.csproj -p:Version=${{ github.event.inputs.version }} --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}
       env:


### PR DESCRIPTION
As [Microsoft Security User Story](security.microsoft.net), <abbr title="static code analysis">SCA</abbr> is required.
I was supposed to upload the SCA result to artifacts in release pipeline, but
1. It is not required. In ADO, CodeQL is auto injected but it doesn't upload the result either.
2. It doesn't work. In the [latest release pipeline](https://github.com/AzureAD/microsoft-authentication-cli/actions/runs/4640483566/jobs/8212474007), under `build (any platform)/Upload CodeQL Analysis Result`, it shows 
```
Warning: No files were found with the provided path: results/csharp.sarif. No artifacts will be uploaded.
```

We know this doesn't work, so we are going to remove it.
I am also trying to do some test with [Upload-sarif](https://github.com/github/codeql-action/tree/v2/upload-sarif) in a forked repo. If it works, I would like to add it again.