### PR TITLE
Azure Pipelines Release: Fixing Pool Definitions & Improving Pipeline Inputs

### DIFF
--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -1,4 +1,12 @@
 # This pipeline will be triggered manually.
+parameters:
+- name: version
+  type: string
+- name: prerelease
+  displayName: Prerelease?
+  type: boolean
+  default: true
+
 variables:
 - name: tags
   value: "nonproduction"
@@ -38,7 +46,7 @@ extends:
               inputs:
                 targetType: inline
                 script: |
-                  echo $(version) | python ./bin/version.py
+                  echo ${{ parameters.version }} | python ./bin/version.py
 
     - stage: build
       displayName: Build
@@ -98,10 +106,10 @@ extends:
             inputs:
               command: publish
               projects: src/AzureAuth/AzureAuth.csproj
-              arguments: -p:Version=$(version) --configuration release --self-contained true --runtime $(runtime) --output dist/$(runtime)
+              arguments: -p:Version=${{ parameters.version }} --configuration release --self-contained true --runtime $(runtime) --output dist/$(runtime)
 
         templateContext:
           outputs:
           - output: pipelineArtifact
             path: dist/$(runtime)
-            artifact: azureauth-$(version)-$(runtime)
+            artifact: azureauth-${{ parameters.version }}-$(runtime)

--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -1,115 +1,118 @@
 # This pipeline will be triggered manually.
 parameters:
-- name: version
-  type: string
-- name: prerelease
-  displayName: Prerelease?
-  type: boolean
-  default: true
-
-variables:
-- name: tags
-  value: "nonproduction"
-  readonly: true
-
-trigger: none
-
-pr: none
-
-resources:
-  repositories:
-  - repository: CustomPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/OfficePipelineTemplates
-    ref: refs/tags/release
-
-extends:
-  template: v1/Office.Unofficial.PipelineTemplate.yml@CustomPipelineTemplates
-  parameters:
-    pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-latest
-      os: windows
-    stages:
-    - stage: validate
-      displayName: Validate
-      jobs:
-        - job: validate
-          pool:
-            name: Azure-Pipelines-1ESPT-ExDShared
-            image: ubuntu-latest
-            os: linux
-          displayName: Validate
-          steps:
-            - checkout: self
-            - task: Bash@3
-              inputs:
-                targetType: inline
-                script: |
-                  echo ${{ parameters.version }} | python ./bin/version.py
-
-    - stage: build
-      displayName: Build
-      jobs:
-      - job: build
-        strategy:
-          matrix:
-            x64-windows:
-              poolName: Azure-Pipelines-1ESPT-ExDShared
-              image: windows-latest
-              os: windows
-              runtime: win10-x64
-            x64-mac:
-              poolName: Azure Pipelines
-              image: macOS-latest
-              os: macOS
-              runtime: osx-x64
-            arm-mac:
-              poolName: Azure Pipelines
-              image: macOS-latest
-              os: macOS
-              runtime: osx-arm64
-        pool:
-          name: $(poolName)
-          image: $(image)
-          os: $(os)
+  - name: version
+    type: string
+  - name: prerelease
+    displayName: Prerelease?
+    type: boolean
+    default: true
+  - name: buildConfigs
+    type: object
+    default:
+    - pool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-latest
+        os: windows
+      runtime: win10-x64
+    - pool:
+        name: Azure Pipelines
+        image: macOS-latest
+        os: macOS
+      runtime: osx-x64
+    - pool:
+        name: Azure Pipelines
+        image: macOS-latest
+        os: macOS
+      runtime: osx-arm64
+  
+  variables:
+  - name: tags
+    value: "nonproduction"
+    readonly: true
+  
+  trigger: none
+  
+  pr: none
+  
+  resources:
+    repositories:
+    - repository: CustomPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/OfficePipelineTemplates
+      ref: refs/tags/release
+  
+  extends:
+    template: v1/Office.Unofficial.PipelineTemplate.yml@CustomPipelineTemplates
+    parameters:
+      pool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: ubuntu-latest
+        os: linux
+      sdl:
+        sourceAnalysisPool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: windows-latest
+          os: windows
+      stages:
+      - stage: validate
+        displayName: Validate
+        jobs:
+          - job: validate
+            displayName: Validate
+            steps:
+              - checkout: self
+              - task: Bash@3
+                inputs:
+                  targetType: inline
+                  script: |
+                    echo ${{ parameters.version }} | python ./bin/version.py
+  
+      - stage: build
         displayName: Build
