### PR TITLE
Switch dependabot to use public nuget feed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,25 +10,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      # Allow updates for MSAL and any packages starting "Microsoft.Identity"
-      - dependency-name: "Microsoft.Identity.*"
-      - dependency-name: "Microsoft.Office.Lasso"
     groups:
-       # Combine MSAL packages to one Pull Request.
-       msal-dependencies:
-          patterns:
-            - "Microsoft.Identity.*"
+      # Combine MSAL packages to one Pull Request.
+      msal-dependencies:
+        patterns:
+          - "Microsoft.Identity.*"
     ignore:
-      - dependency-name: "Microsoft.Identity.*"
-        # For Microsoft.Identity.*, ignore all Dependabot updates for 16.0.*.*, which is an internal version and cannot be used.
-        versions: ["16.0.*.*"]
-    registries:
-      - nuget-azure-devops # Allow version updates for dependencies in this registry
-      
-registries:
-  nuget-azure-devops:
-    type: nuget-feed
-    url: https://office.pkgs.visualstudio.com/DefaultCollection/_packaging/Office/nuget/v3/index.json
-    username: office
-    password: ${{ secrets.ADO_TOKEN }}
+      - dependency-name: "Microsoft.Office.Lasso"


### PR DESCRIPTION
In an attempt to move towards secretless solutions for our release workflows, we need to get rid of our PATs. Dependabot unfortunately relies on PATs to access our internal nuget feed to keep Lasso up to date. However, this hasn't been workign since our PATs are long expired. And unfortunately, there doesn't seem to be a good way to substitute it with a procedurally generated AAD access token.

As such, we're experimenting with tapping into the public feed so that we may still keep our other nuget dependencies up to date. This does mean that we'll need to update Lasso ourselves.