### PR TITLE
Enable Linux release from ADO.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,4 +252,5 @@ jobs:
           azureauth-${{ github.event.inputs.version }}-win10-x64.zip
           azureauth-${{ github.event.inputs.version }}-osx-x64.tar.gz
           azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
-          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb	
+          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,8 @@ jobs:
     strategy:
       matrix:
         # We build on Linux, but don't yet ship Linux because we can't easily sign those releases.
-        runtime: [linux-x64, osx-x64, osx-arm64, win10-x64]
+        runtime: [osx-x64, osx-arm64, win10-x64]
         include:
-          - runtime: linux-x64
-            os: ubuntu-latest
           - runtime: osx-x64
             os: macos-latest
           - runtime: osx-arm64
@@ -148,6 +146,38 @@ jobs:
           name: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
           path: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
 
+  # Build and sign Linux binaries on Azure DevOps and publish them to GitHub and packages.microsoft.com.
+  linux_release:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    env:
+      ADO_LINUX_ARTIFACT_DOWNLOAD_PATH: dist/linux
+      ADO_LINUX_ARTIFACT_NAME: ${{ vars.ADO_LINUX_ARTIFACT_NAME }}
+      DEBIAN_REVISION: 1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Build, Sign and Download Linux Binaries
+      run: |
+        pip install -r bin/requirements.txt
+        python ./bin/trigger_azure_pipelines.py
+      env:
+        AZURE_DEVOPS_BUILD_PAT: ${{ secrets.AZURE_DEVOPS_BUILD_PAT }}
+        ADO_ORGANIZATION: ${{ secrets.ADO_ORGANIZATION }}
+        ADO_PROJECT: ${{ secrets.ADO_PROJECT}}
+        ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
+        ADO_AZUREAUTH_LINUX_STAGE_ID: ${{ vars.ADO_AZUREAUTH_LINUX_STAGE_ID }}
+        VERSION: ${{ github.event.inputs.version }}
+
+    - name: Upload linux artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_*.deb
+
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
     runs-on: ubuntu-latest
@@ -189,13 +219,15 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [package]
+    needs: [package, linux_release]
     # The 'release' environment is what requires reviews before creating the release.
     environment:
       name: release
     # These permissions are required in order to use `softprops/action-gh-release` to upload.
     permissions:
       contents: write
+    env:
+      DEBIAN_REVISION: 1
     steps:
     - name: Download win10-x64 artifact
       uses: actions/download-artifact@v3
@@ -220,3 +252,4 @@ jobs:
           azureauth-${{ github.event.inputs.version }}-win10-x64.zip
           azureauth-${{ github.event.inputs.version }}-osx-x64.tar.gz
           azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
+          azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb	

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,11 +172,16 @@ jobs:
         ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
         ADO_AZUREAUTH_LINUX_STAGE_ID: ${{ vars.ADO_AZUREAUTH_LINUX_STAGE_ID }}
         VERSION: ${{ github.event.inputs.version }}
-
-    - name: Upload linux artifact
+    - name: Upload linux-x64 artifact
       uses: actions/upload-artifact@v3
       with:
-        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_*.deb
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+    - name: Upload linux-arm64 artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
+        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
 
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
@@ -241,6 +246,15 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
+    - name: Download linux-x64 artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+    - name: Download linux-arm64 artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for distributing debian packages.
 
 ## [0.8.2] - 2023-07-06
 ### Added

--- a/bin/sign.py
+++ b/bin/sign.py
@@ -248,7 +248,7 @@ def parse_env_vars(runtime: str) -> tuple[str, str, str, JSON]:
                     "authenticode": os.environ["SIGNING_KEY_CODE_AUTHENTICODE"],
                     "mac": os.environ["SIGNING_KEY_CODE_MAC"],
                 }
