### PR TITLE
Azure Pipeline: Specifying OS in the pool definition

### DIFF
--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -30,6 +30,7 @@ extends:
           pool:
             name: Azure-Pipelines-1ESPT-ExDShared
             image: ubuntu-latest
+            os: linux
           displayName: Validate
           steps:
             - checkout: self
@@ -47,19 +48,23 @@ extends:
           matrix:
             x64-windows:
               poolName: Azure-Pipelines-1ESPT-ExDShared
-              image: 'windows-latest'
-              runtime: 'win10-x64'
+              image: windows-latest
+              os: windows
+              runtime: win10-x64
             x64-mac:
               poolName: Azure Pipelines
-              image: 'macOS-latest'
-              runtime: 'osx-x64'
+              image: macOS-latest
+              os: macOS
+              runtime: osx-x64
             arm-mac:
               poolName: Azure Pipelines
-              image: 'macOS-latest'
-              runtime: 'osx-arm64'
+              image: macOS-latest
+              os: macOS
+              runtime: osx-arm64
         pool:
           name: $(poolName)
           image: $(image)
+          os: $(os)
         displayName: Build
         steps:
           - checkout: self

--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -85,7 +85,7 @@ extends:
               feedsToUse: select
               vstsFeed: $(vstsFeedId)
               includeNuGetOrg: false
-              arguments: '--runtime $(runtime)'
+              arguments: --runtime $(runtime)
 
           - task: DotNetCoreCLI@2
             displayName: Test
@@ -97,8 +97,8 @@ extends:
             displayName: Build artifacts
             inputs:
               command: publish
-              projects: 'src/AzureAuth/AzureAuth.csproj'
-              arguments: '-p:Version=$(version) --configuration release --self-contained true --runtime $(runtime) --output dist/$(runtime)'
+              projects: src/AzureAuth/AzureAuth.csproj
+              arguments: -p:Version=$(version) --configuration release --self-contained true --runtime $(runtime) --output dist/$(runtime)
 
         templateContext:
           outputs:


### PR DESCRIPTION
It is recommended that for pool definitions, you specify the OS on top of the image definition. This is especially true for jobs that specify pools that are different than the one provided to the pipeline template. Otherwise, this can lead to pipeline errors.

This PR specifies the OS input explicitly on all pool definitions. As a bonus, it also removes several unneeded quotes.