### PR TITLE
[2/🗑️] Remove `CachedAuth` usage from Web.

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
     using NLog.Targets;
 
     using NUnit.Framework;
-    using System;
 
     internal class AuthFlowTestBase
     {
@@ -57,23 +56,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.mockAccount.VerifyAll();
         }
 
-        protected virtual void SetupCachedAccount()
+        protected virtual void SetupCachedAccount(bool exists = true)
         {
             this.mockPca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.mockAccount.Object);
+                .ReturnsAsync(exists ? this.mockAccount.Object : (IAccount)null);
         }
 
         protected virtual void SetupAccountUsername()
         {
             this.mockAccount.Setup(a => a.Username).Returns(TestUsername);
-        }
-
-        protected virtual void SetupNoCachedAccount()
-        {
-            this.mockPca
-                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync((IAccount)null);
         }
 
         protected virtual void SetupWithPromptHint()

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -3,53 +3,98 @@
 
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Authentication.TestHelper;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
 
     using Moq;
+
+    using NLog.Targets;
 
     using NUnit.Framework;
     using System;
 
     internal class AuthFlowTestBase
     {
+        protected const string TestUsername = "John Doe";
+        protected const string PromptHint = "test prompt hint";
+        protected const string MsalExceptionErrorCode = "1";
+        protected const string MsalExceptionMessage = "MSAL Exception";
+        protected const string Claims = "claims";
+
+        // These Guids were randomly generated and do not refer to a real resources
+        protected static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
+        protected static readonly IEnumerable<string> Scopes = new string[] { $"{ResourceId}/.default" };
         protected static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
         protected static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
-        protected Mock<IPCAWrapper> mockPca;
-        protected Mock<IAccount> mockAccount;
-        protected string testUsername = "John Doe";
+        protected static readonly Guid CorrelationId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912f");
+
+        protected Mock<IPCAWrapper> pca;
+        protected Mock<IAccount> account;
         protected ILogger logger;
+        protected MemoryTarget logTarget;
+        protected TokenResult testToken;
 
         [SetUp]
         public void Setup()
         {
-            (this.logger, _) = MemoryLogger.Create();
-            this.mockPca = new Mock<IPCAWrapper>(MockBehavior.Strict);
-            this.mockAccount = new Mock<IAccount>(MockBehavior.Strict);
+            (this.logger, this.logTarget) = MemoryLogger.Create();
+            this.pca = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.account = new Mock<IAccount>(MockBehavior.Strict);
+            this.testToken = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), CorrelationId);
         }
 
         [TearDown]
         public void TearDown()
         {
-            this.mockPca.VerifyAll();
-            this.mockAccount.VerifyAll();
+            this.pca.VerifyAll();
+            this.account.VerifyAll();
         }
 
         protected virtual void SetupCachedAccount()
         {
-            this.mockAccount.Setup(a => a.Username).Returns(this.testUsername);
-            this.mockPca
+            this.pca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.mockAccount.Object);
+                .ReturnsAsync(this.account.Object);
+        }
+
+        protected virtual void SetupAccountusername()
+        {
+            this.account.Setup(a => a.Username).Returns(TestUsername);
         }
 
         protected virtual void SetupNoCachedAccount()
         {
-            this.mockPca
+            this.pca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
                 .ReturnsAsync((IAccount)null);
+        }
+
+        protected virtual void SetupWithPromptHint()
+        {
+            this.pca
+                .Setup(pca => pca.WithPromptHint(PromptHint))
+                .Returns((string s) => this.pca.Object);
+        }
+
+        protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount = false)
+        {
+            this.pca
+               .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.account.Object : null, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(this.testToken);
+        }
+
+        protected virtual void SetupGetTokenInteractiveReturnsNull(bool withAccount = false)
+        {
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.account.Object : null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .ReturnsAsync(this.mockAccount.Object);
         }
 
-        protected virtual void SetupAccountusername()
+        protected virtual void SetupAccountUsername()
         {
             this.mockAccount.Setup(a => a.Username).Returns(TestUsername);
         }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         protected static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
         protected static readonly Guid CorrelationId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912f");
 
