### PR TITLE
Bump System.Formats.Asn1 from version 6.0.0 to 6.0.1

### DIFF
--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+      
+    <!-- Transitive dependency of Microsoft.VisualStudio.Services.Client temporarily pinned for security reasons. -->
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Authentication.AdoPat</RootNamespace>
   </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
System.Formats.Asn1 is a transitive dependency of Microsoft.VisualStudio.Services.Client in the AdoPat project. Unfortunately, the latest stable version of Microsoft.VisualStudio.Services.Client does not upgrade System.Formats.Asn1 to a patched version. As such, I've manually pinned the version of System.Formats.Asn1 to 6.0.1

I've tested generating a PAT and OAuth access token using the "ado pat" and "ado token" subcommands on my Windows machine. They both work as expected.