### PR TITLE
Upgrade dependencies with important security updates

### DIFF
--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.32.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.215.0-preview" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
 </Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.32.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.16.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.55.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
 


### PR DESCRIPTION
[CG] Updating 2 dependencies with important security updates:

1. `"Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0"`: Updating to latest stable version.
2. `"System.Data.SqlClient" Version="4.8.6"`: Explicitly specifying version so that it takes precedence over any transitive dependency version declarations. ( In this case, `Microsoft.VisualStudio.Services.Client` whose latest version (like current) uses `4.8.5` but allows > `4.8.5`)

Testing
Tested following commands on both mac and windows:

azureauth --help
azureauth aad --help
azureauth ado pat --help
azureauth ado token --help
azureauth ado pat scopes --help
azureauth info --help
azureauth ado token
azureauth ado pat
azureauth aad (with different output and auth modes)

