### PR TITLE
Upgrade MSAL dependencies to 4.61.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
+- Upgrade MSAL from `4.59.1` to `4.61.3`.
 
 ## [0.8.6] - 2024-04-25
 ### Changed

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -11,7 +11,7 @@
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>

--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Identity.Client;
     using Microsoft.Identity.Client.Broker;
-    using Microsoft.Identity.Client.Desktop;
     using Microsoft.Extensions.Logging;
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
     using BenchmarkDotNet.Running;
@@ -88,6 +87,8 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
                     enablePiiLogging: false,
                     enableDefaultPlatformLogging: true)
 ;
+            clientBuilder.WithBroker(clientBuilder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+            /*
             if (useNativeBroker)
             {
                 BrokerExtension.WithBroker(clientBuilder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
@@ -96,7 +97,7 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
             {
                 clientBuilder.WithWindowsEmbeddedBrowserSupport();
             }
-
+            */
             return new PCAWrapper(logger, clientBuilder.Build(), errors, tenantId);
         }
         private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)

--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
         public void WarmUp()
         {
             NativeBrokerBenchmark();
-            ManagedBrokerBenchmark();
         }
 
         /// <summary>
@@ -53,27 +52,14 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
         [Benchmark]
         public void NativeBrokerBenchmark()
         {
-            var pcaWrapper = BuildPCAWrapper(this.logger, this.clientID, this.tenantID, true);
+            var pcaWrapper = BuildPCAWrapper(this.logger, this.clientID, this.tenantID);
             AuthParameters authParameters = new AuthParameters(this.clientID, this.tenantID, this.scopes);
             Broker broker = new Broker(this.logger, authParameters, pcaWrapper: pcaWrapper);
 
             broker.GetTokenAsync().Wait();
         }
 
-        /// <summary>
-        /// Benchmark with .Net managed broker.
-        /// </summary>
-        [Benchmark]
-        public void ManagedBrokerBenchmark()
-        {
-            var pcaWrapper = BuildPCAWrapper(this.logger, this.clientID, this.tenantID, false);
-            AuthParameters authParameters = new AuthParameters(this.clientID, this.tenantID, this.scopes);
-            Broker broker = new Broker(this.logger, authParameters, pcaWrapper: pcaWrapper);
-
-            broker.GetTokenAsync().Wait();
-        }
-
-        private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId, bool useNativeBroker)
+        private IPCAWrapper BuildPCAWrapper(ILogger logger, Guid clientId, Guid tenantId)
         {
             IList<Exception> errors = new List<Exception>();
 

--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
                     enablePiiLogging: false,
                     enableDefaultPlatformLogging: true)
 ;
-            clientBuilder.WithBroker(clientBuilder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+            clientBuilder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
             /*
             if (useNativeBroker)
             {

--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Identity.Client;
     using Microsoft.Identity.Client.Broker;
+    using Microsoft.Identity.Client.Desktop;
     using Microsoft.Extensions.Logging;
     using Microsoft.Authentication.MSALWrapper.AuthFlow;
     using BenchmarkDotNet.Running;
@@ -89,11 +90,11 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
 ;
             if (useNativeBroker)
             {
-                clientBuilder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+                BrokerExtension.WithBroker(clientBuilder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
             }
             else
             {
-                clientBuilder.WithBroker();
+                clientBuilder.WithWindowsEmbeddedBrowserSupport();
             }
 
             return new PCAWrapper(logger, clientBuilder.Build(), errors, tenantId);

--- a/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
+++ b/src/MSALWrapper.Benchmark/BrokerBenchmark.cs
@@ -88,16 +88,7 @@ namespace Microsoft.Authentication.MSALWrapper.Benchmark
                     enableDefaultPlatformLogging: true)
 ;
             clientBuilder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
-            /*
-            if (useNativeBroker)
-            {
-                BrokerExtension.WithBroker(clientBuilder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
-            }
-            else
-            {
-                clientBuilder.WithWindowsEmbeddedBrowserSupport();
-            }
-            */
+
             return new PCAWrapper(logger, clientBuilder.Build(), errors, tenantId);
         }
         private void LogMSAL(Identity.Client.LogLevel level, string message, bool containsPii)

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -21,7 +21,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.59.1" />
+        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
+        <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.61.3" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
@@ -31,7 +32,7 @@
         <!--Windows: Explicitly continue using the net5 version of MSAL since there is no net6 target yet 
          https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3682-->
         <PackageReference Include="Microsoft.Identity.Client" GeneratePathProperty="true">
-            <Version>4.59.1</Version>
+            <Version>4.61.3</Version>
         </PackageReference>
 
         <Reference Include="Microsoft.Identity.Client">
@@ -41,6 +42,6 @@
     
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.59.1" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     </ItemGroup>
 </Project>

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -22,7 +22,7 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
         <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
-        <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.61.3" />
+
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -22,7 +22,6 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
         <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
-
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.59.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.59.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
 
   </ItemGroup>
 


### PR DESCRIPTION
## Changes:

1.  Upgrading MSAL version to `4.61.3`
2. Starting from MSAL version `4.61.0`, usage of `WithBroker` method with no parameter is deprecated, so the method [` clientBuilder.WithBroker();`](https://github.com/AzureAD/microsoft-authentication-cli/blob/7ae2857d79b7859990f0b34ba3ad606ce93876c9/src/MSALWrapper.Benchmark/BrokerBenchmark.cs#L96) used in `BrokerBenchmark` class becomes obsolete. 

      According to the [release log](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.61.0), the alternative to that is to 
reference `Microsoft.Identity.Client.Desktop` when [authenticating with browser](https://aka.ms/msal-net-uses-web-browser) and call `WithWindowsEmbeddedBrowserSupport()`.  
      
     I tried that, but looks like `Microsoft.Identity.Client.Desktop` only support Windows platform, it does not support macos and ubuntu platforms, so the  [`Build and Test`](https://github.com/AzureAD/microsoft-authentication-cli/actions/runs/10495034169/job/29072621189)  failed for those 2 platforms from my earlier commits .  

      Also currently in `Broker` class, we are explicitly only using [`interactive authentication with Windows Broker`](https://github.com/AzureAD/microsoft-authentication-cli/blob/7ae2857d79b7859990f0b34ba3ad606ce93876c9/src/MSALWrapper/AuthFlow/Broker.cs#L160), so the else block (which is used for `ManagedBrokerBenchmark `) in `BrokerBenchmark` class seems unnecessary. So i decided to just remove the else block.


## Testing

### Benchmark test

`4.61.3`

```

BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.4037)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
.NET SDK=8.0.304
  [Host]     : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
```


|                Method |     Mean |    Error |   StdDev |
|---------------------- |---------:|---------:|---------:|
| NativeBrokerBenchmark | 42.02 ms | 0.329 ms | 0.275 ms |


`4.59.1`

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.4037)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
.NET SDK=8.0.304
  [Host]     : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.33 (6.0.3324.36610), X64 RyuJIT AVX2
```

|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
|  NativeBrokerBenchmark | 44.16 ms | 0.149 ms | 0.132 ms |



### Other

Tested following commands on both mac and windows:
```
azureauth --help
azureauth aad --help
azureauth ado pat --help
azureauth ado token --help
azureauth ado pat scopes --help
azureauth info --help
azureauth ado token
azureauth ado pat
azureauth aad (with different output and auth modes)
```