-        steps:
-          - checkout: self
-          - task: UseDotNet@2
-            displayName: Use .NET Core sdk 6.x
-            inputs:
-              version: 6.x
-
-          - task: NuGetToolInstaller@0
-            displayName: Use NuGet 6.x
-            inputs:
-              versionSpec: 6.x
-
-          - task: DotNetCoreCLI@2
-            displayName: Install dependencies
-            inputs:
-              command: restore
-              feedsToUse: select
-              vstsFeed: $(vstsFeedId)
-              includeNuGetOrg: false
-              arguments: --runtime $(runtime)
-
-          - task: DotNetCoreCLI@2
-            displayName: Test
-            inputs:
-              command: test
-              arguments: --configuration release
-          
-          - task: DotNetCoreCLI@2
-            displayName: Build artifacts
-            inputs:
-              command: publish
-              projects: src/AzureAuth/AzureAuth.csproj
-              arguments: -p:Version=${{ parameters.version }} --configuration release --self-contained true --runtime $(runtime) --output dist/$(runtime)
-
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            path: dist/$(runtime)
-            artifact: azureauth-${{ parameters.version }}-$(runtime)
+        jobs:
+        - ${{ each config in parameters.buildConfigs }}:
+          - job: build_${{ replace(config.runtime,'-', '_') }}
+            displayName: Building for ${{ config.runtime }} on ${{ config.pool.name }}
+            pool:
+              name: ${{ config.pool.name }}
+              image: ${{ config.pool.image }}
+              os: ${{ config.pool.os }}
+            steps:
+              - checkout: self
+              - task: UseDotNet@2
+                displayName: Use .NET Core sdk 6.x
+                inputs:
+                  version: 6.x
+  
+              - task: NuGetToolInstaller@0
+                displayName: Use NuGet 6.x
+                inputs:
+                  versionSpec: 6.x
+  
+              - task: DotNetCoreCLI@2
+                displayName: Install dependencies
+                inputs:
+                  command: restore
+                  feedsToUse: select
+                  vstsFeed: $(vstsFeedId)
+                  includeNuGetOrg: false
+                  arguments: --runtime ${{ config.runtime }}
+  
+              - task: DotNetCoreCLI@2
+                displayName: Test
+                inputs:
+                  command: test
+                  arguments: --configuration release
+              
+              - task: DotNetCoreCLI@2
+                displayName: Build artifacts
+                inputs:
+                  command: publish
+                  projects: src/AzureAuth/AzureAuth.csproj
+                  arguments: -p:Version=${{ parameters.version }} --configuration release --self-contained true --runtime ${{ config.runtime }} --output dist/${{ config.runtime }}
+  
+            templateContext:
+              outputs:
+              - output: pipelineArtifact
+                path: dist/${{ config.runtime }}
+                artifact: azureauth-${{ parameters.version }}-${{ config.runtime }}


### PR DESCRIPTION
My previous PRs unfortunately didn't work as expected, as I later found that pool OS needs to be specified at compile time for 1ES PT. As a result, the [recommended approach](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/faqs#can-i-use-pool-strategy-with-1es-pt) to target multiple OSes in your pipeline is to define your pool configurations as parameters. In doing so, windows and mac builds are able to run.

In addition to making this change, I also moved the definitions of "pre-release" and "version" to be pipeline parameters as opposed to variables. This presents itself better in the UI so that users who trigger the pipeline will be required to provide those inputs.