### PR TITLE
Remove IWA from default auth modes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Removed
-- IWA from default authentcation modes.
+- Removed IWA from default authentcation mode.
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
 - Upgrade MSAL from `4.59.1` to `4.65.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- IWA from default authentcation modes.
 ### Changed
 - Temporarily paused the publishing of Linux binaries.
 - Upgrade MSAL from `4.59.1` to `4.65.0`.

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -38,7 +38,7 @@ namespace AzureAuth.Test
             this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
             this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(string.Empty);
 
-            var subject = new[] { AuthMode.IWA, AuthMode.Web, AuthMode.Broker };
+            var subject = new[] { AuthMode.Web, AuthMode.Broker };
 
             // Act + Assert
             subject.Combine().PreventInteractionIfNeeded(this.envMock.Object, this.logger).Should().Be(AuthMode.Default);

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// </summary>
 #if PlatformWindows
         public const string AuthModeHelperText = @"Authentication mode. Repeated invocations allowed.
-[default: iwa (Integrated Windows Auth), then broker, then web]
+[default: broker, then web]
 [possible values: all, iwa, broker, web, devicecode]";
 #else
         public const string AuthModeHelperText = @"Authentication mode. Repeated invocations allowed. [default: web]

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -111,27 +111,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void Windows10Or11_Defaults()
         {
-            this.MockIsWindows(true);
             this.MockIsWindows10Or11(true);
-
-            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
-
-            subject.Should().HaveCount(4);
-            subject
-                .Select(a => a.GetType())
-                .Should()
-                .ContainInOrder(
-                    typeof(CachedAuth),
-                    typeof(IntegratedWindowsAuthentication),
-                    typeof(Broker),
-                    typeof(Web));
-        }
-
-        [Test]
-        public void Windows_Defaults()
-        {
-            this.MockIsWindows(true);
-            this.MockIsWindows10Or11(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
@@ -141,7 +121,23 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Should()
                 .ContainInOrder(
                     typeof(CachedAuth),
-                    typeof(IntegratedWindowsAuthentication),
+                    typeof(Broker),
+                    typeof(Web));
+        }
+
+        [Test]
+        public void Windows_Defaults()
+        {
+            this.MockIsWindows10Or11(false);
+
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
+
+            subject.Should().HaveCount(2);
+            subject
+                .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
                     typeof(Web));
         }
 
@@ -159,7 +155,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Should()
                 .ContainInOrder(
                     typeof(CachedAuth),
-                    typeof(IntegratedWindowsAuthentication),
                     typeof(Broker),
                     typeof(Web),
                     typeof(DeviceCode));

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             subject.IsWeb().Should().BeTrue();
             subject.IsIWA().Should().BeFalse();
             subject.IsDeviceCode().Should().BeFalse();
-            
-
         }
 
         [TestCase(AuthMode.All, true)]

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -22,10 +22,12 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void WindowsDefaultModes()
         {
             var subject = AuthMode.Default;
-            subject.IsIWA().Should().BeTrue();
             subject.IsBroker().Should().BeTrue();
             subject.IsWeb().Should().BeTrue();
+            subject.IsIWA().Should().BeFalse();
             subject.IsDeviceCode().Should().BeFalse();
+            
+
         }
 
         [TestCase(AuthMode.All, true)]

--- a/src/MSALWrapper/AuthMode.cs
+++ b/src/MSALWrapper/AuthMode.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Authentication.MSALWrapper
         /// <summary>
         /// Default auth mode.
         /// </summary>
-        Default = IWA | Broker | Web,
+        Default = Broker | Web,
 #else
         /// <summary>
         /// All auth modes.


### PR DESCRIPTION
## Testing
Ran below commands with `--verbosity debug` and specifying no modes option (default modes)
```
azureauth ado pat
azureauth aad
azureauth ado token
```

Output

```
2024-11-07 17:50:11.0789 | DEBUG | logger: AzureAuth | Starting CachedAuth...
2024-11-07 17:50:11.0965 | DEBUG | logger: AzureAuth | Accounts found in cache: (0):
2024-11-07 17:50:11.0965 | DEBUG | logger: AzureAuth |
2024-11-07 17:50:11.1101 | DEBUG | logger: AzureAuth | Filtering cached accounts with preferred domain 'microsoft.com'
2024-11-07 17:50:11.1101 | DEBUG | logger: AzureAuth | Accounts found in cache after filtering: (0):
2024-11-07 17:50:11.1101 | DEBUG | logger: AzureAuth |
2024-11-07 17:50:11.1101 | DEBUG | logger: AzureAuth | No cached account
2024-11-07 17:50:11.1101 | DEBUG | logger: AzureAuth | Starting Broker...
2024-11-07 17:50:11.1307 | DEBUG | logger: AzureAuth | Accounts found in cache: (1):
2024-11-07 17:50:11.1307 | DEBUG | logger: AzureAuth | <user>@microsoft.com
2024-11-07 17:50:11.1307 | DEBUG | logger: AzureAuth | Filtering cached accounts with preferred domain 'microsoft.com'
2024-11-07 17:50:11.1307 | DEBUG | logger: AzureAuth | Accounts found in cache after filtering: (1):
2024-11-07 17:50:11.1307 | DEBUG | logger: AzureAuth | <user>@microsoft.com
2024-11-07 17:50:11.1392 | DEBUG | logger: AzureAuth | Using cached account '<user>@microsoft.com'
2024-11-07 17:50:11.5928 | DEBUG | logger: AzureAuth | Broker success: True.
```


With
`$env:Corext_NonInteractive=1`

```
❯ .\azureauth.exe aad --alias ado --verbosity debug
2024-11-07 18:01:10.5158 | DEBUG | logger: Microsoft.Office.Lasso.LassoMcMaster | Log file: ...\azureauth.2024_11_07_18_01_10.13000.log.json
2024-11-07 18:01:10.5158 | DEBUG | logger: Microsoft.Office.Lasso.LassoMcMaster | CommandLineArgs: aad --alias ado --verbosity debug
2024-11-07 18:01:10.5328 | WARN | logger: AzureAuth | Interactive authentication is disabled.
2024-11-07 18:01:10.5328 | WARN | logger: AzureAuth | Only Integrated Windows Authentication will be attempted.
2024-11-07 18:01:10.5743 | DEBUG | logger: AzureAuth | Starting CachedAuth...
2024-11-07 18:01:10.5917 | DEBUG | logger: AzureAuth | Accounts found in cache: (0):
2024-11-07 18:01:10.5917 | DEBUG | logger: AzureAuth |
2024-11-07 18:01:10.5917 | DEBUG | logger: AzureAuth | No cached account
2024-11-07 18:01:10.5917 | DEBUG | logger: AzureAuth | Starting IntegratedWindowsAuthentication...
2024-11-07 18:01:11.4495 | DEBUG | logger: AzureAuth | IWA only works on corporate AD backed network, AzureAuth is trying to use other auth flows if applicable.
2024-11-07 18:01:11.4495 | DEBUG | logger: AzureAuth | Turn on VPN for IWA mode to succeed.
2024-11-07 18:01:11.4495 | DEBUG | logger: AzureAuth | Exception caught during iwa token acquisition
2024-11-07 18:01:11.4495 | DEBUG | logger: AzureAuth | There was an error parsing the WS-Trust response from the endpoint.
This may occur if there are issues with your ADFS configuration. See https://aka.ms/msal-net-iwa-troubleshooting for more details.
```