### PR TITLE
[1/🧹]  Fix async throw assertions

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public void BrokerAuthFlow_General_Exceptions_Are_ReThrown()
+        public async Task BrokerAuthFlow_General_Exceptions_Are_ReThrown()
         {
             var message = "Something somwhere has gone terribly wrong!";
             this.MockAccount();
@@ -156,7 +156,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             Func<Task> subject = async () => await broker.GetTokenAsync();
 
             // Assert
-            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
         }
 
         [Test]

--- a/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/IntegratedWindowsAuthenticationTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public void General_Exceptions_Are_ReThrown()
+        public async Task General_Exceptions_Are_ReThrown()
         {
             var message = "Something somwhere has gone terribly wrong!";
             this.mockPca
@@ -48,7 +48,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             Func<Task> subject = async () => await iwa.GetTokenAsync();
 
             // Assert
-            subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
         }
 
         [Test]


### PR DESCRIPTION
When using `ThrowsExactlyAsync` this is an asynchronous action and it will only be done if you `await` it :).

## Example

Currently we have the following:
```csharp
// This test passes incorrectly.
[Test]
public void General_Exceptions_Are_ReThrown()
{
    var message = "Something somewhere has gone terribly wrong!";
    this.mockPca
        .Setup(pca => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
        .Throws(new Exception(message));

    // Act
    AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
    Func<Task> subject = async () => await iwa.GetTokenAsync();

    // Assert
    subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
}
```

This test _passes_, because it runs without actually making any assertions...

## How do we Know?
Changing the test to the following:
```csharp
// This test passes incorrectly.
[Test]
public void General_Exceptions_Are_ReThrown()
{
    var message = "Something somewhere has gone terribly wrong!";
    this.mockPca
        .Setup(pca => pca.GetTokenIntegratedWindowsAuthenticationAsync(Scopes, It.IsAny<CancellationToken>()))
        .Throws(new Exception(message));

    // Act
    AuthFlow.IntegratedWindowsAuthentication iwa = this.Subject();
    Func<Task> subject = async () => await iwa.GetTokenAsync();

    // Assert
    subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message + "foobar");
}
```
Note the `message + "foobar"` at the end. This test _also passes_ when it clearly should not.

By awaiting the `ThrowExactlyAsync` call, we actually kick off that assertion, it runs asynchronously, and fails, and we get our expected test failure. To `await` that call we change `void` -> `async Task`.