### PR TITLE
[1/n] Consolidate Error Handling into `AuthFlowBase`

### DIFF
--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -13,11 +13,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public abstract class AuthFlowBase : IAuthFlow
     {
+        /// <summary>
+        /// The list of errors encountered during token acquisition.
+        /// </summary>
+        protected IList<Exception> errors = new List<Exception>();
+
         /// <inheritdoc/>
         public async Task<AuthFlowResult> GetTokenAsync()
         {
-            (var result, var errors) = await this.GetTokenInnerAsync();
-            return new AuthFlowResult(result, errors, this.Name());
+            this.errors = new List<Exception>();
+            var result = await this.GetTokenInnerAsync();
+            return new AuthFlowResult(result, this.errors, this.Name());
         }
 
         /// <summary>
@@ -25,7 +31,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Performs token acquisition.
         /// </summary>
         /// <returns>a tuple of <see cref="TokenResult"/> and <see cref="IList{Exception}"/>.</returns>
-        protected abstract Task<(TokenResult result, IList<Exception> errors)> GetTokenInnerAsync();
+        protected abstract Task<TokenResult> GetTokenInnerAsync();
 
         /// <summary>
         /// The name of this AuthFlow.

--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             typeof(MsalUiRequiredException),
             typeof(MsalClientException),
             typeof(MsalServiceException),
+            typeof(MsalException),
             typeof(NullReferenceException),
         };
 

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
-        private readonly IList<Exception> errors;
         private readonly IPCAWrapper pcaWrapper;
 
         /// <summary>
@@ -43,7 +42,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
         public Broker(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
         {
-            this.errors = new List<Exception>();
             this.logger = logger;
             this.scopes = scopes;
             this.preferredDomain = preferredDomain;
@@ -73,7 +71,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override string Name() => NameValue;
 
         /// <inheritdoc/>
-        protected override async Task<(TokenResult, IList<Exception>)> GetTokenInnerAsync()
+        protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain)
                  ?? PublicClientApplication.OperatingSystemAccount;
@@ -90,7 +88,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
                 if (tokenResult != null)
                 {
-                    return (tokenResult, this.errors);
+                    return tokenResult;
                 }
 
                 try
@@ -131,7 +129,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return (tokenResult, this.errors);
+            return tokenResult;
         }
 
         private Func<CancellationToken, Task<TokenResult>> GetTokenInteractive(IAccount account)

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
-        private readonly IList<Exception> errors;
         private readonly IPCAWrapper pcaWrapper;
 
         #region Public configurable properties
