### PR TITLE
Ignore CachedAuth if Broker is present in AuthMode on win 10 or 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed ChachedAuth mode if Broker is already present in auth modes on windows 10 or 11 since Broker already tries CachedAuth in a compliant way.
 
 ## [0.9.0] - 2024-11-07
 ### Removed

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -101,11 +101,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Broker);
 
-            subject.Should().HaveCount(2);
+            subject.Should().HaveCount(1);
             subject
                 .Select(a => a.GetType())
                 .Should()
-                .ContainInOrder(typeof(CachedAuth), typeof(Broker));
+                .Contain(typeof(Broker));
         }
 
         [Test]
@@ -115,12 +115,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
-            subject.Should().HaveCount(3);
+            subject.Should().HaveCount(2);
             subject
                 .Select(a => a.GetType())
                 .Should()
                 .ContainInOrder(
-                    typeof(CachedAuth),
                     typeof(Broker),
                     typeof(Web));
         }
@@ -149,12 +148,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
-            subject.Should().HaveCount(5);
+            subject.Should().HaveCount(4);
             subject
                 .Select(a => a.GetType())
                 .Should()
                 .ContainInOrder(
-                    typeof(CachedAuth),
                     typeof(Broker),
                     typeof(Web),
                     typeof(DeviceCode));
@@ -228,13 +226,12 @@ namespace Microsoft.Authentication.MSALWrapper.Test
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
-            subject.Should().HaveCount(5);
+            subject.Should().HaveCount(4);
             subject
                 .Select(flow => flow.GetType())
                 .Should()
                 .BeEquivalentTo(new[]
                 {
-                    typeof(CachedAuth),
                     typeof(IntegratedWindowsAuthentication),
                     typeof(Broker),
                     typeof(Web),

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -37,11 +37,14 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             // This is a list. The order in which flows get added is very important
             // as it sets the order in which auth flows will be attempted.
-            List<IAuthFlow> flows = new List<IAuthFlow>
+            List<IAuthFlow> flows = new List<IAuthFlow>();
+
+            // We skip CachedAuth if Broker is present in authMode on windows 10 or 11, since Broker 
+            // already tries CachedAuth with its PCAWrapper object built using withBroker(options).
+            if (!(authMode.IsBroker() && platformUtils.IsWindows10Or11()))
             {
-                // We always try cached auth first.
-                new CachedAuth(logger, authParams, preferredDomain, pcaWrapper),
-            };
+                flows.Add(new CachedAuth(logger, authParams, preferredDomain, pcaWrapper));
+            }
 
             // We try IWA as the first auth flow as it works for any Windows version
             // and tries to auth silently.


### PR DESCRIPTION
## Investigation findings:

1. Cached auth = publicClientApp.getTokenSilentAsync(....), which means it calls `getTokenSilent()` method of PCA class and the way silent Auth is performed when calling this method depends on the way each AuthFlow builds and passes its own PCA wrapper object.
2. CachedAuth (which is always added by default ) builds PCAWrapper without Broker configs. This when it is used to call the `getTokenSilent` method, detects windows platform, and makes the call non-compliant when the RT expires/some conditions change because it needs to fetch new RT (and thus API call). 
3. Broker builds the PCAWrapper using `withBroker(options)` and also calls CachedAuth with its own built PCAWraapper. This means that when someone calls AzureAuth and specifies to use only Broker mode, we try CachedAuth 2 times, one with PCAWrapper that CachedAuth itself builds (because cached auth is always added) without Broker config and then when Broker flow gets executed, it will pass on the PCA Wrapper that it built `withbroker(options)`.


## Workaround:

It might be important for us to reconsider the Auth flows and make it more close to current MSAL ideology of silent v/s interactive. However, to address current compliance issues, I am implementing following workaround - Whenever Broker is present in AuthMode (default/all/separate invocation to Broker), we leverage the CachedAuth call from Broker and ignore the initial CachedAuth call which is non-compliant.

## Testing:
For the following commands, make sure the default/all mode skips initial CachedAuth call and uses CachedAuth from Broker. For `--mode Broker` make sure it only calls Broker and not separate CachedAuth. 
For `--mode web`, `--mode device-code` make sure CachedAuth is still present and works.
On mac the current behavior should remain unchanged.
1. azureauth --help
2. azureauth aad 
3. azureauth ado pat 
4. azureauth ado token 
