### PR TITLE
Set Release Pipeline Type to "releaseJob"

### DIFF
--- a/.github/workflows/release-azure-pipelines.yml
+++ b/.github/workflows/release-azure-pipelines.yml
@@ -356,6 +356,8 @@ extends:
           image: ubuntu-latest
           os: linux
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             artifactName: azureauth-${{ parameters.version }}-packaged


### PR DESCRIPTION
Updating the GitHub release job's type to "releaseJob" as required by 1ESPT since we make use of the GitHubRelease task. This warning has popped up in [prior releases](https://dev.azure.com/office/OE/_build/results?buildId=36786408&view=results) so this PR attempts to remediate that.