-            case "linux-x64":
+            case "linux-x64" | "linux-arm64":
                 # This key code is used for signing .deb on Linux.
                 key_codes = {"linux": os.environ["SIGNING_KEY_CODE_LINUX"]}
 

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -10,7 +10,8 @@ import zipfile
 
 from azure.devops.connection import Connection
 from azure.devops.v6_0.pipelines.pipelines_client import PipelinesClient
-from azure.devops.v6_0.pipelines.models import Run
+from azure.devops.v6_0.build.build_client import BuildClient
+from azure.devops.v6_0.build.models import TimelineRecord
 from msrest.authentication import BasicAuthentication
 from requests import Response
 
@@ -27,23 +28,25 @@ def ado_connection(organization: str, ado_pat: str) -> Connection:
         creds=BasicAuthentication("", ado_pat),
     )
 
-
-def wait_for_pipeline_run(
-    pipeline_client: PipelinesClient, project: str, pipeline_id: int, run_id: str
-) -> Run:
-    """Wait for the azure devops pipepline run to finish"""
-    run = pipeline_client.get_run(project, pipeline_id, run_id)
+def wait_for_stage(
+    build_client: BuildClient, project: str, stage_id: str, run_id: str
+) -> TimelineRecord:
+    """Wait for the dedicated stage in azure devops pipepline run to finish"""
 
     # polling interval is set in accordance with the rate limits specified here:
     # https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rate-limits?view=azure-devops
     polling_interval_seconds = 30
 
