### PR TITLE
Respect the $BROWSER environment variable when attempting to launch URLs

### DIFF
--- a/src/MSALWrapper/PCAWrapper.cs
+++ b/src/MSALWrapper/PCAWrapper.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Authentication.MSALWrapper
                 return Task.CompletedTask;
             }
 
-            // $BROWSER not set — use default .NET behavior (UseShellExecute tries xdg-open etc.)
+            // $BROWSER not set — fall back to default .NET behavior (UseShellExecute tries xdg-open etc.)
             Process.Start(new ProcessStartInfo(uri.AbsoluteUri)
             {
                 UseShellExecute = true,


### PR DESCRIPTION
Right now, `azureauth` attempts a known list of browser opening tools (such as `xdg-open`) in order to launch the oauth authorize url in `--mode web`, and fails if it can't find one of these tools. This doesn't work in github codespaces, as none of these tools exist! Comparing to how `az-cli`, and their `az login` command handles it, they use the `$BROWSER` environment variable in order to inform what browser to use, rather than attempting to find known browser tools.

This PR moves us to that environment variable model. To provide backwards compatibility for environments that don't have that set, `azureauth` will still use the static list if nothing is found.