### PR TITLE
Update release workflow to release Linux binaries.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,38 @@ jobs:
           name: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
           path: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
 
+  # Build and sign Linux binaries on Azure DevOps and publish them to GitHub and packages.microsoft.com.
+  linux_release:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    env:
+      ADO_LINUX_ARTIFACT_DOWNLOAD_PATH: dist/linux-x64
+      ADO_LINUX_ARTIFACT_NAME: ${{ secrets.ADO_LINUX_ARTIFACT_NAME }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Build, Sign and Download Linux Binaries
+      run: |
+        pip install -r bin/requirements.txt
+        python ./bin/trigger_azure_pipelines.py
+      env:
+        AZURE_DEVOPS_BUILD_PAT: ${{ secrets.AZURE_DEVOPS_BUILD_PAT }}
+        ADO_ORGANIZATION: ${{ secrets.ADO_ORGANIZATION }}
+        ADO_PROJECT: ${{ secrets.ADO_PROJECT}}
+        ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
+        VERSION: ${{ github.event.inputs.version }}
+    - name: Upload ubuntu-amd64 artifact
+      uses: actions/upload-artifact@v3
+      env:
+        DEBIAN_REVISION: 1
+      with:
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+        
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
     runs-on: ubuntu-latest
@@ -189,13 +221,15 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [package]
+    needs: [package, linux_release]
     # The 'release' environment is what requires reviews before creating the release.
     environment:
       name: release
     # These permissions are required in order to use `softprops/action-gh-release` to upload.
     permissions:
       contents: write
+    env:
+      DEBIAN_REVISION: 1
     steps:
     - name: Download win10-x64 artifact
       uses: actions/download-artifact@v3
@@ -209,6 +243,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
+    - name: Download ubuntu-amd64 artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -220,3 +258,4 @@ jobs:
           azureauth-${{ github.event.inputs.version }}-win10-x64.zip
           azureauth-${{ github.event.inputs.version }}-osx-x64.tar.gz
           azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
+          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,8 @@ jobs:
     strategy:
       matrix:
         # We build on Linux, but don't yet ship Linux because we can't easily sign those releases.
-        runtime: [linux-x64, osx-x64, osx-arm64, win10-x64]
+        runtime: [osx-x64, osx-arm64, win10-x64]
         include:
-          - runtime: linux-x64
-            os: ubuntu-latest
           - runtime: osx-x64
             os: macos-latest
           - runtime: osx-arm64


### PR DESCRIPTION
In #211 we created a workflow to enable Linux release, but there was a bug in ADO side and we reverted it in #226.

Now the bug in ADO has been fixed, and we want to enable it again.