### PR TITLE
Add support for Component Governance ADO Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.8.5] - 2024-03-04
-### Changed
+### Added
 - The `azureauth ado pat` subcommand now supports the `vso.governance` Azure DevOps scope.
 
 ## [0.8.4] - 2023-09-05
@@ -180,8 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.5...HEAD
-[0.8.5]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.4...0.8.5
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.4...HEAD
 [0.8.4]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.1...0.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5] - 2024-03-04
+### Changed
+- The `azureauth ado pat` subcommand now supports the `vso.governance` Azure DevOps scope.
+
 ## [0.8.4] - 2023-09-05
 ### Changed
 - Upgrade Lasso to `2023.8.24.1`.
@@ -176,7 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project release.
 
-[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.4...HEAD
+[Unreleased]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.5...HEAD
+[0.8.5]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.4...0.8.5
 [0.8.4]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/AzureAD/microsoft-authentication-cli/compare/0.8.1...0.8.2

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Authentication.AdoPat
             "vso.identity",
             "vso.identity_manage",
 
+            // Governance
+            "vso.governance",
+
             // Load Test
             "vso.loadtest",
             "vso.loadtest_write",


### PR DESCRIPTION
According to [the Azure Dev Ops PAT documentation](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops&tabs=Windows#create-a-pat), the `vso.governance` scope is supported to interact with Azure DevOps Component Governance API's.

> For a custom defined PAT, the required scope for accessing the Component Governance API, vso.governance, isn't selectable in the UI.

This PR adds `vso.governance` as a supported scope.

**Validation:** the executable was built locally and a PAT was generated with the `vso.governance` scope and confirmed that the PAT was able to be utilized with the `ComponentGovernanceHttpClient` library from ADO.