### PR TITLE
Reclassify CG pipeline as nonproduction

### DIFF
--- a/.github/workflows/azure-devops-pipelines-cg.yml
+++ b/.github/workflows/azure-devops-pipelines-cg.yml
@@ -1,7 +1,7 @@
 # This pipeline will be triggered when either main branch is pushed or 2AM on workdays.
 variables:
   - name: tags
-    value: "production"
+    value: "nonproduction"
     readonly: true
 trigger:
   branches:


### PR DESCRIPTION
While important, it doesn't appear as though this pipeline requires a `production` classification and can instead be classified as `nonproduction`.