### PR TITLE
Add scopes validation

### DIFF
--- a/src/AdoPat.Test/PatManagerTest.cs
+++ b/src/AdoPat.Test/PatManagerTest.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.AdoPat.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -47,7 +48,7 @@ namespace Microsoft.Authentication.AdoPat.Test
         {
             DisplayName = DisplayName,
             Organization = Organization,
-            Scopes = new string[] { Scope },
+            Scopes = ImmutableSortedSet.CreateRange<string>(new[] { Scope }),
         };
 
         [SetUp]

--- a/src/AdoPat.Test/PatOptionsTest.cs
+++ b/src/AdoPat.Test/PatOptionsTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Authentication.AdoPat.Test
 {
+    using System.Collections.Immutable;
     using FluentAssertions;
     using NUnit.Framework;
 
@@ -20,33 +21,11 @@ namespace Microsoft.Authentication.AdoPat.Test
             {
                 Organization = Organization,
                 DisplayName = DisplayName,
-                Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
+                Scopes = ImmutableSortedSet.CreateRange<string>(new[] { "test.scope.a", "test.scope.b", "test.scope.c" }),
             };
             var expected = $"{OrganizationHash}-{DisplayNameHash}-eb52c21ad04b684f72bb1cef51e7f4ca58ce5a753744123a5df8f4e1781f831d";
 
             patOptions.CacheKey().Should().Be(expected);
-        }
-
-        [Test]
-        public void CacheKey_Scope_Order_Is_Deterministic()
-        {
-            // These two PAT options have the same organization, display name,
-            // and scopes, but the scopes are in different orders. They should
-            // still be considered to have the same PAT cache key.
-            var patOptions1 = new PatOptions
-            {
-                Organization = Organization,
-                DisplayName = DisplayName,
-                Scopes = new[] { "test.scope.a", "test.scope.b", "test.scope.c" },
-            };
-            var patOptions2 = new PatOptions
-            {
-                Organization = Organization,
-                DisplayName = DisplayName,
-                Scopes = new[] { "test.scope.b", "test.scope.a", "test.scope.c" },
-            };
-
-            patOptions1.CacheKey().Should().Be(patOptions2.CacheKey());
         }
     }
 }

