### PR TITLE
Update AzureAuth to .NET 8 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade MSAL from `4.59.1` to `4.61.3`.
 - Upgrade Lasso from `2024.8.24.1` to `2024.10.23.1`.
 - Upgrade from .NET 6 to .NET 8.
+- Disable trimmed version when publishing AzureAuth.
 
 ## [0.8.6] - 2024-04-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
 - Upgrade MSAL from `4.59.1` to `4.61.3`.
-- Upgrade Lasso from `2024.8.24.1` to `2024.10.14.1`.
+- Upgrade Lasso from `2024.8.24.1` to `2024.10.23.1`.
+- Upgrade from .NET 6 to .NET 8.
 
 ## [0.8.6] - 2024-04-25
 ### Changed

--- a/bin/mac/publish
+++ b/bin/mac/publish
@@ -42,4 +42,4 @@ esac
 #------------------------------------------
 
 # Publish
-$GIT_DIR/bin/mac/dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -r "$runtime" -c release -o $DIST $*
+$GIT_DIR/bin/mac/dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -p:PublishTrimmed=false -r "$runtime" -c release -o $DIST $*

--- a/bin/mac/publish
+++ b/bin/mac/publish
@@ -42,4 +42,4 @@ esac
 #------------------------------------------
 
 # Publish
-$GIT_DIR/bin/mac/dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -p:PublishTrimmed=false -r "$runtime" -c release -o $DIST $*
+$GIT_DIR/bin/mac/dotnet publish "$GIT_DIR/src/AzureAuth/AzureAuth.csproj" --self-contained true -r "$runtime" -c release -o $DIST $*

--- a/bin/win/publish.cmd
+++ b/bin/win/publish.cmd
@@ -9,4 +9,4 @@ if exist %~dp0\dist (
 )
 
 
-CALL %~dp0\dotnet.cmd publish %~dp0\..\..\src\AzureAuth\AzureAuth.csproj --self-contained true -p:PublishTrimmed=false -r win-x64 -c release -o %~dp0\..\..\dist %*
+CALL %~dp0\dotnet.cmd publish %~dp0\..\..\src\AzureAuth\AzureAuth.csproj --self-contained true -r win-x64 -c release -o %~dp0\..\..\dist %*

--- a/bin/win/publish.cmd
+++ b/bin/win/publish.cmd
@@ -8,4 +8,5 @@ if exist %~dp0\dist (
     rmdir /S /Q %~dp0\dist
 )
 
-CALL %~dp0\dotnet.cmd publish %~dp0\..\..\src\AzureAuth\AzureAuth.csproj --self-contained true -r win10-x64 -c release -o %~dp0\..\..\dist %*
+
+CALL %~dp0\dotnet.cmd publish %~dp0\..\..\src\AzureAuth\AzureAuth.csproj --self-contained true -p:PublishTrimmed=false -r win-x64 -c release -o %~dp0\..\..\dist %*

--- a/src/AdoPat.Test/AdoPat.Test.csproj
+++ b/src/AdoPat.Test/AdoPat.Test.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <!-- Stylecop warnings as errors flag for build to fail -->
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
-      <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
-      <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
+    <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
@@ -24,10 +19,8 @@
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
     <ProjectReference Include="..\AdoPat\AdoPat.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -1,23 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageId>Microsoft.Authentication.AdoPat</PackageId>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.Authentication.AdoPat</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-      
     <!-- Transitive dependencies of Microsoft.VisualStudio.Services.Client temporarily pinned for security reasons. -->
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
   </ItemGroup>
-
 </Project>

--- a/src/AzureAuth.Test/AzureAuth.Test.csproj
+++ b/src/AzureAuth.Test/AzureAuth.Test.csproj
@@ -1,22 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <PackageId>Microsoft.Authentication.AzureAuth.Test</PackageId>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
-      <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
-      <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
+    <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
@@ -26,10 +22,8 @@
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="7.0.7" />
     <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\AzureAuth\AzureAuth.csproj" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='release'">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/AzureAuth/AzureAuth.csproj
+++ b/src/AzureAuth/AzureAuth.csproj
@@ -1,47 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
-
-<!-- Release configuration -->
+  <!-- Release configuration -->
   <PropertyGroup Condition="'$(Configuration)'=='release'">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- Output an executable -->
     <PackageId>microsoft.authentication.azureauth</PackageId>
     <OutputType>Exe</OutputType>
     <AssemblyName>azureauth</AssemblyName>
     <RootNamespace>Microsoft.Authentication.AzureAuth</RootNamespace>
