### PR TITLE
[3/🧹] Use `AuthParameters` in broker.

### DIFF
--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
         public void NativeBrokerBenchmark()
         {
             var pcaWrapper = BuildPCAWrapper(this.logger, this.clientID, this.tenantID, true);
-            Broker broker = new Broker(this.logger, this.clientID, this.tenantID, this.scopes, pcaWrapper: pcaWrapper);
+            AuthParameters authParameters = new AuthParameters(this.clientID, this.tenantID, this.scopes);
+            Broker broker = new Broker(this.logger, authParameters, pcaWrapper: pcaWrapper);
 
             broker.GetTokenAsync().Wait();
         }
@@ -66,7 +67,8 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
         public void ManagedBrokerBenchmark()
         {
             var pcaWrapper = BuildPCAWrapper(this.logger, this.clientID, this.tenantID, false);
-            Broker broker = new Broker(this.logger, this.clientID, this.tenantID, this.scopes, pcaWrapper: pcaWrapper);
+            AuthParameters authParameters = new AuthParameters(this.clientID, this.tenantID, this.scopes);
+            Broker broker = new Broker(this.logger, authParameters, pcaWrapper: pcaWrapper);
 
             broker.GetTokenAsync().Wait();
         }

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.pcaWrapperMock.VerifyAll();
         }
 
-        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, ClientId, TenantId, this.scopes, pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
+        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, new AuthParameters(ClientId, TenantId, this.scopes), pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
 
         [Test]
         public async Task BrokerAuthFlow_CachedAuth()

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // https://github.com/AzureAD/microsoft-authentication-cli/issues/55
             if (authMode.IsBroker() && platformUtils.IsWindows10Or11())
             {
-                flows.Add(new Broker(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
+                flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
             }
 
             if (authMode.IsWeb())

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -32,19 +32,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Initializes a new instance of the <see cref="Broker"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        /// <param name="clientId">The client id.</param>
-        /// <param name="tenantId">The tenant id.</param>
-        /// <param name="scopes">The scopes.</param>
+        /// <param name="authParameters">The authentication paramaters.</param>
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
-        public Broker(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
+        public Broker(ILogger logger, AuthParameters authParameters, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
         {
             this.logger = logger;
-            this.scopes = scopes;
+            this.scopes = authParameters.Scopes;
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
-            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, clientId, tenantId);
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(logger, authParameters.Client, authParameters.Tenant);
         }
 
         private enum GetAncestorFlags


### PR DESCRIPTION
This continues addressing the data clump of client, tenant, scopes. We made an abstraction for this with `AuthParameters` but didn't finish using it in the places where we pass all 3 of those arguments. 