### PR TITLE
Improve ADO PAT debug logging

### DIFF
--- a/src/AdoPat.Test/AdoPat.Test.csproj
+++ b/src/AdoPat.Test/AdoPat.Test.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
     <ProjectReference Include="..\AdoPat\AdoPat.csproj" />
   </ItemGroup>
 

--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Authentication.AdoPat.Test
     using System.Threading.Tasks;
     using FluentAssertions;
     using Microsoft.Authentication.TestHelper;
+    using Microsoft.Extensions.Logging;
     using Microsoft.VisualStudio.Services.DelegatedAuthorization;
     using Moq;
     using NLog.Targets;
@@ -34,7 +35,7 @@ namespace Microsoft.Authentication.AdoPat.Test
 
         private readonly string cacheKey = string.Join('-', OrganizationHash, DisplayNameHash, ScopeHash);
 
-        private Extensions.Logging.ILogger logger;
+        private ILogger logger;
         private MemoryTarget logTarget;
 
         // Common mocks which are configured via the Setup and Teardown methods.

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -10,6 +10,7 @@
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.25.3" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.215.0-preview" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/AdoPat/PatManager.cs
+++ b/src/AdoPat/PatManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Authentication.AdoPat
         private const int ValidToExtensionDays = 7;
         private const int NearingExpirationDays = 2;
 
-        // Note: Logging in this class intentionally avoids referencing any PAT details lest those leak into log files.
+        // Note: Do NOT use this logger instance to log any fields on a PAT, ESPECIALLY the token.
         private ILogger logger;
 
         private IPatCache cache;

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -54,5 +54,13 @@ namespace Microsoft.Authentication.AdoPat
                 return string.Join('-', hashes);
             }
         }
+
+        /// <summary>Create a human-readable string representation of PAT options.</summary>
+        /// <returns>The string.</returns>
+        public override string ToString()
+        {
+            var scopes = string.Join(' ', this.Scopes);
+            return $"organization='{this.Organization}', displayName='{this.DisplayName}', scopes='{scopes}'";
+        }
     }
 }

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
             var cache = this.Cache();
             var client = this.Client(accessToken.Token);
-            var manager = new PatManager(cache, client);
+            var manager = new PatManager(logger, cache, client);
 
             using (new CrossPlatLock(LockfilePath))
             {


### PR DESCRIPTION
There was previously no debug logging within the `ado pat` subcommand. This PR addresses that and gives users information with `--verbosity debug` about

- Whether a PAT was found in the cache.
- Whether a PAT was inactive.
- Whether a PAT was expiring soon.
- Whether a PAT was created.
- Whether a PAT was regenerated.

In the event that we do suffer failures this information should help us better diagnose the errors. Catastrophic failures are already sent in telemetry (if and **only** if telemetry is enabled).