### PR TITLE
[2/n] Make CachedAuth an AuthFlow

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -72,8 +72,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Web);
 
-            subject.Should().HaveCount(1);
-            subject.First().GetType().Name.Should().Be(typeof(Web).Name);
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(typeof(CachedAuth), typeof(Web));
         }
 
 #if PlatformWindows
@@ -84,8 +87,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.IWA);
 
-            subject.Should().HaveCount(1);
-            subject.First().GetType().Name.Should().Be(typeof(IntegratedWindowsAuthentication).Name);
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(typeof(CachedAuth), typeof(IntegratedWindowsAuthentication));
         }
 
         [Test]
@@ -95,8 +101,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Broker);
 
-            subject.Should().HaveCount(1);
-            subject.First().GetType().Name.Should().Be(typeof(Broker).Name);
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(typeof(CachedAuth), typeof(Broker));
         }
 
         [Test]
@@ -107,14 +116,15 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
-            subject.Should().HaveCount(3);
-
-            // BeEquivalentTo doesn't assert order for a list :(
-            // so explicitly assert the first and second item names.
-            var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
-            names[1].Should().Be(typeof(Broker).Name);
-            names[2].Should().Be(typeof(Web).Name);
+            subject.Should().HaveCount(4);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Broker),
+                    typeof(Web));
         }
 
         [Test]
@@ -125,10 +135,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
-            subject.Should().HaveCount(2);
-            var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
-            names[1].Should().Be(typeof(Web).Name);
+            subject.Should().HaveCount(3);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Web));
         }
 
         [Test]
@@ -139,15 +153,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
-            subject.Should().HaveCount(4);
-
-            // BeEquivalentTo doesn't assert order for a list :(
-            // so explicitly assert the first and second item names.
-            var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
-            names[1].Should().Be(typeof(Broker).Name);
-            names[2].Should().Be(typeof(Web).Name);
-            names[3].Should().Be(typeof(DeviceCode).Name);
+            subject.Should().HaveCount(5);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Broker),
+                    typeof(Web),
+                    typeof(DeviceCode));
         }
 
         [Test]
@@ -158,14 +173,15 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
-            subject.Should().HaveCount(3);
-
-            // BeEquivalentTo doesn't assert order for a list :(
-            // so explicitly assert the first and second item names.
-            var names = subject.Select(a => a.GetType().Name).ToList();
-            names[0].Should().Be(typeof(IntegratedWindowsAuthentication).Name);
-            names[1].Should().Be(typeof(Web).Name);
-            names[2].Should().Be(typeof(DeviceCode).Name);
+            subject.Should().HaveCount(4);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Web),
+                    typeof(DeviceCode));
         }
 #endif
 
@@ -175,8 +191,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.DeviceCode);
 
             this.pcaWrapperMock.VerifyAll();
-            subject.Should().HaveCount(1);
-            subject.First().GetType().Name.Should().Be(typeof(DeviceCode).Name);
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(DeviceCode));
         }
 
         [Test]
@@ -189,15 +210,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
-            subject.Should().HaveCount(3);
+            subject.Should().HaveCount(4);
             subject
-                .Select(flow => flow.GetType().Name)
+                .Select(flow => flow.GetType())
                 .Should()
                 .BeEquivalentTo(new[]
                 {
-                    typeof(IntegratedWindowsAuthentication).Name,
-                    typeof(Web).Name,
-                    typeof(DeviceCode).Name,
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Web),
+                    typeof(DeviceCode),
                 });
         }
 
@@ -211,16 +233,17 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
-            subject.Should().HaveCount(4);
+            subject.Should().HaveCount(5);
             subject
-                .Select(flow => flow.GetType().Name)
+                .Select(flow => flow.GetType())
                 .Should()
                 .BeEquivalentTo(new[]
                 {
-                    typeof(IntegratedWindowsAuthentication).Name,
-                    typeof(Broker).Name,
-                    typeof(Web).Name,
-                    typeof(DeviceCode).Name,
+                    typeof(CachedAuth),
+                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Broker),
+                    typeof(Web),
+                    typeof(DeviceCode),
                 });
         }
 
