### PR TITLE
Fix the download path of Linux artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,11 +249,11 @@ jobs:
     - name: Download linux-x64 artifact
       uses: actions/download-artifact@v3
       with:
-        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+        name: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
     - name: Download linux-arm64 artifact
       uses: actions/download-artifact@v3
       with:
-        name: azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
+        name: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
 
     - name: Create Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The download-artifact path should be same as what we uploaded at [release.yml:183](https://github.com/AzureAD/microsoft-authentication-cli/blob/1d1a9bcd3e3aa8ab28cefcceb599f01e9a812349/.github/workflows/release.yml#L183)
```
    - name: Upload linux-x64 artifact
      uses: actions/upload-artifact@v3
      with:
        name: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
    - name: Upload linux-arm64 artifact
      uses: actions/upload-artifact@v3
      with:
        name: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
```