### PR TITLE
Allow pat and token subcommands to use custom tenant

### DIFF
--- a/src/AzureAuth/Ado/AuthParameters.cs
+++ b/src/AzureAuth/Ado/AuthParameters.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.AzureAuth.Ado
+{
+    /// <summary>Azure DevOps-specific authentication parameters.</summary>
+    public static class AuthParameters
+    {
+        /// <summary>Create Azure DevOps-specific authentication parameters.</summary>
+        /// <param name="tenant">The tenant. Defaults to Microsoft.</param>
+        /// <returns>A new instance of the <see cref="MSALWrapper.AuthParameters"/> class.</returns>
+        public static MSALWrapper.AuthParameters AdoParameters(string tenant = Constants.Tenant.Microsoft)
+        {
+            return new MSALWrapper.AuthParameters(
+                Constants.Client.VisualStudio,
+                tenant,
+                new[] { Constants.Scope.AzureDevOpsDefault });
+        }
+    }
+}

--- a/src/AzureAuth/Ado/Constants.cs
+++ b/src/AzureAuth/Ado/Constants.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Authentication.AzureAuth.Ado
         public const string SystemDefinitionId = "SYSTEM_DEFINITIONID";
 
         /// <summary>
-        /// The default auth params for AzureDevops.
-        /// </summary>
-        public static readonly AuthParameters AdoParams = new AuthParameters(Client.VisualStudio, Tenant.Microsoft, new[] { Scope.AzureDevOpsDefault });
-
-        /// <summary>
         /// Azure tenant IDs.
         /// </summary>
         public static class Tenant

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -81,6 +81,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         [Option(CommandAad.PromptHintOption, CommandAad.PromptHintHelpText, CommandOptionType.SingleValue)]
         private string PromptHint { get; set; } = null;
 
+        [Option(CommandAad.TenantOption, Description = "The Azure Tenant ID to use for authentication. Defaults to Microsoft.")]
+        private string Tenant { get; set; } = AzureAuth.Ado.Constants.Tenant.Microsoft;
+
         [Option(CommandAad.ModeOption, CommandAad.AuthModeHelperText, CommandOptionType.MultipleValue)]
         private IEnumerable<AuthMode> AuthModes { get; set; } = new[] { AuthMode.Default };
 
@@ -201,7 +204,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private TokenResult AccessToken(IPublicClientAuth publicClientAuth, CommandExecuteEventData eventData)
         {
             return publicClientAuth.Token(
-                AzureAuth.Ado.Constants.AdoParams,
+                AzureAuth.Ado.AuthParameters.AdoParameters(this.Tenant),
                 this.AuthModes,
                 this.Domain,
                 this.PromptHint,

--- a/src/AzureAuth/Commands/Ado/CommandToken.cs
+++ b/src/AzureAuth/Commands/Ado/CommandToken.cs
@@ -100,7 +100,7 @@ For use by short-lived processes. More info at https://aka.ms/AzureAuth")]
 
             // If no PAT then use AAD AT.
             TokenResult token = publicClientAuth.Token(
-                authParams: AzureAuth.Ado.Constants.AdoParams,
+                AzureAuth.Ado.AuthParameters.AdoParameters(this.Tenant),
                 authModes: this.AuthModes,
                 domain: this.Domain,
                 prompt: this.PromptHint,


### PR DESCRIPTION
Currently neither the `ado pat` nor `ado token` subcommands pass through a custom tenant (although the `ado token` subcommand had the flag for it). This PR addresses that issue for both subcommands.