### PR TITLE
Fix the release issue `Pattern 'azureauth-0.8.3-linux-x64.deb' does not match any files`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,16 +172,22 @@ jobs:
         ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
         ADO_AZUREAUTH_LINUX_STAGE_ID: ${{ vars.ADO_AZUREAUTH_LINUX_STAGE_ID }}
         VERSION: ${{ github.event.inputs.version }}
-    - name: Upload linux-x64 artifact
+
+    - name: Rename linux-x64 artifact
+      run: |
+        mv ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb \
+        azureauth-${{ github.event.inputs.version }}-linux-x64.deb
+    - name: Rename linux-arm64 artifact
+      run: |
+        mv ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb \
+        azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
+    - name: Upload linux artifact
       uses: actions/upload-artifact@v3
       with:
-        name: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
-    - name: Upload linux-arm64 artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
-        path: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
+        name: azureauth-linux
+        path: |
+          azureauth-${{ github.event.inputs.version }}-linux-x64.deb
+          azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
 
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
@@ -231,8 +237,6 @@ jobs:
     # These permissions are required in order to use `softprops/action-gh-release` to upload.
     permissions:
       contents: write
-    env:
-      DEBIAN_REVISION: 1
     steps:
     - name: Download win10-x64 artifact
       uses: actions/download-artifact@v3
@@ -249,11 +253,7 @@ jobs:
     - name: Download linux-x64 artifact
       uses: actions/download-artifact@v3
       with:
-        name: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-    - name: Download linux-arm64 artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
+        name: azureauth-linux
 
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,14 +173,16 @@ jobs:
         ADO_AZUREAUTH_LINUX_STAGE_ID: ${{ vars.ADO_AZUREAUTH_LINUX_STAGE_ID }}
         VERSION: ${{ github.event.inputs.version }}
 
-    - name: Rename linux-x64 artifact
+    - name: Rename linux artifact
+      env:
+          DEB_AMD64_SOURCE: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
+          DEB_AMD64_TARGET: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
+          DEB_ARM64_SOURCE: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
+          DEB_ARM64_TARGET: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
       run: |
-        mv ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb \
-        azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-    - name: Rename linux-arm64 artifact
-      run: |
-        mv ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb \
-        azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
+            mv ${{ env.DEB_AMD64_SOURCE }} ${{ env.DEB_AMD64_TARGET}}
+            mv ${{ env.DEB_ARM64_SOURCE }} ${{ env.DEB_ARM64_TARGET}}
+            
     - name: Upload linux artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,8 +180,8 @@ jobs:
           DEB_ARM64_SOURCE: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
           DEB_ARM64_TARGET: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
       run: |
-            mv ${{ env.DEB_AMD64_SOURCE }} ${{ env.DEB_AMD64_TARGET}}
-            mv ${{ env.DEB_ARM64_SOURCE }} ${{ env.DEB_ARM64_TARGET}}
+            mv ${{ env.DEB_AMD64_SOURCE }} ${{ env.DEB_AMD64_TARGET }}
+            mv ${{ env.DEB_ARM64_SOURCE }} ${{ env.DEB_ARM64_TARGET }}
             
     - name: Upload linux artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Background
We got errors from our latest release
**🤔 Pattern 'azureauth-0.8.3-linux-x64.deb' does not match any files.
🤔 Pattern 'azureauth-0.8.3-linux-arm64.deb' does not match any files.**

## Issue
The artifact name doesn't mean the file name. In the last step, the artifact was downloaded with the raw name `azureauth_0.8.3-1_amd64.deb`, that's why the file cannot be matched.

## Solution
Rename the deb package before uploading to artifact.

## Validation
https://github.com/goagain/microsoft-authentication-cli/actions/runs/6043610356
https://github.com/goagain/microsoft-authentication-cli/releases/tag/0.8.3

