### PR TITLE
Downgrade IWA warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AzureAuth now can handle SIGINT(Ctrl+C) correctly and return 2.
 
 ### Changed
-- Optimize the warning message from IWA auth flow when VPN is not connected.
+- Optimize the warning message from IWA auth flow when VPN is not connected, and downgrade it to debug level.
 
 ## [0.8.2] - 2023-07-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - AzureAuth now can handle SIGINT(Ctrl+C) correctly and return 2.
 
+### Changed
+- When attempting the IWA authentication flow without a VPN connection, the warning message "IWA only works on Corp Net, please turn on VPN." will be downgraded to info level.
+
 ## [0.8.2] - 2023-07-06
 ### Added
 - The `azureauth ado` subcommands now support a `--tenant` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AzureAuth now can handle SIGINT(Ctrl+C) correctly and return 2.
 
 ### Changed
-- When attempting the IWA authentication flow without a VPN connection, the warning message "IWA only works on Corp Net, please turn on VPN." will be downgraded to info level.
+- Optimize the warning message from IWA auth flow when VPN is not connected.
 
 ## [0.8.2] - 2023-07-06
 ### Added

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (MsalClientException ex) when (ex.Message.Contains("WS-Trust endpoint not found"))
             {
-                this.logger.LogWarning($"IWA only works on Corp Net, please turn on VPN.");
+                this.logger.LogInformation($"IWA only works on Corp Net, please turn on VPN.");
                 throw;
             }
 

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (MsalClientException ex) when (ex.Message.Contains("WS-Trust endpoint not found"))
             {
-                this.logger.LogWarning($"IWA only works on corporate AD backed network, AzureAuth is trying to use other auth flows.");
-                this.logger.LogWarning($"If you specify the IWA mode, please turn on VPN.");
+                this.logger.LogDebug($"IWA only works on corporate AD backed network, AzureAuth is trying to use other auth flows if applicable.");
+                this.logger.LogDebug($"Turn on VPN for IWA mode to succeed.");
                 throw;
             }
 

--- a/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
+++ b/src/MSALWrapper/AuthFlow/IntegratedWindowsAuthentication.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             }
             catch (MsalClientException ex) when (ex.Message.Contains("WS-Trust endpoint not found"))
             {
-                this.logger.LogInformation($"IWA only works on Corp Net, please turn on VPN.");
+                this.logger.LogWarning($"IWA only works on corporate AD backed network, AzureAuth is trying to use other auth flows.");
+                this.logger.LogWarning($"If you specify the IWA mode, please turn on VPN.");
                 throw;
             }
 


### PR DESCRIPTION
Many customers report that the warning message "IWA only works on Corp Net, please turn on VPN." from IWA is very confusing. We can be clearer by downgrading it to debug level and changing it to 
```
IWA only works on corporate AD backed network, AzureAuth is trying to use other auth flows.
If you specify the IWA mode, please turn on VPN.
```