### PR TITLE
Cleanly log catastrophic errors

### DIFF
--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.3.8.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.4.21.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
             var accessToken = this.AccessToken(publicClientAuth, eventData);
             if (accessToken == null)
             {
-                logger.LogError("Failed to acquire an Azure DevOps access token. Re-run with '--verbosity debug' for more info.");
+                logger.LogError("Failed to acquire an Azure DevOps access token. Re-run with --verbosity=debug for more info.");
                 return 1;
             }
 


### PR DESCRIPTION
Right now the `azureauth ado pat` subcommand lets users see the full stack trace for a catastrophic error. This PR presents that in a cleaner fashion and also makes sure that errors are included in telemetry when applicable.