### PR TITLE
Upgrade Lasso to 2023.5.11.1

### DIFF
--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.4.21.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.5.11.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The latest Lasso will not generate log files in sub-process for async telemetry mode.
It will mitigate the number of files in temp folder (which has a maximum at 65535 on DotNet 7.0 and lower).

https://learn.microsoft.com/en-us/dotnet/api/system.io.path.gettempfilename?view=net-7.0#:~:text=On%20.NET%207,any%20operating%20system.