### PR TITLE
Update Microsoft.NET.Test.Sdk to 17.3.3 in test projs

### DIFF
--- a/src/AdoPat.Test/AdoPat.Test.csproj
+++ b/src/AdoPat.Test/AdoPat.Test.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />

--- a/src/AzureAuth.Test/AzureAuth.Test.csproj
+++ b/src/AzureAuth.Test/AzureAuth.Test.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />

--- a/src/MSALWrapper.Test/MSALWrapper.Test.csproj
+++ b/src/MSALWrapper.Test/MSALWrapper.Test.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage.

Our test projects AdoPat.Test, AzureAuth.Test, MASLWrapper.Test uses `Microsoft.NET.Test.Sdk Version < 17.3.3` which uses a Newtonsoft.Json ` 9.0.1` having the above-mentioned vulnerability.

 ## Test
Run all tests in Windows and Mac to ensure nothing breaks.

More info about releases of `Microsoft.NET.Test.Sdk Version` can be found in their [project](https://github.com/microsoft/vstest/blob/main/docs/releases.md)