### PR TITLE
Handle SIGINT (Ctrl+C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- AzureAuth now can handle SIGINT(Ctrl+C) correctly and return 2.
 
 ## [0.8.2] - 2023-07-06
 ### Added

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -97,6 +97,12 @@ namespace Microsoft.Authentication.AzureAuth
             services.AddSingleton<IPublicClientAuth, PublicClientAuth>();
             services.AddSingleton<ILogger>(logger);
 
+            Console.CancelKeyPress += (_, _) =>
+            {
+                logger.LogWarning("Received SIGINT (Ctrl+C), exiting...");
+                Environment.Exit(2);
+            };
+
             new Lasso(app, options, services).Execute(args);
         }
     }


### PR DESCRIPTION
AzureAuth may hang forever when receiving SIGINT signal. This PR will handle the signal and exit gracefully.