### PR TITLE
Configure Dependabot to use public Nuget registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 # Set update schedule for GitHub Actions
 version: 2
+registries:
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -8,6 +12,7 @@ updates:
       interval: "weekly"
   - package-ecosystem: "nuget"
     directory: "/"
+    registries: "*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
In an attempt to get continuous version and security updates from dependabot, I want to experiment with having it explicitly target the public nuget feed.

Because our nuget.config file points to a private nuget registry, dependabot is unable to successfully run against our Nuget packages. This is visible through the most recent dependabot update logs: https://github.com/AzureAD/microsoft-authentication-cli/network/updates/875662189.

You can configure dependabot.yml with credentials to access a private registry, but you need to provide it with a static token defined in the repo secrets. Since long-lived PATs are being phased out as part of SFI, we're unable to do so. Dependabot also does not have a way to programmatically retrieve a short-lived OAuth token.

My thinking is that if you can configure dependabot to point to a private registry, perhaps we can configure it to point to the public nuget registry?

I have not found a way to test dependabot against a non-default branch, so my current plan is to experiment with it in main and see if it works. If it doesn't work as expected, I'll be making subsequent PRs to either patch it some more or revert the change.