@@ -49,7 +48,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
         public DeviceCode(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
         {
-            this.errors = new List<Exception>();
             this.logger = logger;
             this.scopes = scopes;
             this.preferredDomain = preferredDomain;
@@ -61,7 +59,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override string Name() => NameValue;
 
         /// <inheritdoc/>
-        protected override async Task<(TokenResult, IList<Exception>)> GetTokenInnerAsync()
+        protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
             TokenResult tokenResult = null;
@@ -77,7 +75,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
                 if (tokenResult != null)
                 {
-                    return (tokenResult, this.errors);
+                    return tokenResult;
                 }
 
                 this.logger.LogWarning($"Device Code Authentication for: {this.promptHint}");
@@ -95,7 +93,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.logger.LogError(ex.Message);
             }
 
-            return (tokenResult, this.errors);
+            return tokenResult;
         }
 
         private Task<TokenResult> DeviceCodeAuth(CancellationToken cancellationToken)

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     public class IntegratedWindowsAuthentication : AuthFlowBase
     {
         private const string NameValue = "iwa";
-        private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly IPCAWrapper pcaWrapper;
@@ -38,7 +37,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
         public IntegratedWindowsAuthentication(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
         {
-            this.errors = new List<Exception>();
             this.logger = logger;
             this.scopes = scopes;
             this.preferredDomain = preferredDomain;
@@ -52,22 +50,20 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
-            TokenResult tokenResult = null;
+            TokenResult tokenResult = await CachedAuth.GetTokenAsync(
+                this.logger,
+                this.scopes,
+                account,
+                this.pcaWrapper,
+                this.errors);
+
+            if (tokenResult != null)
+            {
+                return tokenResult;
+            }
 
             try
             {
-                tokenResult = await CachedAuth.GetTokenAsync(
-                    this.logger,
-                    this.scopes,
-                    account,
-                    this.pcaWrapper,
-                    this.errors);
-
-                if (tokenResult != null)
-                {
-                    return tokenResult;
-                }
-
                 tokenResult = await TaskExecutor.CompleteWithin(
                     this.logger,
                     this.integratedWindowsAuthTimeout,
@@ -78,36 +74,18 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 // If IWA worked, it was 100% silent.
                 tokenResult.SetSilent();
             }
-            catch (MsalUiRequiredException ex)
+            catch (MsalUiRequiredException ex) when (
+                ex.Classification == UiRequiredExceptionClassification.BasicAction
+                && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
             {
-                this.errors.Add(ex);
-                this.logger.LogDebug(ex.Message);
-
-                if (ex.Classification == UiRequiredExceptionClassification.BasicAction
-                      && ex.Message.StartsWith("AADSTS50076", StringComparison.OrdinalIgnoreCase))
-                {
-                    this.logger.LogWarning("IWA failed, 2FA is required.");
-                    this.logger.LogWarning("IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.");
-                }
+                this.logger.LogWarning("IWA failed, 2FA is required.");
+                this.logger.LogWarning("IWA can pass this requirement if you log into Windows with either a Smart Card or Windows Hello.");
+                throw;
             }
-            catch (MsalServiceException ex)
+            catch (MsalClientException ex) when (ex.Message.Contains("WS-Trust endpoint not found"))
             {
-                this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
-                this.errors.Add(ex);
-            }
-            catch (MsalClientException ex)
-            {
-                this.logger.LogWarning($"Msal Client Exception! (Not expected)\n{ex.Message}");
-                this.errors.Add(ex);
-                if (ex.Message.Contains("WS-Trust endpoint not found"))
-                {
-                    this.logger.LogWarning($"IWA only works on Corp Net, please turn on VPN.");
-                }
-            }
-            catch (NullReferenceException ex)
-            {
-                this.logger.LogWarning($"Msal unexpected null reference! (Not Expected)\n{ex.Message}");
-                this.errors.Add(ex);
+                this.logger.LogWarning($"IWA only works on Corp Net, please turn on VPN.");
+                throw;
             }
 
             return tokenResult;

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
-        private readonly IList<Exception> errors;
         private readonly IPCAWrapper pcaWrapper;
 
         /// <summary>
@@ -50,7 +49,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override string Name() => NameValue;
 
         /// <inheritdoc/>
-        protected override async Task<(TokenResult, IList<Exception>)> GetTokenInnerAsync()
+        protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
             TokenResult tokenResult = null;
@@ -66,7 +65,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
                 if (tokenResult != null)
                 {
-                    return (tokenResult, this.errors);
+                    return tokenResult;
                 }
 
                 tokenResult = await TaskExecutor.CompleteWithin(
@@ -111,7 +110,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return (tokenResult, this.errors);
+            return tokenResult;
         }
 
         private async Task<TokenResult> Iwa(CancellationToken cancellationToken)

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
-        private readonly IList<Exception> errors;
         private readonly IPCAWrapper pcaWrapper;
 
         /// <summary>
@@ -41,7 +40,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
         public Web(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
         {
-            this.errors = new List<Exception>();
             this.logger = logger;
             this.scopes = scopes;
             this.preferredDomain = preferredDomain;
@@ -53,7 +51,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override string Name() => NameValue;
 
         /// <inheritdoc/>
-        protected override async Task<(TokenResult, IList<Exception>)> GetTokenInnerAsync()
+        protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
             TokenResult tokenResult = null;
@@ -71,7 +69,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
                     if (tokenResult != null)
                     {
-                        return (tokenResult, this.errors);
+                        return tokenResult;
                     }
 
                     tokenResult = await TaskExecutor.CompleteWithin(
@@ -110,7 +108,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 this.errors.Add(ex);
             }
 
-            return (tokenResult, this.errors);
+            return tokenResult;
         }
 
         private Func<CancellationToken, Task<TokenResult>> GetTokenInteractive(IAccount account)

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     public class Web : AuthFlowBase
     {
         private const string NameValue = "web";
-        private readonly ILogger logger;
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
@@ -54,58 +53,40 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         protected override async Task<TokenResult> GetTokenInnerAsync()
         {
             IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
-            TokenResult tokenResult = null;
+
+            TokenResult tokenResult = await CachedAuth.GetTokenAsync(
+                this.logger,
+                this.scopes,
+                account,
+                this.pcaWrapper,
+                this.errors);
+
+            if (tokenResult != null)
+            {
+                return tokenResult;
+            }
 
             try
             {
-                try
-                {
-                    tokenResult = await CachedAuth.GetTokenAsync(
-                        this.logger,
-                        this.scopes,
-                        account,
-                        this.pcaWrapper,
-                        this.errors);
-
-                    if (tokenResult != null)
-                    {
-                        return tokenResult;
-                    }
-
-                    tokenResult = await TaskExecutor.CompleteWithin(
-                        this.logger,
-                        this.interactiveAuthTimeout,
-                        $"{this.Name()} interactive auth",
-                        this.GetTokenInteractive(account),
-                        this.errors).ConfigureAwait(false);
-                }
-                catch (MsalUiRequiredException ex)
-                {
-                    this.errors.Add(ex);
-                    this.logger.LogDebug($"Initial ${this.Name()} auth failed. Trying again with claims.\n{ex.Message}");
-
-                    tokenResult = await TaskExecutor.CompleteWithin(
-                        this.logger,
-                        this.interactiveAuthTimeout,
-                        "Interactive Auth (with extra claims)",
-                        this.GetTokenInteractiveWithClaims(ex.Claims),
-                        this.errors).ConfigureAwait(false);
-                }
+                tokenResult = await TaskExecutor.CompleteWithin(
+                    this.logger,
+                    this.interactiveAuthTimeout,
+                    $"{this.Name()} interactive auth",
+                    this.GetTokenInteractive(account),
+                    this.errors).ConfigureAwait(false);
             }
-            catch (MsalServiceException ex)
+            catch (MsalUiRequiredException ex)
             {
-                this.logger.LogWarning($"MSAL Service Exception! (Not expected)\n{ex.Message}");
                 this.errors.Add(ex);
-            }
-            catch (MsalClientException ex)
-            {
-                this.logger.LogWarning($"MSAL Client Exception! (Not expected)\n{ex.Message}");
-                this.errors.Add(ex);
-            }
-            catch (NullReferenceException ex)
-            {
-                this.logger.LogWarning($"MSAL unexpected null reference! (Not Expected)\n{ex.Message}");
-                this.errors.Add(ex);
+                this.logger.LogDebug($"Initial ${this.Name()} auth failed. Trying again with claims.\n{ex.Message}");
+
+
+                tokenResult = await TaskExecutor.CompleteWithin(
+                    this.logger,
+                    this.interactiveAuthTimeout,
+                    "Interactive Auth (with extra claims)",
+                    this.GetTokenInteractiveWithClaims(ex.Claims),
+                    this.errors).ConfigureAwait(false);
             }
 
             return tokenResult;


### PR DESCRIPTION
After moving the cached auth into a static function, we can start to see the outer MSAL error handling that is common to all authflows. This PR moves that common handling into the base class along with the ownership of the `errors` list.

Namely:
* We add an `IList<Exception> errors` to the `AuthFlowBase` class.
* We remove it from each auth flow so as to not "shadow" the base member.
* We extend the GetTokenAsync method to include the error handling so that all logging, and error collection is done in that 1 place for the suite of MSAL errors thrown by any AuthFlow.

I recommend viewing these diffs using "Side by Side" view.