@@ -231,14 +254,15 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
-            subject.Should().HaveCount(2);
+            subject.Should().HaveCount(3);
             subject
-                .Select(flow => flow.GetType().Name)
+                .Select(flow => flow.GetType())
                 .Should()
                 .BeEquivalentTo(new[]
                 {
-                    typeof(Web).Name,
-                    typeof(DeviceCode).Name,
+                    typeof(CachedAuth),
+                    typeof(Web),
+                    typeof(DeviceCode),
                 });
         }
 
@@ -251,10 +275,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             var subject = this.Subject(AuthMode.Default);
 
             this.platformUtilsMock.VerifyAll();
-            subject.Select(async => async.GetType().Name).Should().BeEquivalentTo(new[]
-            {
-                typeof(Web).Name,
-            });
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(Web));
         }
 
         private void MockIsWindows10Or11(bool value)

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.TestHelper;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+
+    using Moq;
+
+    using NUnit.Framework;
+    using System;
+
+    internal class AuthFlowTestBase
+    {
+        protected static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
+        protected static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
+        protected Mock<IPCAWrapper> mockPca;
+        protected Mock<IAccount> mockAccount;
+        protected string testUsername = "John Doe";
+        protected ILogger logger;
+
+        [SetUp]
+        public void Setup()
+        {
+            (this.logger, _) = MemoryLogger.Create();
+            this.mockPca = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.mockAccount = new Mock<IAccount>(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.mockPca.VerifyAll();
+            this.mockAccount.VerifyAll();
+        }
+
+        protected virtual void SetupCachedAccount()
+        {
+            this.mockAccount.Setup(a => a.Username).Returns(this.testUsername);
+            this.mockPca
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync(this.mockAccount.Object);
+        }
+
+        protected virtual void SetupNoCachedAccount()
+        {
+            this.mockPca
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync((IAccount)null);
+        }
+    }
+}

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // as it sets the order in which auth flows will be attempted.
             List<IAuthFlow> flows = new List<IAuthFlow>();
 
+            // We always try cached auth first.
+            flows.Add(new CachedAuth(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain, pcaWrapper));
+
             // We try IWA as the first auth flow as it works for any Windows version
             // and tries to auth silently.
             if (authMode.IsIWA() && platformUtils.IsWindows())

--- a/src/MSALWrapper/AuthFlow/CachedAuth.cs
+++ b/src/MSALWrapper/AuthFlow/CachedAuth.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
@@ -16,7 +15,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class CachedAuth : AuthFlowBase
     {
-        private const string NameValue = "cache";
+        private const string NameValue = "pca_cache";
         private static readonly TimeSpan CachedAuthTimeout = TimeSpan.FromSeconds(30);
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -39,58 +38,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(clientId, tenantId);
         }
 
-        /// <inheritdoc/>
-        protected override string Name() => NameValue;
-
-        /// <inheritdoc/>
-        protected override async Task<TokenResult> GetTokenInnerAsync()
-        {
-            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
-            if (account == null)
-            {
-                this.logger.LogDebug("No cached account found!");
-                return null;
-            }
-
-            this.logger.LogDebug($"Using cached account '{account.Username}'");
-
-            TokenResult tokenResult = await TaskExecutor.CompleteWithin(
-                this.logger,
-                CachedAuthTimeout,
-                "Get Token Silent",
-                (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
-                this.errors).ConfigureAwait(false);
-
-            tokenResult.SetSilent();
-
-            return tokenResult;
-        }
-
-        private IPCAWrapper BuildPCAWrapper(Guid clientId, Guid tenantId)
-        {
-            var clientBuilder =
-                PublicClientApplicationBuilder
-                .Create($"{clientId}")
-                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
-                .WithLogging(
-                    this.LogMSAL,
-                    Identity.Client.LogLevel.Verbose,
-                    enablePiiLogging: false,
-                    enableDefaultPlatformLogging: true);
-
-            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId);
-        }
-
-        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
-        {
-            this.logger.LogTrace($"MSAL: {message}");
-        }
-
         /// <summary>
         /// Try to get a token silently.
         /// </summary>
         /// <param name="logger">An <see cref="ILogger"/>.</param>
