### PR TITLE
Moving Release Workflow to Azure Pipelines

### DIFF
--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -79,7 +79,7 @@ extends:
             inputs:
               command: restore
               feedsToUse: select
-              vstsFeed: $(feedId)
+              vstsFeed: $(vstsFeedId)
               includeNuGetOrg: false
               arguments: '--runtime ${{ matrix.runtime }}'
 

--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -17,7 +17,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  template: v1/Office.Official.PipelineTemplate.yml@CustomPipelineTemplates
+  template: v1/Office.Unofficial.PipelineTemplate.yml@CustomPipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared

--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -1,0 +1,103 @@
+# This pipeline will be triggered when either main branch is pushed or 2AM on workdays.
+variables:
+- name: tags
+  value: "nonproduction"
+  readonly: true
+
+trigger:
+- main
+
+pr: none
+
+resources:
+  repositories:
+  - repository: CustomPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/Office.Official.PipelineTemplate.yml@CustomPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+    stages:
+    - stage: validate
+      displayName: Validate
+      jobs:
+        - job: validate
+          pool:
+            name: Azure-Pipelines-1ESPT-ExDShared
+            image: ubuntu-latest
+          displayName: Validate
+          steps:
+            - checkout: self
+            - task: Bash@3
+              inputs:
+                targetType: inline
+                script: |
+                  echo $(version) | python ./bin/version.py
+
+    - stage: build
+      displayName: Build
+      jobs:
+      - job: build
+        strategy:
+          matrix:
+            x64-windows:
+              poolName: Azure-Pipelines-1ESPT-ExDShared
+              image: 'windows-latest'
+              runtime: 'win10-x64'
+            x64-mac:
+              poolName: Azure Pipelines
+              image: 'macOS-latest'
+              runtime: 'osx-x64'
+            arm-mac:
+              poolName: Azure Pipelines
+              image: 'macOS-latest'
+              runtime: 'osx-arm64'
+        pool:
+          name: ${{ matrix.poolName }}
+          image: ${{ matrix.image }}
+        displayName: Build
+        steps:
+          - checkout: self
+          - task: UseDotNet@2
+            displayName: Use .NET Core sdk 6.x
+            inputs:
+              version: 6.x
+
+          - task: NuGetToolInstaller@0
+            displayName: Use NuGet 6.x
+            inputs:
+              versionSpec: 6.x
+
+          - task: DotNetCoreCLI@2
+            displayName: Install dependencies
+            inputs:
+              command: restore
+              feedsToUse: select
+              vstsFeed: $(feedId)
+              includeNuGetOrg: false
+              arguments: '--runtime ${{ matrix.runtime }}'
+
+          - task: DotNetCoreCLI@2
+            displayName: Test
+            inputs:
+              command: test
+              arguments: --configuration release
+          
+          - task: DotNetCoreCLI@2
+            displayName: Build artifacts
+            inputs:
+              command: publish
+              projects: 'src/AzureAuth/AzureAuth.csproj'
+              arguments: '-p:Version=$(version) --configuration release --self-contained true --runtime ${{ matrix.runtime }} --output dist/${{ matrix.runtime }}'
+
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            path: dist/${{ matrix.runtime }}
+            artifact: azureauth-$(version)-${{ matrix.runtime }}


### PR DESCRIPTION
The secure future initiative is making it increasingly difficult to continue supporting the build and release of "production" tools via GitHub Actions/Workflows. This appears to be because of the fact that GitHub itself is considered an untrusted "environment", especially from the perspective of our production tenants.

[This official Microsoft Open Source doc](https://docs.opensource.microsoft.com/security/azure/) explains those considerations in detail and are a good signal for us to move to Azure Pipelines.

This PR will be the first in a series designed to move us away from GitHub workflows to Azure Pipelines. It introduces a new pipeline that will live side-by-side with our existing workflow. This new pipeline will act as a testing ground for us, in which we'll iteratively port over steps from our workflow.

Unfortunately, as there is no way to test out these pipelines on a GitHub connected repo until they're merged into main, there will likely be many PRs introducing experimental changes to the pipeline.