### PR TITLE
Add "ado pat scopes" sub-command to print available scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added new sub-command `azureauth ado pat scopes` to list the set of actual scopes the `pat` command validates against and print the short-link to the pat scopes docs.
 
 ## [0.8.4] - 2023-09-05
 ### Changed

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
     /// An ADO Command for creating or fetching, and returning Azure Devops PATs.
     /// </summary>
     [Command("pat", Description = "Create and cache Azure Devops Personal Access Tokens (PATs) using encrypted local storage.")]
+    [Subcommand(typeof(Pat.CommandScopes))]
     public class CommandPat
     {
         private const string OrganizationOption = "--organization";

--- a/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
+++ b/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
@@ -10,7 +10,8 @@ using System.Linq;
 namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
 {
     /// <summary>
-    /// Command to print the list of avaialable scopes
+    /// Command to print the list of available scopes
+
     /// </summary>
     [Command("scopes", Description = "List the valid ado pat scopes")]
     public class CommandScopes

--- a/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
+++ b/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
@@ -4,6 +4,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Authentication.AdoPat;
 using Microsoft.Extensions.Logging;
 
+using System;
 using System.Linq;
 
 namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
@@ -33,17 +34,12 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
         /// <returns></returns>
         public int OnExecute()
         {
-            // Print at the top and bottom because it's a long list.
-            logger.LogInformation(UrlMessage + "\n");
-
             var scopes = Scopes.ValidScopes.ToList();
             scopes.Sort();
 
-            foreach (var scope in scopes)
-            {
-                logger.LogInformation(scope);
-            }
-
+            // Print URL at the top and bottom because it's a long list of scopes.
+            logger.LogInformation(UrlMessage + "\n");
+            logger.LogInformation(string.Join(Environment.NewLine, scopes));
             logger.LogInformation("\n" + UrlMessage);
             return 0;
         }

--- a/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
+++ b/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
@@ -3,7 +3,6 @@ using McMaster.Extensions.CommandLineUtils;
 
 using Microsoft.Authentication.AdoPat;
 using Microsoft.Extensions.Logging;
-using Microsoft.Office.Lasso.Telemetry;
 
 using System.Linq;
 
@@ -16,6 +15,8 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
     public class CommandScopes
     {
         private readonly ILogger logger;
+
+        private readonly string UrlMessage = $"See {AdoPat.Constants.PatListURL} for details.";
 
         /// <summary>
         /// Create a CommandScopes
@@ -32,6 +33,9 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
         /// <returns></returns>
         public int OnExecute()
         {
+            // Print at the top and bottom because it's a long list.
+            logger.LogInformation(UrlMessage + "\n");
+
             var scopes = Scopes.ValidScopes.ToList();
             scopes.Sort();
 
@@ -40,6 +44,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
                 logger.LogInformation(scope);
             }
 
+            logger.LogInformation("\n" + UrlMessage);
             return 0;
         }
     }

--- a/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
+++ b/src/AzureAuth/Commands/Ado/Pat/CommandScopes.cs
@@ -1,0 +1,46 @@
+
+using McMaster.Extensions.CommandLineUtils;
+
+using Microsoft.Authentication.AdoPat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Office.Lasso.Telemetry;
+
+using System.Linq;
+
+namespace Microsoft.Authentication.AzureAuth.Commands.Ado.Pat
+{
+    /// <summary>
+    /// Command to print the list of avaialable scopes
+    /// </summary>
+    [Command("scopes", Description = "List the valid ado pat scopes")]
+    public class CommandScopes
+    {
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Create a CommandScopes
+        /// </summary>
+        /// <param name="logger"></param>
+        public CommandScopes(ILogger<CommandScopes> logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Executes the Scopes command listing the available scopes
+        /// </summary>
+        /// <returns></returns>
+        public int OnExecute()
+        {
+            var scopes = Scopes.ValidScopes.ToList();
+            scopes.Sort();
+
+            foreach (var scope in scopes)
+            {
+                logger.LogInformation(scope);
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
# azureauth ado pat scopes
## Motivation
It's hard to remember where or find the actual list of scopes in the ADO documentation. After 5 searches this morning, I couldn't find it online and had to come here to the source to figure out what the actual scope was to request while using the `ado pat` command.

This adds a new subcommand onto the existing `ado pat` command path to list the available scopes and the link to the documentation making it much easier to use the command.

## Usage
```
C:\r\microsoft-authentication-cli> .\dist\azureauth.exe ado pat -h                                                                      
1.0.0.0
Create and cache Azure Devops Personal Access Tokens (PATs) using encrypted local storage.

Usage: azureauth ado pat [command] [options]

Options:
  --organization  The name of the Azure DevOps organization.
  --display-name  The PAT name.
  --scope         A token scope for accessing Azure DevOps resources. Repeated invocations allowed.
  --output        How PAT information is displayed. [default: token]
                  [possible values: none, status, token, base64, header, headervalue, json]
  --prompt-hint   A prompt hint to contextualize prompts and identify uses in telemetry, when captured.
  --tenant        The Azure Tenant ID to use for authentication. Defaults to Microsoft.
  --mode          Authentication mode. Repeated invocations allowed.
                  [default: iwa (Integrated Windows Auth), then broker, then web]
                  [possible values: all, iwa, broker, web, devicecode]
  --domain        Preferred domain for filtering cached accounts.
                  Skips launching an account picker if only one cached account matches the preferred domain.
                  [default: microsoft.com]
  --timeout       The number of minutes before authentication times out.
                  [default: 15 minutes]
  -?|-h|--help    Show help information.
  --version       Show version information.
  --debug         Turn off telemetry reporting.
  --verbosity     Configure the minimum log level to show.
                  Allowed values are: trace, debug, info, information, warn, warning, error, critical, fatal, none, off.

Commands:
  scopes          List the valid ado pat scopes

Run 'pat [command] -?|-h|--help' for more information about a command.
```

Note the new Commands section at the bottom 👆.

```
.\dist\azureauth.exe ado pat scopes                                                                  02/15/24 14:51:55 PMvso.agentpools
vso.agentpools_manage
vso.analytics
vso.auditlog
vso.build
vso.build_execute
vso.code
vso.code_full
vso.code_manage
vso.code_status
vso.code_write
vso.dashboards
vso.dashboards_manage
vso.drop
vso.drop_manage
vso.drop_write
vso.entitlements
vso.environment_manage
vso.extension
vso.extension_manage
vso.extension.data
vso.extension.data_write
vso.gallery
vso.gallery_acquire
vso.gallery_manage
vso.gallery_publish
vso.graph
vso.graph_manage
vso.identity
vso.identity_manage
vso.loadtest
vso.loadtest_write
vso.machinegroup_manage
vso.memberentitlementmanagement
vso.memberentitlementmanagement_write
vso.notification
vso.notification_diagnostics
vso.notification_manage
vso.notification_write
vso.packaging
vso.packaging_manage
vso.packaging_write
vso.profile
vso.profile_write
vso.project
vso.project_manage
vso.project_write
vso.release
vso.release_execute
vso.release_manage
vso.security_manage
vso.serviceendpoint
vso.serviceendpoint_manage
vso.serviceendpoint_query
vso.settings
vso.settings_write
vso.symbols
vso.symbols_manage
vso.symbols_write
vso.taskgroups_manage
vso.taskgroups_read
vso.taskgroups_write
vso.test
vso.test_write
vso.tokenadministration
vso.tokens
vso.variablegroups_manage
vso.variablegroups_read
vso.variablegroups_write
vso.wiki
vso.wiki_write
vso.work
vso.work_full
vso.work_write
```
