### PR TITLE
Remove Linux publishing jobs and its dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,59 +193,6 @@ jobs:
           name: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
           path: azureauth-${{ github.event.inputs.version }}-${{ matrix.runtime }}
 
-  # Build and sign Linux binaries on Azure DevOps and publish them to GitHub and packages.microsoft.com.
-  linux_release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    env:
-      ADO_LINUX_ARTIFACT_DOWNLOAD_PATH: dist/linux
-      ADO_LINUX_ARTIFACT_NAME: ${{ vars.ADO_LINUX_ARTIFACT_NAME }}
-      DEBIAN_REVISION: 1
-    permissions:
-      id-token: write
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Get Azure DevOps Access Token
-      id: getToken
-      uses: "./.github/actions/get-ado-token"
-      with:
-        client-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_RELEASE_WORKFLOW_TENANT_ID }}
-        organization: ${{ secrets.ADO_ORGANIZATION }}
-    - name: Build, Sign and Download Linux Binaries
-      run: |
-        pip install -r bin/requirements.txt
-        python ./bin/trigger_azure_pipelines.py
-      env:
-        AZURE_DEVOPS_ACCESS_TOKEN: ${{ steps.getToken.outputs.token }}
-        ADO_ORGANIZATION: ${{ secrets.ADO_ORGANIZATION }}
-        ADO_PROJECT: ${{ secrets.ADO_PROJECT}}
-        ADO_AZUREAUTH_LINUX_PIPELINE_ID: ${{ secrets.ADO_AZUREAUTH_LINUX_PIPELINE_ID }}
-        ADO_AZUREAUTH_LINUX_STAGE_ID: ${{ vars.ADO_AZUREAUTH_LINUX_STAGE_ID }}
-        VERSION: ${{ github.event.inputs.version }}
-
-    - name: Rename linux artifact
-      env:
-          DEB_AMD64_SOURCE: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_amd64.deb
-          DEB_AMD64_TARGET: azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-          DEB_ARM64_SOURCE: ${{ env.ADO_LINUX_ARTIFACT_DOWNLOAD_PATH }}/${{ env.ADO_LINUX_ARTIFACT_NAME }}/azureauth_${{ github.event.inputs.version }}-${{ env.DEBIAN_REVISION }}_arm64.deb
-          DEB_ARM64_TARGET: azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
-      run: |
-            mv ${{ env.DEB_AMD64_SOURCE }} ${{ env.DEB_AMD64_TARGET }}
-            mv ${{ env.DEB_ARM64_SOURCE }} ${{ env.DEB_ARM64_TARGET }}
-            
-    - name: Upload linux artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: azureauth-linux
-        path: |
-          azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-          azureauth-${{ github.event.inputs.version }}-linux-arm64.deb
 
   # Currently we package artifacts into the most commonly accessible archive format for their respective platforms.
   package:
@@ -288,7 +235,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [package, linux_release]
+    needs: [package]
     # The 'release' environment is what requires reviews before creating the release.
     environment:
       name: release
@@ -308,11 +255,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
-    - name: Download linux-x64 artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: azureauth-linux
-
+    
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -324,5 +267,3 @@ jobs:
           azureauth-${{ github.event.inputs.version }}-win10-x64.zip
           azureauth-${{ github.event.inputs.version }}-osx-x64.tar.gz
           azureauth-${{ github.event.inputs.version }}-osx-arm64.tar.gz
-          azureauth-${{ github.event.inputs.version }}-linux-x64.deb
-          azureauth-${{ github.event.inputs.version }}-linux-arm64.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Temporarily paused the publishing of Linux binaries.
 
 ## [0.8.6] - 2024-04-25
 ### Changed


### PR DESCRIPTION
Temporarily pause publishing Linux binaries until publishing tool supports arbitrary access tokens. 