### PR TITLE
Add `--allow-custom-scopes` flag to skip scope validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `--no-validate` flag to skip scope validation for `ado pat`. This allows addition of non-public ADO scopes.
 
 ## [0.8.4] - 2023-09-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `--no-validate` flag to skip scope validation for `ado pat`. This allows addition of non-public ADO scopes.
+- `--allow-custom-scopes` to skip validation and allow custom Azure DevOps PAT scopes.
 
 ## [0.8.4] - 2023-09-05
 ### Changed

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Authentication.AdoPat
 
         /// <summary>Validate the given scopes.</summary>
         /// <param name="scopes">The scopes to validate.</param>
-        /// <returns>The set of known scopes present in the given scopes. The
+        /// <returns>The set of unknown scopes present in the given scopes. The
         /// empty set means no scopes were unknown.</returns>
         public static ImmutableHashSet<string> Validate(IEnumerable<string> scopes)
         {

--- a/src/AdoPat/Scopes.cs
+++ b/src/AdoPat/Scopes.cs
@@ -145,8 +145,8 @@ namespace Microsoft.Authentication.AdoPat
 
         /// <summary>Validate the given scopes.</summary>
         /// <param name="scopes">The scopes to validate.</param>
-        /// <returns>The set of invalid scopes present in the given scopes. The
-        /// empty set means no scopes were invalid.</returns>
+        /// <returns>The set of known scopes present in the given scopes. The
+        /// empty set means no scopes were unknown.</returns>
         public static ImmutableHashSet<string> Validate(IEnumerable<string> scopes)
         {
             return scopes.Except(ValidScopes).ToImmutableHashSet();

--- a/src/AzureAuth/Commands/Ado/CommandPat.cs
+++ b/src/AzureAuth/Commands/Ado/CommandPat.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands.Ado
         private const string ScopeHelp = "A token scope for accessing Azure DevOps resources. Repeated invocations allowed.";
 
         private const string NoValidationFlag = "--no-validate";
-        private const string NoValidationHelp = "Flag to skip scope validation. Allows addition of non-public ADO scopes.";
+        private const string NoValidationHelp = "Skip scopes validation.";
 
         private const string OutputOption = "--output";
         private const string OutputHelp = "How PAT information is displayed. [default: token]\n[possible values: none, status, token, base64, header, headervalue, json]";


### PR DESCRIPTION
This PR adds a `--allow-custom-scopes` flag to skip scope validation for PAT. This allows addition undocumented ADO scopes.

Testing:
1. PAT with just 1 invalid scope.
Earlier
![image](https://github.com/AzureAD/microsoft-authentication-cli/assets/36398394/c80db772-c678-4352-a0f7-b922d7c3499f)

With `--allow-custom-scopes` flag

![image](https://github.com/AzureAD/microsoft-authentication-cli/assets/36398394/53448bf0-0e98-4139-9791-4e291a2b2b61)


```
microsoft-authentication-cli\dist on  user/haashah/add-no-validate-flag [!]
❯ .\azureauth.exe ado pat  --organization "office" --scope "lolwut" --display-name "Test PAT" --prompt-hint "Creating custom PAT test" --allow-custom-scopes
Skipping scopes validation.
<pat>
```

2. PAT with 1 known and 1 invalid scope
```
❯ .\azureauth.exe ado pat  --organization "office" --scope "lolwut" --scope "vso.code" --display-name "Test PAT 2" --prompt-hint "Creating PAT for testing" --allow-custom-scopes
Skipping scopes validation.
One or more errors occurred. (Failed to create PAT: InvalidScope)
An unexpected error ocurred. Re-run with --verbosity=debug for more info.
```
3. PAT with valid known ADO scope and valid unknown ADO scope.

```
❯ .\azureauth.exe ado pat  --organization "office" --scope "vso.governance" --scope "vso.code" --display-name "Non-public valid scope" --prompt-hint "Creating PAT for testing" --allow-custom-scopes
Skipping scopes validation.
<pat>
```

4. Without `--allow-custom-scopes` flag
```
❯  .\azureauth.exe ado pat  --organization "office" --scope "vso.governance" --scope "vso.code" --display-name "Non-public valid scope" --prompt-hint "Creating PAT for testing"
vso.governance is not a known Azure DevOps PAT scope.
Consult https://aka.ms/azure-devops-pat-scopes for a list of known scopes.
Use --allow-custom-scopes to create a PAT with custom scopes.
```





