### PR TITLE
Update dev scripts to call azureauth >= 0.8.0

### DIFF
--- a/bin/mac/dotnet
+++ b/bin/mac/dotnet
@@ -2,5 +2,5 @@
 
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-export ADO_TOKEN=$(azureauth --prompt-hint "azureauth dev nuget" --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token)
+export ADO_TOKEN=$(azureauth ado token --prompt-hint "azureauth dev nuget" --output token)
 dotnet $*

--- a/bin/win/dotnet.cmd
+++ b/bin/win/dotnet.cmd
@@ -1,7 +1,7 @@
 @ECHO OFF
 
 rem This is a workaround for setting the ADO_TOKEN environment variable to the output of azureauth
-FOR /F "tokens=* USEBACKQ" %%F IN (`azureauth --prompt-hint "azureauth dev nuget" --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 --scope 499b84ac-1321-427f-aa17-267ca6975798/.default --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --output token`) DO (
+FOR /F "tokens=* USEBACKQ" %%F IN (`azureauth ado token --prompt-hint "azureauth dev nuget" --output token`) DO (
 SET ADO_TOKEN=%%F
 )
 dotnet %*


### PR DESCRIPTION
This is a small change that assumes AzureAuth developers locally, have installed at least `azureauth >= 0.8.0` for use in the dev scripts, which can now use `azureauth ado token`!