### PR TITLE
[8/🧹] Align `BrokerTest` with `AuthFlowTestBase`

### DIFF
--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowTestBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.mockPca
                 .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(exists ? this.mockAccount.Object : (IAccount)null);
+                .ReturnsAsync(exists ? this.mockAccount.Object : null);
         }
 
         protected virtual void SetupAccountUsername()
@@ -92,11 +92,18 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                .ReturnsAsync((TokenResult)null);
         }
 
-        protected virtual void SetupGetTokenSilentThrowsMsalUiRequiredException()
+        protected virtual void SetupGetTokenSilentMsalUiRequiredException()
         {
             this.mockPca
                 .Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new MsalUiRequiredException(MsalExceptionErrorCode, "2fa is required", new Exception("inner 2fa exception"), UiRequiredExceptionClassification.AcquireTokenSilentFailed));
+        }
+
+        protected virtual void SetupGetTokenSilentTimeout()
+        {
+            this.mockPca
+                .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
         }
 
         protected virtual void SetupGetTokenInteractiveSuccess(bool withAccount)
@@ -113,10 +120,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .ReturnsAsync((TokenResult)null);
         }
 
-        protected virtual void SetupGetTokenInteractiveMsalUiRequiredException(bool withAccount)
+        protected virtual void SetupGetTokenInteractiveMsalUiRequiredException(IAccount account)
         {
             this.mockPca
-                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, account, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new MsalUiRequiredException(MsalExceptionErrorCode, "UI Required Exception"));
         }
 
@@ -134,10 +141,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .ThrowsAsync(new OperationCanceledException());
         }
 
-        protected virtual void SetupGetTokenInteractiveGeneralException()
+        protected virtual void SetupGetTokenInteractiveGeneralException(bool withAccount)
         {
             this.mockPca
-                .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .Setup((pca) => pca.GetTokenInteractiveAsync(Scopes, withAccount ? this.mockAccount.Object : null, It.IsAny<CancellationToken>()))
                 .Throws(new Exception(GeneralExceptionMessage));
         }
 

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -22,101 +22,61 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
     using NUnit.Framework;
 
-    public class BrokerTest
+    internal class BrokerTest : AuthFlowTestBase
     {
-        private const string MsalServiceExceptionErrorCode = "1";
-        private const string MsalServiceExceptionMessage = "MSAL Service Exception: Something bad has happened!";
-        private const string TestUser = "user@microsoft.com";
-
-        // These Guids were randomly generated and do not refer to a real resource or client
-        // as we don't need either for our testing.
-        private static readonly Guid ResourceId = new Guid("6e979987-a7c8-4604-9b37-e51f06f08f1a");
-        private static readonly Guid ClientId = new Guid("5af6def2-05ec-4cab-b9aa-323d75b5df40");
-        private static readonly Guid TenantId = new Guid("8254f6f7-a09f-4752-8bd6-391adc3b912e");
-
-        private string promptHint = "test prompt hint";
-
-        private MemoryTarget logTarget;
-        private ILogger logger;
-
-        // MSAL Specific Mocks
-        private Mock<IPCAWrapper> pcaWrapperMock;
-        private Mock<IAccount> testAccount;
-        private IEnumerable<string> scopes = new string[] { $"{ResourceId}/.default" };
-        private TokenResult tokenResult;
-
-        [SetUp]
-        public void Setup()
-        {
-            (this.logger, this.logTarget) = MemoryLogger.Create();
-
-            // MSAL Mocks
-            this.testAccount = new Mock<IAccount>(MockBehavior.Strict);
-            this.testAccount.Setup(a => a.Username).Returns(TestUser);
-
-            this.pcaWrapperMock = new Mock<IPCAWrapper>(MockBehavior.Strict);
-
-            // Mock successful token result
-            this.tokenResult = new TokenResult(new JsonWebToken(TokenResultTest.FakeToken), Guid.NewGuid());
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            this.pcaWrapperMock.VerifyAll();
-        }
-
-        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, new AuthParameters(ClientId, TenantId, this.scopes), pcaWrapper: this.pcaWrapperMock.Object, promptHint: this.promptHint);
+        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object, promptHint: PromptHint);
 
         [Test]
