### PR TITLE
Bump Lasso dependency from 2024.8.24.1 to 2024.10.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
 - Upgrade MSAL from `4.59.1` to `4.61.3`.
+- Upgrade Lasso from `2024.8.24.1` to `2024.10.14.1`.
 
 ## [0.8.6] - 2024-04-25
 ### Changed

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2023.8.24.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2024.10.14.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
There is a new version of Lasso available that we can upgrade to.