### PR TITLE
Improvements to the README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The CLI is designed for authenticating and returning an access token for public 
 
 # Platform Support
 
-| Operating System                           | Auth Broker Integration | Web Auth Flow | Device Code Flow | Token Caching | Multi-Account Support           |
-| ------------------------------------------ | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
-| Windows                                    | ✅                      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
-| OSX (MacOS)                                | ⚠️ via Web Browser      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❌            | ⚠️ `--domain` account filtering |
+| Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow | Device Code Flow | Token Caching | Multi-Account Support           |
+| ------------------------------------------ | ----------------------- | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
+| Windows                                    | ✅                      | ✅                      | ✅            | ✅               | ✅          | ⚠️ `--domain` account filtering |
+| OSX (MacOS)                                | ❌                      | ⚠️ via Web Browser      | ✅            | ✅               | ✅          | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon  | ❌                      | ⚠️ via Edge             | ✅            | ✅               | ❌          | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | ------------------------------------------ | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
 | OSX (MacOS)                                | ⚠️ via Web Browser      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❌       | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❌            | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The CLI is designed for authenticating and returning an access token for public 
 | Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow            | Device Code Flow | Token Caching | Multi-Account Support           |
 | ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
-| OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon  | N/A                      | ⚠️ via Edge             | ⚠️ In graphical environments | ✅              | ❌          | ⚠️ `--domain` account filtering |
+| OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅             | ✅          | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon  | N/A                      | ⚠️ via Edge             | ⚠️ in GUI environments | ✅        | ⚠️ in GUI environments. See [msal/#3033](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3033)      | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-`AzureAuth` is a CLI wrapper for performing AAD Authentication. It makes use of [MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) for authentication and [MSAL Extensions](https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet) for caching.
+`AzureAuth` is a CLI wrapper for performing AAD Authentication. It makes use of [MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) for authentication and caching.
 
 The CLI is designed for authenticating and returning an access token for public client AAD applications. This acts like a credential provider for Azure Devops and any other [public client app](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-client-applications).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | ------------------------------------------ | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
 | OSX (MacOS)                                | ⚠️ via Web Browser      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❎         | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❌       | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
 | OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅             | ✅          | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon  | N/A                      | ⚠️ via Edge             | ⚠️ in GUI environments | ✅        | ⚠️ in GUI environments. See [msal/#3033](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3033)      | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon  | N/A                      | ⚠️ via Edge             | ⚠️ in GUI environments | ✅        | ⚠️ in GUI environments. See [msal#3033](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3033)      | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow            | Device Code Flow | Token Caching | Multi-Account Support           |
 | ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
-| OSX (MacOS)                                | ❌                      | ⚠️ via Web Browser      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
+| OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
 | Ubuntu (linux) <br/>‼️Releases coming soon  | ❌                      | ⚠️ via Edge             | ⚠️ via non headless env | ✅              | ❌          | ⚠️ `--domain` account filtering |
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The CLI is designed for authenticating and returning an access token for public 
 
 # Platform Support
 
-| Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow | Device Code Flow | Token Caching | Multi-Account Support           |
-| ------------------------------------------ | ----------------------- | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
-| Windows                                    | ✅                      | ✅                      | ✅            | ✅               | ✅          | ⚠️ `--domain` account filtering |
-| OSX (MacOS)                                | ❌                      | ⚠️ via Web Browser      | ✅            | ✅               | ✅          | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon  | ❌                      | ⚠️ via Edge             | ✅            | ✅               | ❌          | ⚠️ `--domain` account filtering |
+| Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow            | Device Code Flow | Token Caching | Multi-Account Support           |
+| ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
+| Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
+| OSX (MacOS)                                | ❌                      | ⚠️ via Web Browser      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon  | ❌                      | ⚠️ via Edge             | ⚠️ via non headless env | ✅              | ❌          | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
 | OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon  | ❌                      | ⚠️ via Edge             | ⚠️ via non headless env | ✅              | ❌          | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon  | N/A                      | ⚠️ via Edge             | ⚠️ In graphical environments | ✅              | ❌          | ⚠️ `--domain` account filtering |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | ------------------------------------------ | ----------------------- | ------------- | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
 | OSX (MacOS)                                | ⚠️ via Web Browser      | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
-| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ✅            | ⚠️ `--domain` account filtering |
+| Ubuntu (linux) <br/>‼️Releases coming soon | ⚠️ via Edge             | ✅            | ✅               | ❎         | ⚠️ `--domain` account filtering |
 
 <br/>
 


### PR DESCRIPTION
Following updates are made:
1. AzureAuth currently doesn't support token caching in Linux environments. MSAL under the hood doesn't support token caching yet. Updating the README accordingly. 
2. On Ubuntu, the web auth flow requires a non-headless environment. Updated it.
3. Remove the reference to an archived MSAL extension repo.
4. Add IWA auth flow to the `platform X auth flow support` table.