### PR TITLE
[4/🧹] Use `AuthParameters` in cached auth.

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         protected ILogger logger;
         protected MemoryTarget logTarget;
         protected TokenResult testToken;
+        protected AuthParameters authParameters;
 
         [SetUp]
         public void Setup()
@@ -47,6 +48,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.mockPca = new Mock<IPCAWrapper>(MockBehavior.Strict);
             this.mockAccount = new Mock<IAccount>(MockBehavior.Strict);
             this.testToken = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), CorrelationId);
+            this.authParameters = new AuthParameters(ClientId, TenantId, Scopes);
         }
 
         [TearDown]

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.SetupCachedAccount(false);
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, new[] { "scope" }, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -109,13 +109,12 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // Setup
             this.SetupCachedAccount();
             this.SetupAccountUsername();
-            var scopes = new[] { "scope" };
 
-            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ThrowsAsync(new MsalUiRequiredException("1", "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert
@@ -128,16 +127,15 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void CachedAuthFlow_SuccessfulCachedAuth_IsSilent()
         {
             // Setup
-            var scopes = new[] { "scope" };
             var tokenResult = new TokenResult(new IdentityModel.JsonWebTokens.JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
 
             this.SetupCachedAccount();
             this.SetupAccountUsername();
-            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
+            this.mockPca.Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(tokenResult);
 
             // Act
-            IAuthFlow subject = new CachedAuth(this.logger, ClientId, TenantId, scopes, pcaWrapper: this.mockPca.Object);
+            IAuthFlow subject = new CachedAuth(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object);
             AuthFlowResult result = subject.GetTokenAsync().Result;
 
             // Assert

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -37,10 +37,11 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             // This is a list. The order in which flows get added is very important
             // as it sets the order in which auth flows will be attempted.
-            List<IAuthFlow> flows = new List<IAuthFlow>();
-
-            // We always try cached auth first.
-            flows.Add(new CachedAuth(logger, authParams.Client, authParams.Tenant, authParams.Scopes, preferredDomain, pcaWrapper));
+            List<IAuthFlow> flows = new List<IAuthFlow>
+            {
+                // We always try cached auth first.
+                new CachedAuth(logger, authParams, preferredDomain, pcaWrapper),
+            };
 
             // We try IWA as the first auth flow as it works for any Windows version
             // and tries to auth silently.

--- a/src/MSALWrapper/AuthFlow/CachedAuth.cs
+++ b/src/MSALWrapper/AuthFlow/CachedAuth.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Initializes a new instance of the <see cref="CachedAuth"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        /// <param name="authParameters">The authenticaation paramaters.</param>
+        /// <param name="authParameters">The authentication paramaters.</param>
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
         public CachedAuth(ILogger logger, AuthParameters authParameters, string preferredDomain = null, IPCAWrapper pcaWrapper = null)

--- a/src/MSALWrapper/AuthFlow/CachedAuth.cs
+++ b/src/MSALWrapper/AuthFlow/CachedAuth.cs
@@ -24,17 +24,15 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// Initializes a new instance of the <see cref="CachedAuth"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        /// <param name="clientId">The client id.</param>
-        /// <param name="tenantId">The tenant id.</param>
-        /// <param name="scopes">The scopes.</param>
+        /// <param name="authParameters">The authenticaation paramaters.</param>
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
-        public CachedAuth(ILogger logger, Guid clientId, Guid tenantId, IEnumerable<string> scopes, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
+        public CachedAuth(ILogger logger, AuthParameters authParameters, string preferredDomain = null, IPCAWrapper pcaWrapper = null)
         {
             this.logger = logger;
-            this.scopes = scopes;
+            this.scopes = authParameters.Scopes;
             this.preferredDomain = preferredDomain;
-            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(clientId, tenantId);
+            this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(authParameters.Client, authParameters.Tenant);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Address the auth params data clump in `CachedAuth`.