-        protected Mock<IPCAWrapper> pca;
-        protected Mock<IAccount> account;
+        protected Mock<IPCAWrapper> mockPca;
+        protected Mock<IAccount> mockAccount;
         protected ILogger logger;
         protected MemoryTarget logTarget;
         protected TokenResult testToken;
@@ -45,55 +45,55 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void Setup()
         {
             (this.logger, this.logTarget) = MemoryLogger.Create();
-            this.pca = new Mock<IPCAWrapper>(MockBehavior.Strict);
-            this.account = new Mock<IAccount>(MockBehavior.Strict);
+            this.mockPca = new Mock<IPCAWrapper>(MockBehavior.Strict);
+            this.mockAccount = new Mock<IAccount>(MockBehavior.Strict);
             this.testToken = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), CorrelationId);
         }
 
         [TearDown]
         public void TearDown()
         {
-            this.pca.VerifyAll();
-            this.account.VerifyAll();
+            this.mockPca.VerifyAll();
+            this.mockAccount.VerifyAll();
         }
 
         protected virtual void SetupCachedAccount()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.account.Object);
+                .ReturnsAsync(this.mockAccount.Object);
         }
 
         protected virtual void SetupAccountusername()
         {
-            this.account.Setup(a => a.Username).Returns(TestUsername);
+            this.mockAccount.Setup(a => a.Username).Returns(TestUsername);
         }
 
         protected virtual void SetupNoCachedAccount()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
                 .ReturnsAsync((IAccount)null);
         }
 
         protected virtual void SetupWithPromptHint()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.WithPromptHint(PromptHint))
-                .Returns((string s) => this.pca.Object);
+                .Returns((string s) => this.mockPca.Object);
         }
 
         protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount = false)
         {
-            this.pca
-               .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.account.Object : null, It.IsAny<CancellationToken>()))
+            this.mockPca
+               .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                .ReturnsAsync(this.testToken);
         }
 
         protected virtual void SetupGetTokenInteractiveReturnsNull(bool withAccount = false)
         {
-            this.pca
-                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.account.Object : null, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((TokenResult)null);
         }
     }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -93,7 +93,21 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("1", "UI Required Exception"));
+                .ThrowsAsync(new MsalUiRequiredException("1", "UI Required Exception"));
+        }
+
+        protected virtual void SetupGetTokenInteractiveMsalServiceException(bool withAccount)
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new MsalServiceException("1", "MSAL Service Exception"));
+        }
+
+        protected virtual void SetupGetTokenInteractiveTimeout(bool withAccount)
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new OperationCanceledException());
         }
 
         protected virtual void SetupGetTokenInteractiveWithClaimsSuccess()
@@ -115,6 +129,13 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
+        }
+
+        protected virtual void SetupGetTokenInteractiveWithClaimsTimeout()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -75,18 +75,46 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Returns((string s) => this.mockPca.Object);
         }
 
-        protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount = false)
+        protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount)
         {
             this.mockPca
                .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                .ReturnsAsync(this.testToken);
         }
 
-        protected virtual void SetupGetTokenInteractiveReturnsNull(bool withAccount = false)
+        protected virtual void SetupGetTokenInteractiveReturnsNull(bool withAccount)
         {
             this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((TokenResult)null);
+        }
+
+        protected virtual void SetupGetTokenInteractiveMsalUiRequiredException(bool withAccount)
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
+                .Throws(new MsalUiRequiredException("1", "UI Required Exception"));
+        }
+
+        protected virtual void SetupGetTokenInteractiveWithClaimsSuccess()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.testToken);
+        }
+
+        protected virtual void SetupGetTokenInteractiveWithClaimsReturnsNull()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
+        }
+
+        protected virtual void SetupGetTokenInteractiveWithClaimsThrowsServiceException()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void CachedAuthFlow_No_Account_Results_In_Null_Without_Errors()
         {
             // Setup
-            this.SetupNoCachedAccount();
+            this.SetupCachedAccount(false);
 
             // Act
             IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.mockPca.Object);

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             // Setup
             this.SetupCachedAccount();