--- a/src/AdoPat.Test/ScopesTest.cs
+++ b/src/AdoPat.Test/ScopesTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class ScopesTest
+    {
+        private static HashSet<string> validScopes = Scopes.ValidScopes;
+
+        [Test, TestCaseSource(nameof(validScopes))]
+        public void Valid_Scopes_Are_Valid(string scope)
+        {
+            var expected = ImmutableHashSet.Create<string>();
+            Scopes.Validate(new[] { scope }).Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void Invalid_Scopes_Are_Invalid()
+        {
+            var scopes = new[] { "vso.invalid_scope", "VSO.INVALID_SCOPE" };
+            var expected = ImmutableHashSet.CreateRange<string>(scopes);
+            Scopes.Validate(scopes).Should().BeEquivalentTo(expected);
+        }
+
+        public void Only_Invalid_Scopes_Are_Invalid()
+        {
+            var invalidScope = "vso.invalid_scope";
+            var scopes = new[] { "vso.packaging", invalidScope };
+            var expected = ImmutableHashSet.CreateRange<string>(new[] { invalidScope });
+            Scopes.Validate(scopes).Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void Normalization_Ignores_Case()
+        {
+            var given = new[] { "FOO", "BAR" };
+            var expected = ImmutableSortedSet.CreateRange<string>(new[] { "foo", "bar" });
+            var actual = Scopes.Normalize(given);
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void Normalization_Removes_Duplicates()
+        {
+            var given = new[] { "foo", "foo" };
+            var expected = ImmutableSortedSet.CreateRange<string>(new[] { "foo" });
+            var actual = Scopes.Normalize(given);
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/AdoPat.Test/ScopesTest.cs
+++ b/src/AdoPat.Test/ScopesTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Authentication.AdoPat.Test
 
     public class ScopesTest
     {
-        private static HashSet<string> validScopes = Scopes.ValidScopes;
+        private static ImmutableHashSet<string> validScopes = Scopes.ValidScopes;
 
         [Test, TestCaseSource(nameof(validScopes))]
         public void Valid_Scopes_Are_Valid(string scope)

--- a/src/AdoPat/Constants.cs
+++ b/src/AdoPat/Constants.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    /// <summary>Azure DevOps PAT constant values.</summary>
+    public static class Constants
+    {
+        /// <summary>A link to the canonical list of Azure DevOps PAT scopes.</summary>
+        public static readonly string PatListURL = "https://aka.ms/azure-devops-pat-scopes";
+    }
+}

--- a/src/AdoPat/PatOptions.cs
+++ b/src/AdoPat/PatOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Authentication.AdoPat
         /// <summary>
         /// Gets the PAT scopes.
         /// </summary>
-        public string[] Scopes { get; init; } = default;
+        public ImmutableSortedSet<string> Scopes { get; init; } = default;
 
         /// <summary>
         /// Gets the string used as a cache key which corresponds to these options.
@@ -38,7 +38,7 @@ namespace Microsoft.Authentication.AdoPat
         {
             // We concatenate scopes with the empty string after sorting and
             // deduplicating them to ensure the cache key is always the same.
-            var sortedScopes = string.Concat(this.Scopes.ToImmutableSortedSet());
+            var sortedScopes = string.Concat(this.Scopes);
 
             using (SHA256 sha256 = SHA256.Create())
             {

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Authentication.AdoPat
     public static class Scopes
     {
         // These scopes should be kept up-to-date with https://aka.ms/azure-devops-pat-scopes.
-        public static HashSet<string> ValidScopes = new HashSet<string>
-        {
+        public static ImmutableHashSet<string> ValidScopes = ImmutableHashSet.CreateRange<string>(new[] {
             // Agent Pools
             "vso.agentpools",
             "vso.agentpools_manage",
@@ -137,7 +136,7 @@ namespace Microsoft.Authentication.AdoPat
             "vso.work",
             "vso.work_write",
             "vso.work_full",
-        };
+        });
 
         /// <summary>Validate the given scopes.</summary>
         /// <param name="scopes">The scopes to validate.</param>
@@ -153,10 +152,7 @@ namespace Microsoft.Authentication.AdoPat
         /// <returns>Normalized scopes in sorted order. This might be the empty set.</returns>
         public static ImmutableSortedSet<string> Normalize(IEnumerable<string> scopes)
         {
-            var scopesCount = scopes?.Count() ?? 0;
-            return (scopesCount == 0) ?
-                ImmutableSortedSet.Create<string>() :
-                scopes.Select(scope => scope.ToLower()).ToImmutableSortedSet();
+            return (scopes ?? Enumerable.Empty<string>()).Select(scope => scope.ToLower()).ToImmutableSortedSet();
         }
     }
 }

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AdoPat
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    /// <summary>Azure DevOps scopes and utility methods for working with them.</summary>
+    public static class Scopes
+    {
+        // These scopes should be kept up-to-date with https://aka.ms/azure-devops-pat-scopes.
+        public static HashSet<string> ValidScopes = new HashSet<string>
+        {
+            // Agent Pools
+            "vso.agentpools",
+            "vso.agentpools_manage",
+            "vso.environment_manage",
+
+            // Analytics
+            "vso.analytics",
+
+            // Audit Log
+            "vso.auditlog",
+
+            // Build
+            "vso.build",
+            "vso.build_execute",
+
+            // Code
+            "vso.code",
+            "vso.code_write",
+            "vso.code_manage",
+            "vso.code_full",
+            "vso.code_status",
+
+            // Entitlements
+            "vso.entitlements",
+            "vso.memberentitlementmanagement",
+            "vso.memberentitlementmanagement_write",
+
+            // Extensions
+            "vso.extension",
+            "vso.extension_manage",
+            "vso.extension.data",
+            "vso.extension.data_write",
+
+            // Graph & Identity
+            "vso.graph",
+            "vso.graph_manage",
+            "vso.identity",
+            "vso.identity_manage",
+
+            // Load Test
+            "vso.loadtest",
+            "vso.loadtest_write",
+
+            // Machine Group
+            "vso.machinegroup_manage",
+
+            // Marketplace
+            "vso.gallery",
+            "vso.gallery_acquire",
+            "vso.gallery_publish",
+            "vso.gallery_manage",
+
+            // Notifications
+            "vso.notification",
+            "vso.notification_write",
+            "vso.notification_manage",
+            "vso.notification_diagnostics",
+
+            // Packaging
+            "vso.packaging",
+            "vso.packaging_write",
+            "vso.packaging_manage",
+
+            // Project and Team
+            "vso.project",
+            "vso.project_write",
+            "vso.project_manage",
+
+            // Release
+            "vso.release",
+            "vso.release_execute",
+            "vso.release_manage",
+
+            // Security
+            "vso.security_manage",
+
+            // Service Connections
+            "vso.serviceendpoint",
+            "vso.serviceendpoint_query",
+            "vso.serviceendpoint_manage",
+
+            // Settings
+            "vso.settings",
+            "vso.settings_write",
+
+            // Symbols
+            "vso.symbols",
+            "vso.symbols_write",
+            "vso.symbols_manage",
+
+            // Task Groups
+            "vso.taskgroups_read",
+            "vso.taskgroups_write",
+            "vso.taskgroups_manage",
+
+            // Team Dashboard
+            "vso.dashboards",
+            "vso.dashboards_manage",
+
+            // Test Management
+            "vso.test",
+            "vso.test_write",
+
+            // Tokens
+            "vso.tokens",
+            "vso.tokenadministration",
+
+            // User Profile
+            "vso.profile",
+            "vso.profile_write",
+
+            // Variable Groups
+            "vso.variablegroups_read",
+            "vso.variablegroups_write",
+            "vso.variablegroups_manage",
+
+            // Wiki
+            "vso.wiki",
+            "vso.wiki_write",
+
+            // Work Items
+            "vso.work",
+            "vso.work_write",
+            "vso.work_full",
+        };
+
+        /// <summary>Validate the given scopes.</summary>
+        /// <param name="scopes">The scopes to validate.</param>
+        /// <returns>The set of invalid scopes present in the given scopes. The
+        /// empty set means no scopes were invalid.</returns>
+        public static ImmutableHashSet<string> Validate(IEnumerable<string> scopes)
+        {
+            return scopes.Except(ValidScopes).ToImmutableHashSet();
+        }
+
+        /// <summary>Normalize scopes by deduplicating and converting to lowercase.</summary>
+        /// <param name="scopes">The scopes to normalize.</param>
+        /// <returns>Normalized scopes in sorted order. This might be the empty set.</returns>
+        public static ImmutableSortedSet<string> Normalize(IEnumerable<string> scopes)
+        {
+            var scopesCount = scopes?.Count() ?? 0;
+            return (scopesCount == 0) ?
+                ImmutableSortedSet.Create<string>() :
+                scopes.Select(scope => scope.ToLower()).ToImmutableSortedSet();
+        }
+    }
+}

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
     using McMaster.Extensions.CommandLineUtils;
 
@@ -72,7 +73,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private string DisplayName { get; set; } = null;
 
         [Option(ScopeOption, ScopeHelp, CommandOptionType.MultipleValue)]
-        private string[] Scopes { get; set; } = null;
+        private IEnumerable<string> RawScopes { get; set; } = null;
 
         [Option(OutputOption, OutputHelp, CommandOptionType.SingleValue)]
         private OutputMode Output { get; set; } = OutputMode.Token;
@@ -88,6 +89,20 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
 
         [Option(CommandAad.TimeoutOption, CommandAad.TimeoutHelpText, CommandOptionType.SingleValue)]
         private double Timeout { get; set; } = CommandAad.GlobalTimeout.TotalMinutes;
+
+        // Scopes are normalized from application start to prevent reparsing.
+        private ImmutableSortedSet<string> _scopes;
+        private ImmutableSortedSet<string> Scopes
+        {
+            get
+            {
+                if (this._scopes is null)
+                {
+                    this._scopes = AdoPat.Scopes.Normalize(this.RawScopes);
+                }
+                return this._scopes;
+            }
+        }
 
         /// <summary>
         /// Executes the command and returns a status code indicating the success or failure of the execution.
@@ -142,12 +157,24 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private bool ValidOptions(ILogger logger)
         {
             bool validOptions = true;
-            int scopesCount = this.Scopes?.Length ?? 0;
 
-            if (scopesCount == 0)
+            if (this.Scopes.IsEmpty)
             {
                 logger.LogError($"The {ScopeOption} field is required.");
                 validOptions = false;
+            }
+            else
+            {
+                var invalidScopes = AdoPat.Scopes.Validate(this.Scopes);
+                if (!invalidScopes.IsEmpty)
+                {
+                    foreach (var scope in invalidScopes)
+                    {
+                        logger.LogError($"{scope} is not a valid Azure DevOps PAT scope.");
+                    }
+                    logger.LogError($"Consult {AdoPat.Constants.PatListURL} for a list of valid scopes.");
+                    validOptions = false;
+                }
             }
 
             if (string.IsNullOrEmpty(this.Organization))


### PR DESCRIPTION
Prior to this PR the `ado pat` subcommand did not validate Azure DevOps PAT scopes, we just accepted any random string you wanted. With this PR that has changed and we will now validate and normalize scopes.

Normalization involves converting to lowercase and removing duplicates. Validation involves comparing those normalized scopes against the known list of [Azure DevOps scopes](https://aka.ms/azure-devops-pat-scopes).

After this change users should see error messages like this when giving invalid scopes.
```
$ azureauth ado pat --prompt-hint='My Application' --organization=Contoso --display-name='Test PAT' --scope=foo --scope=bar --scope=vso.packaging
bar is not a valid Azure DevOps PAT scope.
foo is not a valid Azure DevOps PAT scope.
Consult https://aka.ms/azure-devops-pat-scopes for a list of valid scopes.
```
Notice that `foo` and `bar` above are invalid and thus get error messages, but `vso.packaging` is a valid scope and so is not present in the error output. Additionally, we display an [aka.ms](https://aka.ms) link to the valid scopes for convenience to keep users from having to do too much guess work.