### PR TITLE
Switch out PATs for AAD Tokens in "Build and Test" workflow

### DIFF
--- a/.github/actions/get-ado-token/action.yml
+++ b/.github/actions/get-ado-token/action.yml
@@ -1,0 +1,34 @@
+name: Get Azure DevOps Access Token
+inputs:
+  client-id:
+    description: "The client ID of the application calling Azure DevOps"
+    required: true
+  tenant-id:
+    description: "The tenant ID of the application calling Azure DevOps"
+    required: true
+  organization:
+    description: "The Azure DevOps organization to authenticate with"
+    required: true
+outputs:
+  token:
+    description: "The access token to authenticate with Azure DevOps"
+    value: ${{ steps.ADOAuth.outputs.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: OIDC Login with AzPowershell
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        allow-no-subscriptions: true
+        enable-AzPSSession: true
+    - id: ADOAuth
+      name: Get ADO Access Token
+      uses: azure/powershell@v1
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+          $accessToken = (Get-AzAccessToken -ResourceUrl "https://${{inputs.organization}}.visualstudio.com").Token
+          "token=$accessToken" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -44,7 +44,7 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     permissions:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -21,10 +23,18 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
+      - name: Get Azure DevOps Access Token
+        id: getToken
+        uses: "./.github/actions/get-ado-token"
+        with:
+          client-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_TENANT_ID }}
+          organization: ${{ secrets.ADO_ORGANIZATION }}
+
       - name: Restore dependencies
         run: dotnet restore
         env:
-          ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
+          ADO_TOKEN: ${{ steps.getToken.outputs.token }}
 
       - name: Build
         run: dotnet build --no-restore
@@ -34,20 +44,27 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
-      matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     permissions:
       actions: read
       contents: read
       security-events: write
       statuses: write
-      
+      id-token: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Get Azure DevOps Access Token
+      id: getToken
+      uses: "./.github/actions/get-ado-token"
+      with:
+        client-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_TENANT_ID }}
+        organization: ${{ secrets.ADO_ORGANIZATION }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -60,7 +77,7 @@ jobs:
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
       env:
-        ADO_TOKEN: ${{ secrets.ADO_TOKEN }}
+        ADO_TOKEN: ${{ steps.getToken.outputs.token }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
As the title says, this PR updates the Build and Test workflow to now dynamically retrieve an access token to pass into dotnet restore, as opposed to relying on a manually maintained PAT.

We also modified the CodeQL actions to only run on Windows since CodeQL interferes with other jobs using Azure Powershell on a Mac agent. Since CodeQL is really just a code inspection tool, there isn't really a need to run it on multiple OSes (Windows, Mac, Linux)