### PR TITLE
Enable dependabot to track Lasso and MSAL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     allow:
       # Allow updates for Lasso
       - dependency-name: "Microsoft.Office.Lasso"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
       # Allow updates for MSAL and any packages starting "Microsoft.Identity"
       - dependency-name: "Microsoft.Identity*"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
        msal-dependencies:
           patterns:
             - "Microsoft.Identity.*"
+    ignore:
+      - dependency-name: "Microsoft.Identity.*"
+        # For Microsoft.Identity.*, ignore all Dependabot updates for 16.0.*.*
+        versions: ["16.0.*.*"]
+
     registries:
       - nuget-azure-devops # Allow version updates for dependencies in this registry
 registries:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,28 +8,13 @@ updates:
       interval: "weekly"
   - package-ecosystem: "nuget"
     directory: "/"
-    registries:
-      - nuget-azure-devops # Allow version updates for dependencies in this registry
-    schedule:
-      interval: "weekly"
-    allow:
-      # Allow updates for Lasso
-      - dependency-name: "Microsoft.Office.Lasso"
-  - package-ecosystem: "nuget"
-    directory: "/"
     schedule:
       interval: "weekly"
     allow:
       # Allow updates for MSAL and any packages starting "Microsoft.Identity"
-      - dependency-name: "Microsoft.Identity*"
+      - dependency-name: "Microsoft.Identity.*"
     groups:
        # Combine MSAL packages to one Pull Request.
        msal-dependencies:
           patterns:
             - "Microsoft.Identity.*"
-registries:
-  nuget-azure-devops:
-    type: nuget-feed
-    url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
-    username: office
-    password: ${{ secrets.ADO_TOKEN }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
   - package-ecosystem: "nuget"
-    directory: "/src"
+    directory: "/"
     registries:
       - nuget-azure-devops # Allow version updates for dependencies in this registry
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,17 @@ updates:
     allow:
       # Allow updates for MSAL and any packages starting "Microsoft.Identity"
       - dependency-name: "Microsoft.Identity.*"
+      - dependency-name: "Microsoft.Office.Lasso"
     groups:
        # Combine MSAL packages to one Pull Request.
        msal-dependencies:
           patterns:
             - "Microsoft.Identity.*"
+    registries:
+      - nuget-azure-devops # Allow version updates for dependencies in this registry
+registries:
+  nuget-azure-devops:
+    type: nuget-feed
+    url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
+    username: office
+    password: ${{ secrets.ADO_TOKEN }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,11 @@ updates:
       - dependency-name: "Microsoft.Office.Lasso"
       # Allow updates for MSAL and any packages starting "Microsoft.Identity"
       - dependency-name: "Microsoft.Identity*"
-
+    groups:
+       # Combine MSAL packages to one Pull Request.
+       msal-dependencies:
+          patterns:
+            - "Microsoft.Identity.*"
 registries:
   nuget-azure-devops:
     type: nuget-feed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,11 @@ updates:
             - "Microsoft.Identity.*"
     ignore:
       - dependency-name: "Microsoft.Identity.*"
-        # For Microsoft.Identity.*, ignore all Dependabot updates for 16.0.*.*
+        # For Microsoft.Identity.*, ignore all Dependabot updates for 16.0.*.*, which is an internal version and cannot be used.
         versions: ["16.0.*.*"]
-
     registries:
       - nuget-azure-devops # Allow version updates for dependencies in this registry
+      
 registries:
   nuget-azure-devops:
     type: nuget-feed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       - nuget-azure-devops # Allow version updates for dependencies in this registry
     schedule:
       interval: "weekly"
+    allow:
+      # Allow updates for Lasso
+      - dependency-name: "Microsoft.Office.Lasso"
+      # Allow updates for MSAL and any packages starting "Microsoft.Identity"
+      - dependency-name: "Microsoft.Identity*"
+
 registries:
   nuget-azure-devops:
     type: nuget-feed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-  - package-ecosystem: "docker"
+  - package-ecosystem: "nuget"
     directory: "/src"
     registries:
       - nuget-azure-devops # Allow version updates for dependencies in this registry


### PR DESCRIPTION
Upgrading dependencies should be a routine in AzureAuth. For example, the version of MSAL we are using is from 1 year ago. Dependabot can automatically create Pull Request for dependencies.

In this PR, Lasso and MSAL are enabled for auto update.

You can see the pull request in my repo: https://github.com/goagain/microsoft-authentication-cli/pulls