-
     <NuspecFile>AzureAuth.nuspec</NuspecFile>
     <NuspecProperties>$(NuspecProperties);Configuration=$(Configuration);Version=$(Version)$(VersionSuffix)</NuspecProperties>
-
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Office.Lasso" Version="2024.10.14.1" />
+    <PackageReference Include="Microsoft.Office.Lasso" Version="2024.10.23.1" />
     <PackageReference Include="Tomlyn" Version="0.11.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
     <ProjectReference Include="..\AdoPat\AdoPat.csproj" />
   </ItemGroup>
-
   <!-- Assemblies we need to manually mark as roots so they are not trimmed. -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <!-- Needed for Web mode on Windows -->

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
@@ -32,6 +32,6 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
+     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
   </ItemGroup>
 </Project>

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -1,46 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-        <DefineConstants>PlatformWindows</DefineConstants>
-        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <RootNamespace>Microsoft.Authentication.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
-    </ItemGroup>
-
-    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <!--Windows: Explicitly continue using the net5 version of MSAL since there is no net6 target yet 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net8.0</TargetFramework>
+    <DefineConstants>PlatformWindows</DefineConstants>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Microsoft.Authentication.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <!--Windows: Explicitly continue using the net5 version of MSAL since there is no net6 target yet 
          https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3682-->
-        <PackageReference Include="Microsoft.Identity.Client" GeneratePathProperty="true">
-            <Version>4.61.3</Version>
-        </PackageReference>
-
-        <Reference Include="Microsoft.Identity.Client">
-            <HintPath>$(PkgPMicrosoft_Identity_Client)\lib\net5.0-windows10.0.17763\Microsoft.Identity.Client.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    
-    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
+    <Reference Include="Microsoft.Identity.Client">
+      <HintPath>$(PkgPMicrosoft_Identity_Client)\lib\net5.0-windows10.0.17763\Microsoft.Identity.Client.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    </ItemGroup>
+     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
+  </ItemGroup>
 </Project>

--- a/src/MSALWrapper.Test/MSALWrapper.Test.csproj
+++ b/src/MSALWrapper.Test/MSALWrapper.Test.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Authentication.MSALWrapper.Test</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <Compile Include="..\stylecop\GlobalSuppressions.Test.cs" Link="GlobalSuppressions.Test.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
@@ -20,14 +17,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
-
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -1,40 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <!-- Package Naming, Building, & Versioning -->
     <PackageId>Microsoft.Authentication.MSALWrapper</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Authentication.MSALWrapper</RootNamespace>
-
     <PackageOutputPath>../</PackageOutputPath>
-
     <!-- Human Metadata -->
     <Title>Microsoft Authentication MSAL Wrapper</Title>
     <RepositoryUrl>https://github.com/AzureAD/microsoft-authentication-cli</RepositoryUrl>
     <Description>A library for quickly authenticating with various Azure resources</Description>
     <PackageTags>MSAL;authentication</PackageTags>
-
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
-
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>PlatformWindows</DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Stylecop required items -->
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-
   </ItemGroup>
-
 </Project>

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -1,13 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.3" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Changes:
This PR is to update AzureAuth to .NET 8 version. I made these changes via the [.NET Upgrade Assistant](https://dotnet.microsoft.com/en-us/platform/upgrade-assistant)  in Visual Studio 2022, which takes care of updating code and breaking changes if need be.

During testing, we also found out that currently AzureAuth is enabled with trimming, and we have always published the trimmed version of AzureAuth in the past. However, Lasso is not enabled with trimming, nor its dependency McMaster CommandLineUtils. Updating AzureAuth to .NET 8 makes it incompatible with Lasso and CommandLineUtils. So in order to finish updating version for now, we decide to disable trimming in AzureAuth. 

Also updated CHANGELOG to reflect all the changes. 

## Testing
Tested following commands on both mac and windows:
```
azureauth --help
azureauth aad --help
azureauth ado pat --help
azureauth ado token --help
azureauth ado pat scopes --help
azureauth info --help
azureauth ado token
azureauth ado pat
azureauth aad (with different output and auth modes)
```
