### PR TITLE
ado token command: add default value for --domain of microsoft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- The `azureauth ado token` command now defaults to `microsoft.com` domain.
+- The `azureauth ado token` command uses `microsoft.com` as the default `--domain` option value.
 
 ## [0.8.0] - 2023-04-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `azureauth ado token` command now defaults to `microsoft.com` domain.
 
 ## [0.8.0] - 2023-04-07
 ### Added

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -24,7 +24,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         private const string OutputOption = "--output";
         private const string OutputOptionDescription = "How to print the token. One of [token, header, headervalue].\nDefault: token";
 
-        private const string DomainOptionDescription = CommandAad.DomainHelpText + "\nDefault:" + AzureAuth.Ado.Constants.PreferredDomain;
+        private const string DomainOptionDescription = CommandAad.DomainHelpText + "\n[default: " + AzureAuth.Ado.Constants.PreferredDomain + "]";
 
         /// <summary>
         /// The available Token Formats.

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -24,6 +24,8 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         private const string OutputOption = "--output";
         private const string OutputOptionDescription = "How to print the token. One of [token, header, headervalue].\nDefault: token";
 
+        private const string DomainOptionDescription = CommandAad.DomainHelpText + "\nDefault:" + AzureAuth.Ado.Constants.PreferredDomain;
+
         /// <summary>
         /// The available Token Formats.
         /// </summary>
@@ -52,7 +54,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
-        [Option(CommandAad.DomainOption, Description = CommandAad.DomainHelpText)]
+        [Option(CommandAad.DomainOption, Description = DomainOptionDescription)]
         private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -53,7 +53,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
         [Option(CommandAad.DomainOption, Description = CommandAad.DomainHelpText)]
-        private string Domain { get; set; }
+        private string Domain { get; set; } = AzureAuth.Ado.Constants.PreferredDomain;
 
         [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]
         private double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;


### PR DESCRIPTION
Adding the default `@microsoft.com` domain for `ado token` command.