-        public async Task BrokerAuthFlow_CachedAuth()
+        public async Task GetTokenSilent_Success()
         {
-            this.MockAccount();
-            this.SilentAuthResult();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentSuccess();
 
             // Act
-            AuthFlow.Broker broker = this.Subject();
-            var authFlowResult = await broker.GetTokenAsync();
+            AuthFlowResult authFlowResult = await this.Subject().GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.Should().Be(this.testToken);
             authFlowResult.TokenResult.IsSilent.Should().BeTrue();
             authFlowResult.Errors.Should().BeEmpty();
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenSilent_ReturnsNull()
+        public async Task GetTokenSilent_ReturnsNull_GetTokeninteractive_Success()
         {
-            this.MockAccount();
-            this.SilentAuthReturnsNull();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentReturnsNull();
             this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
+            this.SetupGetTokenInteractiveSuccess(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.Should().Be(this.testToken);
             authFlowResult.Errors.Should().BeEmpty();
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
-        public async Task BrokerAuthFlow_MsalUIException()
+        public async Task GetTokenSilent_Throws_GetTokenInteractive_Success()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
             this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
+            this.SetupGetTokenInteractiveSuccess(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.Should().Be(this.testToken);
             authFlowResult.TokenResult.IsSilent.Should().BeFalse();
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
@@ -124,46 +84,56 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithoutClaims()
+        public async Task NoAccount_GetTokenInteractive_RetriesWithClaims_Success()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount(false);
+
+            // No account username mock because the account will be the built in OS account
+            // which has a null username.
+
+            // special mock for OS account
+            this.mockPca
+                .Setup(pca => pca.GetTokenSilentAsync(Scopes, PublicClientApplication.OperatingSystemAccount, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TokenResult)null);
+
             this.SetupWithPromptHint();
-            this.InteractiveAuthResultReturnsNullWithoutClaims();
+            this.SetupGetTokenInteractiveMsalUiRequiredException(PublicClientApplication.OperatingSystemAccount);
+            this.SetupGetTokenInteractiveWithClaimsSuccess();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.TokenResult.Should().Be(this.testToken);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
-        public async Task BrokerAuthFlow_General_Exceptions_Are_ReThrown()
+        public async Task General_Exceptions_Are_ReThrown()
         {
-            var message = "Something somwhere has gone terribly wrong!";
-            this.MockAccount();
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new Exception(message));
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
+            this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveGeneralException(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             Func<Task> subject = async () => await broker.GetTokenAsync();
 
             // Assert
-            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(message);
+            await subject.Should().ThrowExactlyAsync<Exception>().WithMessage(GeneralExceptionMessage);
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenSilent_MsalServiceException()
+        public async Task GetTokenSilent_MsalServiceException()
         {
-            this.MockAccount();
-            this.SilentAuthServiceException();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalServiceException();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
@@ -177,19 +147,20 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenSilent_OperationCanceledException_ThenSucceeds()
+        public async Task GetTokenSilent_Timeout_GetTokenInteractive_Success()
         {
-            this.MockAccount();
-            this.SilentAuthTimeout();
-            this.InteractiveAuthResult();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentTimeout();
             this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveSuccess(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
+            authFlowResult.TokenResult.Should().Be(this.testToken);
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(AuthenticationTimeoutException));
             authFlowResult.Errors[0].Message.Should().Be("Get Token Silent timed out after 00:00:30");
@@ -197,10 +168,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenSilent_MsalClientException()
+        public async Task GetTokenSilent_MsalClientException()
         {
-            this.MockAccount();
-            this.SilentAuthClientException();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalClientException();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
@@ -214,78 +186,39 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenSilent_NullReferenceException()
+        public async Task GetTokenSilent_NullReferenceException()
         {
-            this.MockAccount();
-            this.SilentAuthNullReferenceException();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentSilentNullReferenceException();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.TokenResult.Should().BeNull();
             authFlowResult.Errors.Should().HaveCount(1);
             authFlowResult.Errors[0].Should().BeOfType(typeof(NullReferenceException));
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractive_MsalUIException_For_Claims()
+        public async Task GetTokenInteractiveWithClaims_MsalException()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
+            this.SetupGetTokenInteractiveMsalUiRequiredException(this.mockAccount.Object);
             this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsResult();
+            this.SetupGetTokenInteractiveWithClaimsThrowsServiceException();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(this.tokenResult);
-            authFlowResult.TokenResult.IsSilent.Should().BeFalse();
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("broker");
-        }
-
-        [Test]
-        public async Task BrokerAuthFlow_MsalUIException_InteractiveAuthResultReturnsNullWithClaims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthResultReturnsNullWithClaims();
-
-            // Act
-            AuthFlow.Broker broker = this.Subject();
-            var authFlowResult = await broker.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
-            authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.AuthFlowName.Should().Be("broker");
-        }
-
-        [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractive_MsalServiceException_After_Using_Claims()
-        {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
-            this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsServiceException();
-
-            // Act
-            AuthFlow.Broker broker = this.Subject();
-            var authFlowResult = await broker.GetTokenAsync();
-
-            // Assert
-            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.TokenResult.Should().BeNull();
             authFlowResult.Errors.Should().HaveCount(3);
             authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
             authFlowResult.Errors[1].Should().BeOfType(typeof(MsalUiRequiredException));
@@ -294,32 +227,34 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractive_MsalServiceException()
+        public async Task GetTokenInteractiveWithClaims_ReturnsNull()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
             this.SetupWithPromptHint();
-            this.InteractiveAuthServiceException();
+            this.SetupGetTokenInteractiveMsalUiRequiredException(this.mockAccount.Object);
+            this.SetupGetTokenInteractiveWithClaimsReturnsNull();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             var authFlowResult = await broker.GetTokenAsync();
 
             // Assert
-            authFlowResult.TokenResult.Should().Be(null);
+            authFlowResult.TokenResult.Should().BeNull();
             authFlowResult.Errors.Should().HaveCount(2);
-            authFlowResult.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
-            authFlowResult.Errors[1].Should().BeOfType(typeof(MsalServiceException));
+            authFlowResult.Errors.Should().AllBeOfType(typeof(MsalUiRequiredException));
             authFlowResult.AuthFlowName.Should().Be("broker");
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractive_OperationCanceledException()
+        public async Task GetTokenInteractive_Timeout()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
             this.SetupWithPromptHint();
-            this.InteractiveAuthTimeout();
+            this.SetupGetTokenInteractiveTimeout(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
@@ -335,13 +270,14 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractive_OperationCanceledException_For_Claims()
+        public async Task GetTokenInteractiveWithClaims_Timeout()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
             this.SetupWithPromptHint();
-            this.InteractiveAuthExtraClaimsRequired();
-            this.InteractiveAuthWithClaimsTimeout();
+            this.SetupGetTokenInteractiveMsalUiRequiredException(this.mockAccount.Object);
+            this.SetupGetTokenInteractiveWithClaimsTimeout();
 
             // Act
             AuthFlow.Broker broker = this.Subject();
@@ -358,145 +294,42 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         }
 
         [Test]
-        public async Task BrokerAuthFlow_GetTokenInteractiveAsync_Calls_WithPromptHint()
+        public async Task GetTokenInteractiveAsync_Calls_WithPromptHint()
         {
-            this.MockAccount();
-            this.SilentAuthUIRequired();
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentMsalUiRequiredException();
             this.SetupWithPromptHint();
-            this.InteractiveAuthResult();
+            this.SetupGetTokenInteractiveSuccess(withAccount: true);
 
             // Act
             AuthFlow.Broker broker = this.Subject();
             await broker.GetTokenAsync();
 
-            // Verify
-            this.pcaWrapperMock.VerifyAll();
+            // Assert
+            // yes the inherited TearDown does this, but we do it here since it's the explicit assertion for this test
+            this.mockPca.VerifyAll();
         }
 
-        private void SilentAuthResult()
+        private void SetupGetTokenSilentMsalServiceException()
         {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(this.tokenResult);
+            this.mockPca
+                .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new MsalServiceException(MsalExceptionErrorCode, MsalExceptionMessage));
         }
 
-        private void SilentAuthReturnsNull()
+        private void SetupGetTokenSilentMsalClientException()
         {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-               .ReturnsAsync((TokenResult)null);
-        }
-
-        private void SilentAuthUIRequired()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("1", "UI is required"));
-        }
-
-        private void SilentAuthServiceException()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
-        }
-
-        private void SilentAuthTimeout()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new OperationCanceledException());
-        }
-
-        private void SilentAuthClientException()
-        {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new MsalClientException("1", "Could not find a WAM account for the silent request."));
         }
 
-        private void SilentAuthNullReferenceException()
+        private void SetupGetTokenSilentSilentNullReferenceException()
         {
-            this.pcaWrapperMock
-                .Setup((pca) => pca.GetTokenSilentAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
+            this.mockPca
+                .Setup((pca) => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
                 .Throws(new NullReferenceException("There was a null reference excpetion. This should absolutly never happen and if it does it is a bug."));
-        }
-
-        private void InteractiveAuthResult()
-        {
-            this.pcaWrapperMock
-               .Setup((pca) => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-               .ReturnsAsync(this.tokenResult);
-        }
-
-        private void InteractiveAuthResultReturnsNullWithoutClaims()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((TokenResult)null);
-        }
-
-        private void InteractiveAuthWithClaimsResult()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(this.tokenResult);
-        }
-
-        private void InteractiveAuthResultReturnsNullWithClaims()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((TokenResult)null);
-        }
-
-        private void InteractiveAuthTimeout()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new OperationCanceledException());
-        }
-
-        private void InteractiveAuthExtraClaimsRequired()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalUiRequiredException("1", "Extra Claims are required."));
-        }
-
-        private void InteractiveAuthServiceException()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, this.testAccount.Object, It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
-        }
-
-        private void InteractiveAuthWithClaimsServiceException()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Throws(new MsalServiceException(MsalServiceExceptionErrorCode, MsalServiceExceptionMessage));
-        }
-
-        private void InteractiveAuthWithClaimsTimeout()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.GetTokenInteractiveAsync(this.scopes, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Throws(new OperationCanceledException());
-        }
-
-        private void MockAccount()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
-                .ReturnsAsync(this.testAccount.Object);
-        }
-
-        private void SetupWithPromptHint()
-        {
-            this.pcaWrapperMock
-                .Setup(pca => pca.WithPromptHint(It.IsAny<string>()))
-                .Returns((string s) => this.pcaWrapperMock.Object);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/CachedAuthTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             // Setup
             this.SetupAccountUsername();
-            this.SetupGetTokenSilentThrowsMsalUiRequiredException();
+            this.SetupGetTokenSilentMsalUiRequiredException();
 
             IList<Exception> errors = new List<Exception>();
 
@@ -97,7 +97,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             // Setup
             this.SetupCachedAccount();
             this.SetupAccountUsername();
-            this.SetupGetTokenSilentThrowsMsalUiRequiredException();
+            this.SetupGetTokenSilentMsalUiRequiredException();
 
             // Act
             AuthFlowResult result = this.Subject().GetTokenAsync().Result;

--- a/src/MSALWrapper.Test/AuthFlow/WebTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/WebTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.SetupCachedAccount(true);
             this.SetupWithPromptHint();
-            this.SetupGetTokenInteractiveGeneralException();
+            this.SetupGetTokenInteractiveGeneralException(withAccount: true);
 
             // Act
             AuthFlow.Web web = this.Subject();
@@ -82,7 +82,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.SetupCachedAccount(withAccount);
             this.SetupWithPromptHint();
-            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount);
+            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount ? this.mockAccount.Object : null);
             this.SetupGetTokenInteractiveWithClaimsSuccess();
 
             // Act
@@ -103,7 +103,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.SetupCachedAccount(withAccount);
             this.SetupWithPromptHint();
-            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount);
+            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount ? this.mockAccount.Object : null);
             this.SetupGetTokenInteractiveWithClaimsReturnsNull();
 
             // Act
@@ -123,7 +123,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.SetupCachedAccount(withAccount);
             this.SetupWithPromptHint();
-            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount);
+            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount ? this.mockAccount.Object : null);
             this.SetupGetTokenInteractiveWithClaimsThrowsServiceException();
 
             // Act
@@ -183,7 +183,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.SetupCachedAccount(withAccount);
             this.SetupWithPromptHint();
-            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount);
+            this.SetupGetTokenInteractiveMsalUiRequiredException(withAccount ? this.mockAccount.Object : null);
             this.SetupGetTokenInteractiveWithClaimsTimeout();
 
             // Act


### PR DESCRIPTION
This removes many of the setup method on `BrokerTest` and setup constants and uses the ones defined on the `AuthFlowTestBase` instead.