-        /// <param name="cachedAuthTimeout">The timeout for getting a cached token.</param>
         /// <param name="scopes">Auth Scopes.</param>
         /// <param name="account"><see cref="IAccount"/> object to use or null if no account has been found.</param>
         /// <param name="pcaWrapper">An <see cref="IPCAWrapper"/>.</param>
@@ -125,6 +76,36 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
 
             return tokenResult;
+        }
+
+        /// <inheritdoc/>
+        protected override string Name() => NameValue;
+
+        /// <inheritdoc/>
+        protected override async Task<TokenResult> GetTokenInnerAsync()
+        {
+            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
+            return await GetTokenAsync(this.logger, this.scopes, account, this.pcaWrapper, this.errors);
+        }
+
+        private IPCAWrapper BuildPCAWrapper(Guid clientId, Guid tenantId)
+        {
+            var clientBuilder =
+                PublicClientApplicationBuilder
+                .Create($"{clientId}")
+                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true);
+
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId);
+        }
+
+        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
+        {
+            this.logger.LogTrace($"MSAL: {message}");
         }
     }
 }

--- a/src/MSALWrapper/AuthFlow/CachedAuth.cs
+++ b/src/MSALWrapper/AuthFlow/CachedAuth.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
@@ -13,9 +14,77 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// <summary>
     /// This class provides an abstraction over how to use the MSAL Cached Auth (known as GetTokenSilent).
     /// </summary>
-    public static class CachedAuth
+    public class CachedAuth : AuthFlowBase
     {
+        private const string NameValue = "cache";
         private static readonly TimeSpan CachedAuthTimeout = TimeSpan.FromSeconds(30);
+        private readonly IEnumerable<string> scopes;
+        private readonly string preferredDomain;
+        private readonly IPCAWrapper pcaWrapper;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedAuth"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="clientId">The client id.</param>
+        /// <param name="tenantId">The tenant id.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="preferredDomain">The preferred domain.</param>
+        /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
+        public CachedAuth(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
+        {
+            this.logger = logger;
+            this.scopes = scopes;
+            this.preferredDomain = preferredDomain;
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(clientId, tenantId);
+        }
+
+        /// <inheritdoc/>
+        protected override string Name() => NameValue;
+
+        /// <inheritdoc/>
+        protected override async Task<TokenResult> GetTokenInnerAsync()
+        {
+            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
+            if (account == null)
+            {
+                this.logger.LogDebug("No cached account found!");
+                return null;
+            }
+
+            this.logger.LogDebug($"Using cached account '{account.Username}'");
+
+            TokenResult tokenResult = await TaskExecutor.CompleteWithin(
+                this.logger,
+                CachedAuthTimeout,
+                "Get Token Silent",
+                (cancellationToken) => this.pcaWrapper.GetTokenSilentAsync(this.scopes, account, cancellationToken),
+                this.errors).ConfigureAwait(false);
+
+            tokenResult.SetSilent();
+
+            return tokenResult;
+        }
+
+        private IPCAWrapper BuildPCAWrapper(Guid clientId, Guid tenantId)
+        {
+            var clientBuilder =
+                PublicClientApplicationBuilder
+                .Create($"{clientId}")
+                .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true);
+
+            return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId);
+        }
+
+        private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)
+        {
+            this.logger.LogTrace($"MSAL: {message}");
+        }
 
         /// <summary>
         /// Try to get a token silently.


### PR DESCRIPTION
Make `CachedAuth` inherit from `AuthFlowBase` and it's own "auth flow". 
This new flow is added to flows in the AuthFlowFactory, always, regardless of mode, to maintain existing behavior, where no matter what mode you choose, you get cached auth first.

This change allows us to apply the common error handling of the `AuthFlowBase` to the cached auth flow the same way it's applied to all other flows.

## `AuthFlowTestBase`
This is a new class in the test project to house the common setup for testing auth flows. 
Following PRs will re-use this to help dedupe the large amount of duplicated test setup we have accumlated across the auth flows, similar to how the error handling being moved into the base class has simplified all the authflows.