### PR TITLE
[2/🧹] Use abstract Property instead of method for `Name`.

### DIFF
--- a/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowBase.cs
@@ -3,12 +3,12 @@
 
 namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 {
-    using Microsoft.Extensions.Logging;
-    using Microsoft.Identity.Client;
-
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
 
     /// <summary>
     /// An abstract class that implements the <see cref="IAuthFlow"/> interface
@@ -21,7 +21,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
         /// <summary>A <see cref="ILogger"/> to use for logging.</summary>
         protected ILogger logger;
-
         private static readonly HashSet<Type> ExceptionsToCatch = new HashSet<Type>()
         {
             typeof(MsalUiRequiredException),
@@ -30,6 +29,12 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             typeof(MsalException),
             typeof(NullReferenceException),
         };
+
+        /// <summary>
+        /// Gets the name of this AuthFlow.
+        /// </summary>
+        /// <returns>The <see cref="string"/> representation of the authflow name.</returns>
+        protected abstract string Name { get; }
 
         /// <inheritdoc/>
         public async Task<AuthFlowResult> GetTokenAsync()
@@ -43,11 +48,11 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             catch (Exception ex) when (ExceptionsToCatch.Contains(ex.GetType()))
             {
                 this.errors.Add(ex);
-                this.logger.LogDebug($"Exception caught during {this.Name()} token acquisition");
+                this.logger.LogDebug($"Exception caught during {this.Name} token acquisition");
                 this.logger.LogDebug(ex.Message);
             }
 
-            return new AuthFlowResult(result, this.errors, this.Name());
+            return new AuthFlowResult(result, this.errors, this.Name);
         }
 
         /// <summary>
@@ -57,11 +62,5 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="account">The <see cref="IAccount"/> to attempt to use.</param>
         /// <returns>a tuple of <see cref="TokenResult"/> and <see cref="IList{Exception}"/>.</returns>
         protected abstract Task<TokenResult> GetTokenInnerAsync();
-
-        /// <summary>
-        /// The name of this AuthFlow.
-        /// </summary>
-        /// <returns>The <see cref="string"/> representation of the authflow name.</returns>
-        protected abstract string Name();
     }
 }

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class Broker : AuthFlowBase
     {
-        private const string NameValue = "broker";
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
@@ -67,7 +66,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         }
 
         /// <inheritdoc/>
-        protected override string Name() => NameValue;
+        protected override string Name { get; } = "broker";
 
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()
@@ -92,19 +91,19 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 tokenResult = await TaskExecutor.CompleteWithin(
                     this.logger,
                     this.interactiveAuthTimeout,
-                    $"{this.Name()} interactive auth",
+                    $"{this.Name} interactive auth",
                     this.GetTokenInteractive(account),
                     this.errors).ConfigureAwait(false);
             }
             catch (MsalUiRequiredException ex)
             {
                 this.errors.Add(ex);
-                this.logger.LogDebug($"initial {this.Name()} auth failed. Trying again with claims from exception.\n{ex.Message}");
+                this.logger.LogDebug($"initial {this.Name} auth failed. Trying again with claims from exception.\n{ex.Message}");
 
                 tokenResult = await TaskExecutor.CompleteWithin(
                     this.logger,
                     this.interactiveAuthTimeout,
-                    $"{this.Name()} interactive auth (with extra claims)",
+                    $"{this.Name} interactive auth (with extra claims)",
                     this.GetTokenInteractiveWithClaims(ex.Claims),
                     this.errors).ConfigureAwait(false);
             }

--- a/src/MSALWrapper/AuthFlow/CachedAuth.cs
+++ b/src/MSALWrapper/AuthFlow/CachedAuth.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class CachedAuth : AuthFlowBase
     {
-        private const string NameValue = "pca_cache";
         private static readonly TimeSpan CachedAuthTimeout = TimeSpan.FromSeconds(30);
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
@@ -37,6 +36,9 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             this.preferredDomain = preferredDomain;
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(clientId, tenantId);
         }
+
+        /// <inheritdoc/>
+        protected override string Name { get; } = "pca_cache";
 
         /// <summary>
         /// Try to get a token silently.
@@ -77,9 +79,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             return tokenResult;
         }
-
-        /// <inheritdoc/>
-        protected override string Name() => NameValue;
 
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()

--- a/src/MSALWrapper/AuthFlow/DeviceCode.cs
+++ b/src/MSALWrapper/AuthFlow/DeviceCode.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class DeviceCode : AuthFlowBase
     {
-        private const string NameValue = "devicecode";
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
@@ -47,7 +46,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         }
 
         /// <inheritdoc/>
-        protected override string Name() => NameValue;
+        protected override string Name { get; } = "devicecode";
 
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()
@@ -58,7 +57,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             tokenResult = await TaskExecutor.CompleteWithin(
                 this.logger,
                 this.deviceCodeFlowTimeout,
-                $"{this.Name()} interactive auth",
+                $"{this.Name} interactive auth",
                 this.DeviceCodeAuth,
                 this.errors).ConfigureAwait(false);
 

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class IntegratedWindowsAuthentication : AuthFlowBase
     {
-        private const string NameValue = "iwa";
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly IPCAWrapper pcaWrapper;
@@ -44,7 +43,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         }
 
         /// <inheritdoc/>
-        protected override string Name() => NameValue;
+        protected override string Name { get; } = "iwa";
 
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()

--- a/src/MSALWrapper/AuthFlow/Web.cs
+++ b/src/MSALWrapper/AuthFlow/Web.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     /// </summary>
     public class Web : AuthFlowBase
     {
-        private const string NameValue = "web";
         private readonly IEnumerable<string> scopes;
         private readonly string preferredDomain;
         private readonly string promptHint;
@@ -47,7 +46,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         }
 
         /// <inheritdoc/>
-        protected override string Name() => NameValue;
+        protected override string Name { get; } = "web";
 
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()
@@ -60,7 +59,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 tokenResult = await TaskExecutor.CompleteWithin(
                     this.logger,
                     this.interactiveAuthTimeout,
-                    $"{this.Name()} interactive auth",
+                    $"{this.Name} interactive auth",
                     this.GetTokenInteractive(account),
                     this.errors).ConfigureAwait(false);
             }
@@ -70,7 +69,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 // but we can't actually create an MsalUiRequiredException with a non-null Claims property.
                 // It's a read only field and so we would not be able to orchestrate this usage under test :(.
                 this.errors.Add(ex);
-                this.logger.LogDebug($"Initial ${this.Name()} auth failed. Trying again with claims.\n{ex.Message}");
+                this.logger.LogDebug($"Initial ${this.Name} auth failed. Trying again with claims.\n{ex.Message}");
 
                 tokenResult = await TaskExecutor.CompleteWithin(
                     this.logger,


### PR DESCRIPTION
This follows up on a suggestion from @goagain that we could simplify the base class to use a property instead of a method, since the value is all we want, not logic.