### PR TITLE
Bumping System.Security.Cryptography.Xml from 5.0.0 to 6.0.1

### DIFF
--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -15,8 +15,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
       
-    <!-- Transitive dependency of Microsoft.VisualStudio.Services.Client temporarily pinned for security reasons. -->
+    <!-- Transitive dependencies of Microsoft.VisualStudio.Services.Client temporarily pinned for security reasons. -->
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
System.Security.Cryptography.Xml is a transitive dependency of Microsoft.VisualStudio.Services.Client in the AdoPat project. Unfortunately, the latest stable version of Microsoft.VisualStudio.Services.Client does not upgrade System.Security.Cryptography.Xml to a patched version. As such, I've manually pinned the version of System.Security.Cryptography.Xml to 6.0.1

I've tested generating a PAT and OAuth access token using the "ado pat" and "ado token" subcommands on my Windows machine. They both work as expected.