### PR TITLE
[7/🧹] Align `CachedAuthTest` with `AuthFlowTestBase`

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         protected const string PromptHint = "test prompt hint";
         protected const string MsalExceptionErrorCode = "1";
         protected const string MsalExceptionMessage = "MSAL Exception";
+        protected const string GeneralExceptionMessage = "General Exception";
         protected const string Claims = "claims";
 
         // These Guids were randomly generated and do not refer to a real resources
@@ -95,7 +96,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.mockPca
                 .Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new MsalUiRequiredException("1", "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
+                .ThrowsAsync(new MsalUiRequiredException(MsalExceptionErrorCode, "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
         }
 
         protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount)
@@ -116,7 +117,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new MsalUiRequiredException("1", "UI Required Exception"));
+                .ThrowsAsync(new MsalUiRequiredException(MsalExceptionErrorCode, "UI Required Exception"));
         }
 
         protected virtual void SetupGetTokenInteractiveMsalServiceException(bool withAccount)
@@ -135,10 +136,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
         protected virtual void SetupGetTokenInteractiveGeneralException()
         {
-            var message = "very bad";
             this.mockPca
                 .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new Exception(message));
+                .Throws(new Exception(GeneralExceptionMessage));
         }
 
         protected virtual void SetupGetTokenInteractiveWithClaimsSuccess()

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -77,6 +77,27 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Returns((string s) => this.mockPca.Object);
         }
 
+        protected virtual void SetupGetTokenSilentSuccess()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.testToken);
+        }
+
+        protected virtual void SetupGetTokenSilentReturnsNull()
+        {
+            this.mockPca
+               .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((TokenResult)null);
+        }
+
+        protected virtual void SetupGetTokenSilentThrowsMsalUiRequiredException()
+        {
+            this.mockPca
+                .Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new MsalUiRequiredException("1", "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
+        }
+
         protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount)
         {
             this.mockPca
@@ -110,6 +131,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             this.mockPca
                 .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException());
+        }
+
+        protected virtual void SetupGetTokenInteractiveGeneralException()
+        {
+            var message = "very bad";
+            this.mockPca
+                .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new Exception(message));
         }
 
         protected virtual void SetupGetTokenInteractiveWithClaimsSuccess()

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void MsalUiRequiredException_Results_In_Null_With_Error()
         {
             // Setup
-            this.SetupCachedAccount();
             this.SetupAccountUsername();
             this.SetupGetTokenSilentThrowsMsalUiRequiredException();
 

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             Func<Task> subject = async () => await web.GetTokenAsync();
 
             // Assert
-            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(GeneralExceptionMessage);
         }
 
         [TestCase(true)]

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -64,13 +64,9 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public async Task General_Exceptions_Are_Thrown()
         {
-            var message = "Something somwhere has gone terribly wrong!";
             this.SetupCachedAccount(true);
             this.SetupWithPromptHint();
-
-            this.mockPca
-                .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new Exception(message));
+            this.SetupGetTokenInteractiveGeneralException();
 
             // Act
             AuthFlow.Web web = this.Subject();


### PR DESCRIPTION
There are some setup methods that are actually common to cached auth and broker auth tests. This PR moves those methods for mocking GetTokenSilent into the base class for re-use in the next PR in the broker test (which doesn't yet inherit from `AuthFlowTestBase` and will be able to re-use all the existing setup methods there already).

There's one method from Web that will also be shared, so it's also moved.