### PR TITLE
🤖 [2/n] Null Accounts: Update Broker

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -5,19 +5,21 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
+
     using FluentAssertions;
+
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Authentication.TestHelper;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
     using Microsoft.IdentityModel.JsonWebTokens;
+
     using Moq;
-    using NLog.Extensions.Logging;
+
     using NLog.Targets;
+
     using NUnit.Framework;
 
     public class BrokerTest

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
 
         [Test]
-        public async Task BrokerAuthFlow_HappyPath()
+        public async Task BrokerAuthFlow_CachedAuth()
         {
             this.MockAccount();
             this.SilentAuthResult();
@@ -128,6 +128,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccount();
             this.SilentAuthUIRequired();
+            this.SetupWithPromptHint();
             this.InteractiveAuthResultReturnsNullWithoutClaims();
 
             // Act
@@ -180,8 +181,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccount();
             this.SilentAuthTimeout();
-            this.SetupWithPromptHint();
             this.InteractiveAuthResult();
+            this.SetupWithPromptHint();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
@@ -255,6 +256,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockAccount();
             this.SilentAuthUIRequired();
+            this.SetupWithPromptHint();
             this.InteractiveAuthExtraClaimsRequired();
             this.InteractiveAuthResultReturnsNullWithClaims();
 

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors.Should().HaveCount(2);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[1].Message.Should().Be("Interactive Auth timed out after 00:15:00");
+            authFlowResult.Errors[1].Message.Should().Be("broker interactive auth timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
@@ -353,7 +353,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
+            authFlowResult.Errors[2].Message.Should().Be("broker interactive auth (with extra claims) timed out after 00:15:00");
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -23,20 +23,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IList<Exception> errors;
-        private IPCAWrapper pcaWrapper;
-
-        #region Public configurable properties
-
-        /// <summary>
-        /// The silent auth timeout.
-        /// </summary>
-        private TimeSpan silentAuthTimeout = TimeSpan.FromSeconds(20);
+        private readonly IPCAWrapper pcaWrapper;
 
         /// <summary>
         /// The interactive auth timeout.
         /// </summary>
         private TimeSpan interactiveAuthTimeout = TimeSpan.FromMinutes(15);
-        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Broker"/> class.
@@ -88,9 +80,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             TokenResult tokenResult = null;
             try
             {
-                tokenResult = await CachedAuth.TryCachedAuthAsync(
+                tokenResult = await CachedAuth.GetTokenAsync(
                     this.logger,
-                    this.silentAuthTimeout,
                     this.scopes,
                     account,
                     this.pcaWrapper,

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -105,8 +105,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                         this.interactiveAuthTimeout,
                         $"{this.Name()} interactive auth",
                         getTokenInteractive,
-                        this.errors)
-                        .ConfigureAwait(false);
+                        this.errors).ConfigureAwait(false);
                 }
                 catch (MsalUiRequiredException ex)
                 {


### PR DESCRIPTION
# Pre Reqs
Review #261 

This PR updates the `Broker` auth flow to use the new `CachedAuth` from #261. As expected only 1 test needs to be updated since we no longer expect to call GetTokenSilent with a null account.

## Test Updates
* Move pcaMock verification into a `[TearDown]` method.
* The mock setup method `SilentAuthUIRequired` used to call `SetupWithPromptHint` for some reason. That method is not directly related as it's a part of the calling of interactive auth. So for example if silent auth returned an exception that bubbles out of the flow - the WithPromptHint mock would be set incorrectly. Separating the two makes the mock setups clearer for each test. 
* Mock setup order: I've re-ordered the calls to mock the calls in the order we expect them to happen.
* `BrokerAuthFlow_GetTokenSilent_ReturnsNull` on line 89 previously asserted after silent auth returned null that no actual auth happened, and now we do proceed with doing auth.