### PR TITLE
Include extra scopes and update CHANGELOG/README for 0.8.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.3] - 2023-08-24
 ### Added
 - Added support for distributing debian packages.
+- The `azureauth ado pat` subcommand now supports additional Azure DevOps scopes.
 
 ### Fixed
 - AzureAuth now can handle SIGINT(Ctrl+C) correctly and return 2.
@@ -168,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.2...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.3...HEAD
+[0.8.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.7.4...0.8.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Microsoft Authentication CLI
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/AzureAd/microsoft-authentication-cli/.github/workflows/dotnet-test.yml?branch=main&style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/actions/workflows/dotnet-test.yml)
-[![Release](https://img.shields.io/badge/Release-0.8.2-orange?style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/0.8.2)
-![GitHub release (latest by SemVer)](https://img.shields.io/github/downloads/azuread/microsoft-authentication-cli/0.8.2/total?logo=github&style=for-the-badge&color=blue)
+[![Release](https://img.shields.io/badge/Release-0.8.3-orange?style=for-the-badge&logo=github)](https://github.com/AzureAD/microsoft-authentication-cli/releases/tag/0.8.3)
+![GitHub release (latest by SemVer)](https://img.shields.io/github/downloads/azuread/microsoft-authentication-cli/0.8.3/total?logo=github&style=for-the-badge&color=blue)
 [![License](https://shields.io/badge/license-MIT-purple?style=for-the-badge)](./LICENSE.txt)
 
 ---
@@ -34,8 +34,8 @@ provide a means of downloading the latest release, so you **must** specify your 
 To install the application, run
 
 ```powershell
-# 0.8.2 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-$env:AZUREAUTH_VERSION = '0.8.2'
+# 0.8.3 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+$env:AZUREAUTH_VERSION = '0.8.3'
 $script = "${env:TEMP}\install.ps1"
 $url = "https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/${env:AZUREAUTH_VERSION}/install/install.ps1"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -55,8 +55,8 @@ release, so you **must** specify your desired version via the `$AZUREAUTH_VERSIO
 To install the application, run
 
 ```bash
-# 0.8.2 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
-export AZUREAUTH_VERSION='0.8.2'
+# 0.8.3 is an example. See https://github.com/AzureAD/microsoft-authentication-cli/releases for the latest.
+export AZUREAUTH_VERSION='0.8.3'
 curl -sL https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/$AZUREAUTH_VERSION/install/install.sh | sh
 ```
 

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Authentication.AdoPat
             "vso.code_full",
             "vso.code_status",
 
+            // Drop
+            "vso.drop",
+            "vso.drop_write",
+            "vso.drop_manage",
+
             // Entitlements
             "vso.entitlements",
             "vso.memberentitlementmanagement",


### PR DESCRIPTION
There were some scopes that we weren't previously aware of which are reasonable to support in validation for the `azureauth ado pat` subcommand. Including these scopes will allow these scopes to be considered valid.

This PR also prepares us to make a 0.8.3 release by updating the `CHANGELOG.md` and `README.md` files accordingly.