-    # Wait until the build have a complete status.
-    # https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/get?view=azure-devops-rest-6.0#runstate
-    while run.state not in COMPLETED_STATUSES:
-        time.sleep(polling_interval_seconds)
-        run = pipeline_client.get_run(project, pipeline_id, run_id)
-    return run
+    # Wait until the stage have a complete status.
+    # https://learn.microsoft.com/en-us/rest/api/azure/devops/build/timeline/get?view=azure-devops-rest-6.0
+    while True:
+        timeline = build_client.get_build_timeline(project, run_id)
+        records = timeline.records
+        record = next(filter(lambda record: record.identifier == stage_id, records), None)
+        if record == None or record.state not in COMPLETED_STATUSES:
+            time.sleep(polling_interval_seconds)
+    
+        return record
 
 
 def trigger_azure_pipeline_and_wait_until_its_completed(
@@ -51,6 +54,7 @@ def trigger_azure_pipeline_and_wait_until_its_completed(
     organization: str,
     project: str,
     pipeline_id: str,
+    stage_id: str,
     version: str,
     commit_hash: str,
 ) -> str:
@@ -71,9 +75,10 @@ def trigger_azure_pipeline_and_wait_until_its_completed(
         "Successfully triggered a pipeline. Waiting for the run to be completed.\n"
         f"More details on the triggered pipeline can be found here: {pipeline_url}"
     )
-    completed_run = wait_for_pipeline_run(
-        pipeline_client, project, pipeline_id, pipeline_status.id
+    completed_run = wait_for_stage(
+        ado_client.get_build_client(), project, stage_id, pipeline_status.id
     )
+
     if completed_run.result in FAILED_STATUSES:
         raise Exception("Azure DevOps pipeline run failed!")
 
@@ -120,6 +125,7 @@ def main() -> None:
         organization = os.environ["ADO_ORGANIZATION"]
         project = os.environ["ADO_PROJECT"]
         pipeline_id = os.environ["ADO_AZUREAUTH_LINUX_PIPELINE_ID"]
+        stage_id = os.environ["ADO_AZUREAUTH_LINUX_STAGE_ID"]
         version = os.environ["VERSION"]
         commit_hash = os.environ["GITHUB_SHA"]
         ado_artifact_name = os.environ["ADO_LINUX_ARTIFACT_NAME"]
@@ -138,6 +144,7 @@ def main() -> None:
         organization,
         project,
         pipeline_id,
+        stage_id,
         version,
         commit_hash,
     )

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -45,8 +45,8 @@ def wait_for_stage(
         record = next(filter(lambda record: record.identifier == stage_id, records), None)
         if record == None or record.state not in COMPLETED_STATUSES:
             time.sleep(polling_interval_seconds)
-    
-        return record
+        else:
+            return record
 
 
 def trigger_azure_pipeline_and_wait_until_its_completed(

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -43,7 +43,7 @@ def wait_for_stage(
     # https://learn.microsoft.com/en-us/rest/api/azure/devops/build/timeline/get?view=azure-devops-rest-6.0
     while True:
         timeline = build_client.get_build_timeline(project, run_id)
-        record = next((r for r in records if r.identifier == stage_id), None)
+        record = next((r for r in timeline.records if r.identifier == stage_id), None)
         if record == None or record.state not in COMPLETED_STATES:
             time.sleep(polling_interval_seconds)
         else:

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -56,6 +56,7 @@ def trigger_azure_pipeline_and_wait_until_its_completed(
     pipeline_id: str,
     stage_id: str,
     version: str,
+    debian_revision: str,
     commit_hash: str,
 ) -> str:
     """Triggers an azure pipeline and waits for it to be finished"""
@@ -66,7 +67,7 @@ def trigger_azure_pipeline_and_wait_until_its_completed(
     # queue build API: https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-6.0
 
     run_parameters = {
-        "templateParameters": {"upstream_version": version, "commit_hash": commit_hash}
+        "templateParameters": {"upstream_version": version, "commit_hash": commit_hash, "debian_revision": debian_revision}
     }
     pipeline_status = pipeline_client.run_pipeline(run_parameters, project, pipeline_id)
     run_id = pipeline_status.id
@@ -127,6 +128,7 @@ def main() -> None:
         pipeline_id = os.environ["ADO_AZUREAUTH_LINUX_PIPELINE_ID"]
         stage_id = os.environ["ADO_AZUREAUTH_LINUX_STAGE_ID"]
         version = os.environ["VERSION"]
+        debian_revision = os.environ["DEBIAN_REVISION"]
         commit_hash = os.environ["GITHUB_SHA"]
         ado_artifact_name = os.environ["ADO_LINUX_ARTIFACT_NAME"]
         artifact_download_path = os.environ["ADO_LINUX_ARTIFACT_DOWNLOAD_PATH"]
@@ -146,6 +148,7 @@ def main() -> None:
         pipeline_id,
         stage_id,
         version,
+        debian_revision,
         commit_hash,
     )
 

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -43,8 +43,7 @@ def wait_for_stage(
     # https://learn.microsoft.com/en-us/rest/api/azure/devops/build/timeline/get?view=azure-devops-rest-6.0
     while True:
         timeline = build_client.get_build_timeline(project, run_id)
-        records = timeline.records
-        record = next(filter(lambda record: record.identifier == stage_id, records), None)
+        record = next((r for r in records if r.identifier == stage_id), None)
         if record == None or record.state not in COMPLETED_STATES:
             time.sleep(polling_interval_seconds)
         else:

--- a/bin/trigger_azure_pipelines.py
+++ b/bin/trigger_azure_pipelines.py
@@ -16,7 +16,7 @@ from msrest.authentication import BasicAuthentication
 from requests import Response
 
 # https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/get?view=azure-devops-rest-6.0#runresult
-FAILED_STATUSES: set[str] = {"canceled", "failed", "unknown"}
+FAILED_STATUSES: set[str] = {"canceled", "failed", "skipped", "unknown"}
 COMPLETED_STATUSES: set[str] = {"completed"}
 
 


### PR DESCRIPTION
This PR contains 2 changes.
- Enable building Linux packages from ADO pipelines again. It will generate both `amd64` and `arm64` packages.
- The ADO pipeline is staged not. We don't need to wait for the publish stage. After the `Sign` stage completed, We can download the artifacts.