### PR TITLE
Enable dependabot to track Lasso and MSAL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,26 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/src"
-    registries:
-      - nuget-azure-devops # Allow version updates for dependencies in this registry
+  - package-ecosystem: "nuget"
+    directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      # Allow updates for MSAL and any packages starting "Microsoft.Identity"
+      - dependency-name: "Microsoft.Identity.*"
+      - dependency-name: "Microsoft.Office.Lasso"
+    groups:
+       # Combine MSAL packages to one Pull Request.
+       msal-dependencies:
+          patterns:
+            - "Microsoft.Identity.*"
+    ignore:
+      - dependency-name: "Microsoft.Identity.*"
+        # For Microsoft.Identity.*, ignore all Dependabot updates for 16.0.*.*, which is an internal version and cannot be used.
+        versions: ["16.0.*.*"]
+    registries:
+      - nuget-azure-devops # Allow version updates for dependencies in this registry
+      
 registries:
   nuget-azure-devops:
     type: nuget-feed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/src"
+    registries:
+      - nuget-azure-devops # Allow version updates for dependencies in this registry
+    schedule:
+      interval: "weekly"
+registries:
+  nuget-azure-devops:
+    type: nuget-feed
+    url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+    username: office
+    password: ${{ secrets.ADO_TOKEN }}


### PR DESCRIPTION
Upgrading dependencies should be a routine in AzureAuth. For example, the version of MSAL we are using is from 1 year ago. Dependabot can automatically create Pull Request for dependencies.

In this PR, Lasso and MSAL are enabled for auto update.

You can see the pull request in my repo: https://github.com/goagain/microsoft-authentication-cli/pulls