### PR TITLE
Update VS Services Client to latest version

### DIFF
--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -12,7 +12,7 @@
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.215.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 


### PR DESCRIPTION
We last updated the `Microsoft.VisualStudio.Services.Client` version more than year ago. We have received couple of bug reports in past few months where the client fails to fetch the list of active PATs for a user. For example see the below stack trace,
```
Microsoft.VisualStudio.Services.WebApi.VssHttpClientBase.HandleResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
at Microsoft.VisualStudio.Services.WebApi.VssHttpClientBase.SendAsync(HttpRequestMessage message, HttpCompletionOption completionOption, Object userState, CancellationToken cancellationToken)
at Microsoft.VisualStudio.Services.WebApi.VssHttpClientBase.SendAsync[T](HttpRequestMessage message, Object userState, CancellationToken cancellationToken)
at Microsoft.VisualStudio.Services.WebApi.VssHttpClientBase.SendAsync[T](HttpMethod method, IEnumerable`1 additionalHeaders, Guid locationId, Object routeValues, ApiResourceVersion version, HttpContent content, IEnumerable`1 queryParameters, Object userState, CancellationToken cancellationToken)
at Microsoft.Authentication.AdoPat.TokensHttpClientWrapper.ListPatsAsync(Nullable`1 displayFilterOption, Nullable`1 sortByOption, Nullable`1 isSortAscending, String continuationToken, Nullable`1 top, Object userState, CancellationToken cancellationToken) in D:\a\microsoft-authentication-cli\microsoft-authentication-cli\src\AdoPat\TokensHttpClientWrapper.cs:line 52
at Microsoft.Authentication.AdoPat.PatClient.ListActiveAsync(CancellationToken cancellationToken) in D:\a\microsoft-authentication-cli\microsoft-authentication-cli\src\AdoPat\PatClient.cs:line 75
```

We should first update our client to latest version so we can reach out to ADO team if the issue persists while using this new version.

## Testing
1. Publish new version locally.
2. Run all the `ado pat` commands with various scopes.
3. Delete cache and re -run pat commands.
4. Do the above for both mac and windows.