### PR TITLE
Reclassify CG pipeline as production

### DIFF
--- a/.github/workflows/azure-devops-pipelines-cg.yml
+++ b/.github/workflows/azure-devops-pipelines-cg.yml
@@ -1,7 +1,7 @@
 # This pipeline will be triggered when either main branch is pushed or 2AM on workdays.
 variables:
   - name: tags
-    value: "nonproduction"
+    value: "production"
     readonly: true
 trigger:
   branches:

--- a/.github/workflows/azure-devops-pipelines-cg.yml
+++ b/.github/workflows/azure-devops-pipelines-cg.yml
@@ -20,7 +20,7 @@ resources:
     name: 1ESPipelineTemplates/OfficePipelineTemplates
     ref: refs/tags/release
 extends:
-  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
+  template: v1/Office.Official.PipelineTemplate.yml@CustomPipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared

--- a/.github/workflows/azure-devops-pipelines-cg.yml
+++ b/.github/workflows/azure-devops-pipelines-cg.yml
@@ -20,7 +20,7 @@ resources:
     name: 1ESPipelineTemplates/OfficePipelineTemplates
     ref: refs/tags/release
 extends:
-  template: v1/Office.Unofficial.PipelineTemplate.yml@CustomPipelineTemplates
+  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared


### PR DESCRIPTION
All the CG alerts go to this [non-production/stale](https://office.visualstudio.com/OE/_componentGovernance/211270?_a=alerts&typeId=15037342&alerts-view-option=active) when CG pipeline is unproduction,

we want those CG alerts go to `production` tab so that we wont miss them. So reclassify CG pipeline as production

