### PR TITLE
Upgrade MSAL dependencies to 4.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Upgrade MSAL to `4.59.1`.
+- Upgrade MSAL from `4.55.0` to `4.59.1`.
 
 ### Added
 - Added the word `Warning` before logging IWA failures so users worry less about IWA issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade MSAL to `4.59.1`.
+
+### Added
 - Added the word `Warning` before logging IWA failures so users worry less about IWA issues.
 
 ## [0.8.5] - 2024-03-06

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Microsoft.Authentication.AdoPat</PackageId>
@@ -11,7 +11,7 @@
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.32.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.215.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.55.0" />
+        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.59.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
@@ -31,7 +31,7 @@
         <!--Windows: Explicitly continue using the net5 version of MSAL since there is no net6 target yet 
          https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3682-->
         <PackageReference Include="Microsoft.Identity.Client" GeneratePathProperty="true">
-            <Version>4.55.0</Version>
+            <Version>4.59.1</Version>
         </PackageReference>
 
         <Reference Include="Microsoft.Identity.Client">
@@ -41,6 +41,6 @@
     
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.59.1" />
     </ItemGroup>
 </Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Package Naming, Building, & Versioning -->
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.32.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.55.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.59.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.59.1" />
 
   </ItemGroup>
 


### PR DESCRIPTION
# Upgrading MSAL version to `4.59.1`

## Why not the latest `4.60.3`?

There are few unresolved issues in 4.60.x version of MSAL for example:
[Bug] Broker-based flows fail for MSA accounts with latest MSAL.

Also, looking at the changelog, there does not seem to be an immediate need to move to `4.60.x`, hence updating to a more stable version for now.


## Selected improvements and bug fixes which can be helpful:

`4.59.0` -
• Fixed a scenario when the same tokens are cached under different cache keys when an identity provider sends scopes in a different order.
• Fixed SemaphoreFullException happening in managed identity flows.

`4.58.1` - 
• Fixed an issue with sending an incorrect operating system descriptor in silent flows on Mac. 
• Added WithForceRefresh support for silent flows using the Windows broker.

`4.57` -
• Included missing Windows broker-related exception data when serializing MSAL exceptions.
• Added additional logging in the cache.

`4.56` -
• Added AuthenticationResult.AuthenticationResultMetadata.Telemetry that currently contains telemetry from the [Windows broker (WAM)](https://learn.microsoft.com/entra/msal/dotnet/acquiring-tokens/desktop-mobile/wam). 
• Added clarity to the Windows broker logs.

## Upgrading [microsoft-authentication-extensions-for-dotnet](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet)

- The MSAL Extensions repository has been archived  and is maintained alongside MSAL.
- [Microsoft.Identity.Client.Extensions.Msal](https://www.nuget.org/packages/Microsoft.Identity.Client.Extensions.Msal) is now in sync with MSAL version. Note that repository mentions there are no breaking changes between 2.x and 4.x pic below)

![image](https://github.com/AzureAD/microsoft-authentication-cli/assets/36398394/e7f219b3-7a9e-4848-8d51-2478c2eedbbd)

## Testing

### Benchmark test

`4.59.1`
```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.3447)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.204
  [Host]     : .NET 6.0.29 (6.0.2924.17105), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.29 (6.0.2924.17105), X64 RyuJIT AVX2
```

|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
|  NativeBrokerBenchmark | 56.71 ms | 0.307 ms | 0.272 ms |
| ManagedBrokerBenchmark | 56.89 ms | 1.070 ms | 0.948 ms |


`4.55.0`
```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.3447)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.204
  [Host]     : .NET 6.0.29 (6.0.2924.17105), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.29 (6.0.2924.17105), X64 RyuJIT AVX2
```

|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
|  NativeBrokerBenchmark | 55.98 ms | 0.265 ms | 0.247 ms |
| ManagedBrokerBenchmark | 55.50 ms | 0.512 ms | 0.453 ms |

### Other

Tested following commands on both mac and windows:
```
azureauth --help
azureauth aad --help
azureauth ado pat --help
azureauth ado token --help
azureauth ado pat scopes --help
azureauth info --help
azureauth ado token
azureauth ado pat
azureauth aad (with different output and auth modes)
```
