### PR TITLE
Upgrade Microsoft.VisualStudio.Services.Client to 19.215.0-preview

### DIFF
--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -11,7 +11,7 @@
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.25.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.212.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.215.0-preview" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Issue
The `AdoPat` project has transitive dependency on `System.Data.SqlClient version 4.4.2` through `Microsoft.VisualStudio.Services.Client 19.212.0-preview`. A vulnerability exists in System.Data.SqlClient and Microsoft.Data.SqlClient libraries where a timeout occurring under high load can cause incorrect data to be returned as the result of an asynchronously executed query.

## Fix
`System.Data.SqlClient 4.8.5` has this vulnerability fixed.
Updating the `Microsoft.VisualStudio.Services.Client` to [19.215.0-preview](https://www.nuget.org/packages/Microsoft.VisualStudio.Services.Client/19.215.0-preview) which depends on `System.Data.SqlClient 4.8.5`.

## Test
1. Build and Test the project locally on mac & Windows.
2. Try creating PAT on both Mac and Windows.