### PR TITLE
Added support to read mode from environment variables for aad subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for reading auth mode from the environment variable `AZUREAUTH_MODE` for aad subcommands.
 
 ## [0.9.1] - 2024-12-09
 ### Changed

--- a/src/AzureAuth.Test/CommandAadTest.cs
+++ b/src/AzureAuth.Test/CommandAadTest.cs
@@ -497,6 +497,19 @@ invalid_key = ""this is not a valid alias key""
             this.logTarget.Logs.Should().ContainMatch($"Invalid value specified for environment variable {EnvVars.AuthMode}*");
         }
 
+        [Test]
+        public void TestEvaluateOptionsWithAuthModeFromEmptyEnvVars()
+        {
+            CommandAad subject = this.serviceProvider.GetService<CommandAad>();
+            subject.Resource = "f0e8d801-3a50-48fd-b2da-6476d6e832a2";
+            subject.Client = "e19f71ed-3b14-448d-9346-9eff9753646b";
+            subject.Tenant = "9f6227ee-3d14-473e-8bed-1281171ef8c9";
+
+            this.envMock.Setup(env => env.Get(EnvVars.AuthMode)).Returns("");
+            subject.EvaluateOptions().Should().BeTrue();
+            subject.AuthModes.Should().Contain(new[] { AuthMode.Default });
+        }
+
         /// <summary>
         /// The root path.
         /// </summary>

--- a/src/AzureAuth.Test/CommandAadTest.cs
+++ b/src/AzureAuth.Test/CommandAadTest.cs
@@ -236,6 +236,7 @@ invalid_key = ""this is not a valid alias key""
 
             // Specify config via env var
             this.envMock.Setup(e => e.Get("AZUREAUTH_CONFIG")).Returns(configFile);
+            this.envMock.Setup(env => env.Get(It.Is<string>(key => key != "AZUREAUTH_CONFIG"))).Returns<string>(key => null);
 
             // Specify a client override on the command line.
             subject.Client = clientOverride;

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -60,13 +60,13 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// The help text for the <see cref="ModeOption"/> option.
         /// </summary>
 #if PlatformWindows
-        public const string AuthModeHelperText = $"Authentication mode. Repeated invocations allowed.\n" +
-            $"[default: broker, then web]\n" +
-            $"[possible values: {AuthModeAllowedValues}]";
+        public const string AuthModeHelperText = $@"Authentication mode. Repeated invocations allowed.
+            [default: broker, then web]
+            [possible values: {AuthModeAllowedValues}]";
 #else
-        public const string AuthModeHelperText = $"Authentication mode. Repeated invocations allowed.\n" +
-            $"[default: web]\n" +
-            $"[possible values: {AuthModeAllowedValues}]";
+        public const string AuthModeHelperText = $@"Authentication mode. Repeated invocations allowed
+            [default: web]
+            [possible values: {AuthModeAllowedValues}]";
 #endif
 
         /// <summary>

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -446,6 +446,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
             }
 
             this.AuthModes = result;
+            this.eventData.Add($"env_{EnvVars.AuthMode}", authModesFromEnv);
             return true;
         }
     }

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -429,6 +429,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
             if (string.IsNullOrEmpty(authModesFromEnv))
             {
                 this.AuthModes = new[] { AuthMode.Default };
+                return true;
             }
 
             var result = new List<AuthMode>();

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// <summary>
         /// Sets the <see cref="AuthMode"/> from the environment variable and sets a default if not set.
         /// </summary>
-        /// <returns>The list of auth modes.</returns>
+        /// <returns>True if authmode is set.</returns>
         public bool TrySetAuthModeFromEnvOrDefault()
         {
             var authModesFromEnv = this.env.Get(EnvVars.AuthMode);

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -61,12 +61,12 @@ namespace Microsoft.Authentication.AzureAuth.Commands
         /// </summary>
 #if PlatformWindows
         public const string AuthModeHelperText = $@"Authentication mode. Repeated invocations allowed.
-            [default: broker, then web]
-            [possible values: {AuthModeAllowedValues}]";
+[default: broker, then web]
+[possible values: {AuthModeAllowedValues}]";
 #else
         public const string AuthModeHelperText = $@"Authentication mode. Repeated invocations allowed
-            [default: web]
-            [possible values: {AuthModeAllowedValues}]";
+[default: web]
+[possible values: {AuthModeAllowedValues}]";
 #endif
 
         /// <summary>

--- a/src/AzureAuth/EnvVars.cs
+++ b/src/AzureAuth/EnvVars.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Authentication.AzureAuth
         public static readonly string AdoPat = $"{EnvVarPrefix}_ADO_PAT";
 
         /// <summary>
+        /// Name of the env var to get the Auth Mode.
+        /// </summary>
+        public static readonly string AuthMode = $"{EnvVarPrefix}_MODE";
+
+        /// <summary>
         /// Name of the env var used to disable user based authentication modes.
         /// NOTE: This is a private variable and it is recommended to not rely on this variable.
         /// </summary>


### PR DESCRIPTION
**Why this change?**

Some users are facing intermittent issues with broker mode while invoking build commands which internally invoke AzureAuth.

If they want to switch to a different mode, they need to change the build scripts and use the changed binaries which is not ideal and is difficult for the end user. 

Hence, added this support, so that the user can set a mode that's not failing while we investigate the problem with the default mode.