### PR TITLE
Update dotnet path in mac publish script

### DIFF
--- a/bin/mac/publish
+++ b/bin/mac/publish
@@ -42,4 +42,4 @@ esac
 #------------------------------------------
 
 # Publish
-dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -r "$runtime" -c release -o $DIST $*
+$GIT_DIR/bin/mac/dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -r "$runtime" -c release -o $DIST $*


### PR DESCRIPTION

The command `./bin/mac/publish` would throw error when i run it at the top level of the folder, for example `/Users/keyuxuan/microsoft-authentication-cli`. The reason is that its using the globally installed `dotnet` instead of the [`dotnet`](https://github.com/AzureAD/microsoft-authentication-cli/blob/main/bin/mac/dotnet) under `bin/mac` folder.

Updating the dotnet to use the absolute path in mac publish script 