-            this.SetupAccountusername();
+            this.SetupAccountUsername();
             var scopes = new[] { "scope" };
 
             this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
@@ -132,7 +132,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             var tokenResult = new TokenResult(new IdentityModel.JsonWebTokens.JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
 
             this.SetupCachedAccount();
-            this.SetupAccountusername();
+            this.SetupAccountUsername();
             this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(tokenResult);
 

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.SetupNoCachedAccount();
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.pca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -111,11 +111,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.SetupAccountusername();
             var scopes = new[] { "scope" };
 
-            this.pca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.account.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ThrowsAsync(new MsalUiRequiredException("1", "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.pca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -133,11 +133,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             this.SetupCachedAccount();
             this.SetupAccountusername();
-            this.pca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.account.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(tokenResult);
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.pca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.SetupNoCachedAccount();
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.pca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -108,13 +108,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             // Setup
             this.SetupCachedAccount();
+            this.SetupAccountusername();
             var scopes = new[] { "scope" };
 
-            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.pca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.account.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ThrowsAsync(new MsalUiRequiredException("1", "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.pca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -131,11 +132,12 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             var tokenResult = new TokenResult(new IdentityModel.JsonWebTokens.JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
 
             this.SetupCachedAccount();
-            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.SetupAccountusername();
+            this.pca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.account.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(tokenResult);
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.pca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
     internal class IntegratedWindowsAuthenticationTest : AuthFlowTestBase
     {
-        public AuthFlow.IntegratedWindowsAuthentication Subject() => new AuthFlow.IntegratedWindowsAuthentication(this.logger, ClientId, TenantId, Scopes, pcaWrapper: this.pca.Object);
+        public AuthFlow.IntegratedWindowsAuthentication Subject() => new AuthFlow.IntegratedWindowsAuthentication(this.logger, ClientId, TenantId, Scopes, pcaWrapper: this.mockPca.Object);
 
         [Test]
         public async Task IWA_Success()
@@ -39,7 +39,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void General_Exceptions_Are_ReThrown()
         {
             var message = "Something somwhere has gone terribly wrong!";
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                 .Throws(new Exception(message));
 
@@ -117,35 +117,35 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         private void SetupIWAReturnsResult()
         {
-            this.pca
+            this.mockPca
                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                .ReturnsAsync(this.testToken);
         }
 
         private void SetupIWAReturnsNull()
         {
-            this.pca
+            this.mockPca
                .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                .ReturnsAsync((TokenResult)null);
         }
 
         private void SetupIWAUIRequiredFor2FA()
         {
-            this.pca
+            this.mockPca
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "AADSTS50076 MSAL UI Required Exception!"));
         }
 
         private void IWAServiceException()
         {
-            this.pca
+            this.mockPca
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                 .Throws(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
         private void IWAClientException()
         {
-            this.pca
+            this.mockPca
                 .Setup((pca) => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
                 .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
         }

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             ClientId,
             TenantId,
             Scopes,
-            pcaWrapper: this.pca.Object,
+            pcaWrapper: this.mockPca.Object,
             promptHint: PromptHint);
 
         [Test]
@@ -296,58 +296,58 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         private void SetupInteractiveAuthWithClaimsSuccess()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, Claims, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(this.testToken);
         }
 
         private void SetupInteractiveAuthWithClaimsReturnsNull()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, Claims, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((TokenResult)null);
         }
 
         private void InteractiveAuthTimeout()
         {
-            this.pca
-                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
         }
 
         private void InteractiveAuthExtraClaimsRequired()
         {
-            this.pca
-                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "Extra Claims are required."));
         }
 
         private void InteractiveAuthServiceException()
         {
-            this.pca
-                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
         private void InteractiveAuthWithClaimsServiceException()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Throws(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
         private void InteractiveAuthWithClaimsTimeout()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
         }
 
         private void MockAccount()
         {
-            this.pca
+            this.mockPca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.account.Object);
+                .ReturnsAsync(this.mockAccount.Object);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -4,506 +4,350 @@
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
     using FluentAssertions;
 
     using Microsoft.Authentication.MSALWrapper;
-    using Microsoft.Authentication.MSALWrapper.AuthFlow;
-    using Microsoft.Authentication.TestHelper;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
-    using Microsoft.IdentityModel.JsonWebTokens;
 
     using Moq;
 
-    using NLog.Extensions.Logging;
-    using NLog.Targets;
-
     using NUnit.Framework;
 
-    internal class WebTest
+    internal class WebTest : AuthFlowTestBase
     {
-        private const string MsalServiceExceptionErrorCode = "1";
-        private const string MsalServiceExceptionMessage = "MSAL Service Exception: Something bad has happened!";
-        private const string TestUser = "user@microsoft.com";
-
-        // These Guids were randomly generated and do not refer to a real resource or client
-        // as we don't need either for our testing.
-        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
-        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
-        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
-
-        private string promptHint = "test prompt hint";
-
-        private MemoryTarget logTarget;
-        private ILogger logger;
-
-        // MSAL Specific Mocks
-        private Mock<IPCAWrapper> pcaWrapperMock;
-        private Mock<IAccount> testAccount;
-        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
-        private TokenResult tokenResult;
-
-        [SetUp]
-        public void Setup()
-        {
-            (this.logger, this.logTarget) = MemoryLogger.Create();
-
-            // MSAL Mocks
-            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
-            this.testAccount.Setup(a => a.Username).Returns(TestUser);
-            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
-
-            // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            this.pcaWrapperMock.VerifyAll();
-        }
-
-        public AuthFlow.Web Subject() => new AuthFlow.Web(this.logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
+        public AuthFlow.Web Subject() => new AuthFlow.Web(
+            this.logger,
+            ClientId,
+            TenantId,
+            Scopes,
+            pcaWrapper: this.pca.Object,
+            promptHint: PromptHint);
 
         [Test]
-        public async Task WebAuthFlow_CachedToken()
+        public async Task WebAuthFlow_NoAccount_Success()
         {
-            this.MockAccount();
-            this.SilentAuthResult();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.TokenResult.IsSilent.Should().BeTrue();
-            authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_NoAccount()
-        {
-            this.pcaWrapperMock.Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>())).ReturnsAsync((IAccount)null);
+            this.SetupNoCachedAccount();
             this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
+            this.SetupGetTokenInteractiveSuccess(withAccount: false);
 
             // Act
             AuthFlow.Web deviceCode = this.Subject();
-            var authFlowResult = await deviceCode.GetTokenAsync();
+            var subject = await deviceCode.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.TokenResult.IsSilent.Should().BeFalse();
+            var expected = new AuthFlowResult(this.testToken, Array.Empty<Exception>(), "web");
+            subject.Should().BeEquivalentTo(expected);
+            subject.TokenResult.IsSilent.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task WebAuthFlow_WithAccount_Success()
+        {
+            this.SetupCachedAccount();
+            this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveSuccess(withAccount: true);
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var subject = await web.GetTokenAsync();
+
+            // Assert
+            var expected = new AuthFlowResult(this.testToken, Array.Empty<Exception>(), "web");
+            subject.Should().BeEquivalentTo(expected);
+            subject.TokenResult.IsSilent.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task WebAuthFlow_NoAccount_Null()
+        {
+            this.SetupNoCachedAccount();
+            this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveReturnsNull(withAccount: false);
+
+            // Act
+            AuthFlow.Web web = this.Subject();
+            var authFlowResult = await web.GetTokenAsync();
+
+            // Assert
+            authFlowResult.TokenResult.Should().Be(null);
             authFlowResult.Errors.Should().BeEmpty();
             authFlowResult.AuthFlowName.Should().Be("web");
         }
 
-        [Test]
-        public async Task WebAuthFlow_GetTokenSilent_ReturnsNull()
+        //[Test]
+        //public void WebAuthFlow_General_Exceptions_Are_ReThrown()
+        //{
+        //    var message = "Something somwhere has gone terribly wrong!";
+        //    this.MockAccount();
+        //    this.mockPca
+        //        .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+        //        .Throws(new Exception(message));
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    Func<Task> subject = async () => await web.GetTokenAsync();
+
+        //    // Assert
+        //    subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenSilent_MsalServiceException()
+        //{
+        //    this.SilentAuthServiceException();
+
+        //    this.MockAccount();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert - this method should not throw for known types of excpeptions, instead return null, so
+        //    // our caller can retry auth another way.
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(1);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenSilent_OperationCanceledException()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthTimeout();
+        //    this.SetupWithPromptHint();
+        //    this.SetupWebSuccess();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(this.testToken);
+        //    authFlowResult.Errors.Should().HaveCount(1);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
+        //    authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:30");
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenSilent_MsalClientException()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthClientException();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(1);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenSilent_NullReferenceException()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthNullReferenceException();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(1);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthExtraClaimsRequired();
+        //    this.InteractiveAuthWithClaimsResult();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(this.testToken);
+        //    authFlowResult.TokenResult.IsSilent.Should().BeFalse();
+        //    authFlowResult.Errors.Should().HaveCount(2);
+        //    authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithClaims()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthExtraClaimsRequired();
+        //    this.InteractiveAuthResultReturnsNullWithClaims();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(2);
+        //    authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthExtraClaimsRequired();
+        //    this.InteractiveAuthWithClaimsServiceException();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(3);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthServiceException();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(2);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthTimeout();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(2);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
+        //    authFlowResult.Errors[1].Message.Should().Be("web interactive auth timed out after 00:15:00");
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        //[Test]
+        //public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
+        //{
+        //    this.MockAccount();
+        //    this.SilentAuthUIRequired();
+        //    this.SetupWithPromptHint();
+        //    this.InteractiveAuthExtraClaimsRequired();
+        //    this.InteractiveAuthWithClaimsTimeout();
+
+        //    // Act
+        //    AuthFlow.Web web = this.Subject();
+        //    var authFlowResult = await web.GetTokenAsync();
+
+        //    // Assert
+        //    authFlowResult.TokenResult.Should().Be(null);
+        //    authFlowResult.Errors.Should().HaveCount(3);
+        //    authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
+        //    authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
+        //    authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
+        //    authFlowResult.AuthFlowName.Should().Be("web");
+        //}
+
+        private void SetupInteractiveAuthWithClaimsSuccess()
         {
-            this.MockAccount();
-            this.SilentAuthReturnsNull();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.Errors.Should().BeEmpty();
-            authFlowResult.AuthFlowName.Should().Be("web");
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, Claims, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.testToken);
         }
 
-        [Test]
-        public async Task WebAuthFlow_MsalUIException()
+        private void SetupInteractiveAuthWithClaimsReturnsNull()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.TokenResult.IsSilent.Should().BeFalse();
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithoutClaims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthResultReturnsNullWithoutClaims();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public void WebAuthFlow_General_Exceptions_Are_ReThrown()
-        {
-            var message = "Something somwhere has gone terribly wrong!";
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new Exception(message));
-
-            this.MockAccount();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            Func<Task> subject = async () => await web.GetTokenAsync();
-
-            // Assert
-            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenSilent_MsalServiceException()
-        {
-            this.SilentAuthServiceException();
-
-            this.MockAccount();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert - this method should not throw for known types of excpeptions, instead return null, so
-            // our caller can retry auth another way.
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenSilent_OperationCanceledException()
-        {
-            this.MockAccount();
-            this.SilentAuthTimeout();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:30");
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenSilent_MsalClientException()
-        {
-            this.MockAccount();
-            this.SilentAuthClientException();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalClientException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenSilent_NullReferenceException()
-        {
-            this.MockAccount();
-            this.SilentAuthNullReferenceException();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(1);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsResult();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.TokenResult.IsSilent.Should().BeFalse();
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithClaims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthResultReturnsNullWithClaims();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsServiceException();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(3);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[2].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenInteractive_MsalServiceException()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthServiceException();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthTimeout();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[1].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[1].Message.Should().Be("web interactive auth timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        [Test]
-        public async Task WebAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsTimeout();
-
-            // Act
-            AuthFlow.Web web = this.Subject();
-            var authFlowResult = await web.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(3);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[2].Should().BeOfType(typeof(AuthenticationTimeoutException));
-            authFlowResult.Errors[2].Message.Should().Be("Interactive Auth (with extra claims) timed out after 00:15:00");
-            authFlowResult.AuthFlowName.Should().Be("web");
-        }
-
-        private void SilentAuthResult()
-        {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(this.tokenResult);
-        }
-
-        private void SilentAuthReturnsNull()
-        {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-               .ReturnsAsync((TokenResult)null);
-        }
-
-        private void SilentAuthUIRequired()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, It.IsAny<IAccount>(), It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("1", "UI is required"));
-        }
-
-        private void SilentAuthServiceException()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
-        }
-
-        private void SilentAuthTimeout()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new OperationCanceledException());
-        }
-
-        private void SilentAuthClientException()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
-        }
-
-        private void SilentAuthNullReferenceException()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
-        }
-
-        private void InteractiveAuthResult()
-        {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<IAccount>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(this.tokenResult);
-        }
-
-        private void InteractiveAuthResultReturnsNullWithoutClaims()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((TokenResult)null);
-        }
-
-        private void InteractiveAuthWithClaimsResult()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(this.tokenResult);
-        }
-
-        private void InteractiveAuthResultReturnsNullWithClaims()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, Claims, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((TokenResult)null);
         }
 
         private void InteractiveAuthTimeout()
         {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
         }
 
         private void InteractiveAuthExtraClaimsRequired()
         {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalUiRequiredException("1", "Extra Claims are required."));
         }
 
         private void InteractiveAuthServiceException()
         {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.account.Object, It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
         private void InteractiveAuthWithClaimsServiceException()
         {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
         private void InteractiveAuthWithClaimsTimeout()
         {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            this.pca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
         }
 
         private void MockAccount()
         {
-            this.pcaWrapperMock
+            this.pca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.testAccount.Object);
-        }
-
-        private void SetupWithPromptHint()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.WithPromptHint(It.IsAny<string>()))
-                .Returns((string s) => this.pcaWrapperMock.Object);
+                .ReturnsAsync(this.account.Object);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -71,14 +71,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             this.mockPca
                 .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new ArgumentException(message));
