### PR TITLE
Update MSAL to 4.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
-- Upgrade MSAL from `4.59.1` to `4.61.3`.
+- Upgrade MSAL from `4.59.1` to `4.65.0`.
 - Upgrade Lasso from `2024.8.24.1` to `2024.10.14.1`.
 
 ## [0.8.6] - 2024-04-25

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -11,7 +11,7 @@
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
       

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
+        <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
@@ -31,7 +31,7 @@
         <!--Windows: Explicitly continue using the net5 version of MSAL since there is no net6 target yet 
          https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3682-->
         <PackageReference Include="Microsoft.Identity.Client" GeneratePathProperty="true">
-            <Version>4.61.3</Version>
+            <Version>4.65.0</Version>
         </PackageReference>
 
         <Reference Include="Microsoft.Identity.Client">
@@ -41,6 +41,6 @@
     
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
     </ItemGroup>
 </Project>

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.61.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
 
   </ItemGroup>
 


### PR DESCRIPTION
`MSAL < 4.64.0` has issues with authentication while using broker. Refer https://github.com/git-ecosystem/git-credential-manager/issues/1617#issuecomment-2332911393.

We plan to release new AzureAuth version soon, so it's good to get to the latest stable version.




# Testing

## Benchmarking
```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.26100.2033)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.403
  [Host]     : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2


|                Method |     Mean |    Error |   StdDev |
|---------------------- |---------:|---------:|---------:|
| NativeBrokerBenchmark | 46.18 ms | 0.437 ms | 0.408 ms |

```

## Other

```
azureauth --help
azureauth aad --help
azureauth ado pat --help
azureauth ado token --help
azureauth ado pat scopes --help
azureauth info --help
azureauth ado token
azureauth ado pat
azureauth aad (with different output and auth modes)
```