### PR TITLE
Refactor release_name function to be more resilient detecting architecture on macOS [#350]

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -26,20 +26,15 @@ release_name() {
     case "${os_name}" in
         Darwin)
             name="${name}-osx"
-            arch="$(echo $os_info | rev | cut -d ' ' -f1 | rev)"
-
-            case "${arch}" in
-                arm64)
-                    name="${name}-arm64"
-                    ;;
-                x86_64)
-                    name="${name}-x64"
-                    ;;
-                *)
-                    error "Unsupported architecture '${arch}', unable to download a release"
-                    exit 1
-                    ;;
-            esac
+            # check if os_info contains arm64 or x86_64
+            if echo $os_info | grep -q arm64; then
+                name="${name}-arm64"
+            elif echo $os_info | grep -q x86_64; then
+                name="${name}-x64"
+            else
+                error "Unsupported architecture '${arch}', unable to download a release"
+                exit 1
+            fi
             ;;
         *)
             error "Unsupported OS '${os_name}', unable to download a release"


### PR DESCRIPTION
Instead of assuming the architecture is the last field of `uname -a`, grep for the architectures we care about and set the release name accordingly.

My `uname -a` for reference:
`Darwin ms-macbook-pro.lan 22.6.0 Darwin Kernel Version 22.6.0: Wed Oct  4 21:26:23 PDT 2023; root:xnu-8796.141.3.701.17~4/RELEASE_ARM64_T6000 arm64 arm Darwin`

This is with coreutils installed through homebrew.

Fixes #350 