+                .Throws(new Exception(message));
 
             // Act
             AuthFlow.Web web = this.Subject();
             Func<Task> subject = async () => await web.GetTokenAsync();
 
             // Assert
-            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage("foobar");
+            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
         }
 
         //[Test]

--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// The inner method required to be implemented by an AuthFlow.
         /// Performs token acquisition.
         /// </summary>
+        /// <param name="account">The <see cref="IAccount"/> to attempt to use.</param>
         /// <returns>a tuple of <see cref="TokenResult"/> and <see cref="IList{Exception}"/>.</returns>
         protected abstract Task<TokenResult> GetTokenInnerAsync();
 

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -52,19 +52,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()
         {
-            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
-
-            TokenResult tokenResult = await CachedAuth.GetTokenAsync(
-                this.logger,
-                this.scopes,
-                account,
-                this.pcaWrapper,
-                this.errors);
-
-            if (tokenResult != null)
-            {
-                return tokenResult;
-            }
+            var account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
+            TokenResult tokenResult = null;
 
             try
             {
@@ -77,6 +66,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (MsalUiRequiredException ex)
             {
+                // It would be nice to use 'when (!string.IsNullOrEmpty(ex.Claims))' as a catch clause above
+                // but we can't actually create an MsalUiRequiredException with a non-null Claims property.
+                // It's a read only field and so we would not be able to orchestrate this usage under test :(.
                 this.errors.Add(ex);
                 this.logger.LogDebug($"Initial ${this.Name()} auth failed. Trying again with claims.\n{ex.Message}");
 


### PR DESCRIPTION
This removes the `CachedAuth` usage from `Web` and removes all the GetTokenSilent related tests from WebTest.

Most of the setup methods for mocking behavior on a PCA are not specific to Web and are also usable by broker, and device code modes so these are moved to the `AuthFlowTestBase` class.