### PR TITLE
Revert "Configure Dependabot to use public Nuget registry"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 # Set update schedule for GitHub Actions
 version: 2
-registries:
-  public-nuget:
-    type: nuget-feed
-    url: https://api.nuget.org/v3/index.json
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -12,7 +8,6 @@ updates:
       interval: "weekly"
   - package-ecosystem: "nuget"
     directory: "/"
-    registries: "*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-cli#404

Unfortunately, this didn't end up working. Dependabot still tries to use the private feed.