### PR TITLE
Change the top-level help text to make sense

### DIFF
--- a/src/AzureAuth/Commands/CommandAzureAuth.cs
+++ b/src/AzureAuth/Commands/CommandAzureAuth.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
     /// <summary>
     /// The command main class parses commands and dispatches to the corresponding methods.
     /// </summary>
-    [Command(Name = "azureauth", Description = "A CLI interface to MSAL (Microsoft Authentication Library).")]
+    [Command(Name = "azureauth", Description = "A command line interface to MSAL (Microsoft Authentication Library).")]
     [Subcommand(typeof(CommandAad))]
     [Subcommand(typeof(CommandAdo))]
     [Subcommand(typeof(CommandInfo))]


### PR DESCRIPTION
Saying CLI interface is like saying ATM machine. The `I` is for `interface`. This just spells it out by using all the words instead of the abbreviation.