### PR TITLE
feat: macOS brokered authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for macOS brokered authentication via Enterprise SSO Extension (opt-in with `--mode broker`)
+
+### Changed
+- Upgrade MSAL from `4.65.0` to `4.83.1`
+- Added `Microsoft.Identity.Client.NativeInterop` v0.20.3
 
 ## [0.9.5] - 2026-02-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The CLI is designed for authenticating and returning an access token for public 
 | Operating System                           | Integrated Windows Auth | Auth Broker Integration | Web Auth Flow            | Device Code Flow | Token Caching | Multi-Account Support           |
 | ------------------------------------------ | ----------------------- | ----------------------- | ------------------------ | ---------------- | ------------- | ------------------------------- |
 | Windows                                    | ✅                      | ✅                      | ✅                      | ✅              | ✅          | ⚠️ `--domain` account filtering |
-| OSX (MacOS)                                | N/A                      | ⚠️ via Web Browser      | ✅                      | ✅             | ✅          | ⚠️ `--domain` account filtering |
+| OSX (macOS)                                | N/A                      | ✅ via Enterprise SSO    | ✅                      | ✅             | ✅          | ⚠️ `--domain` account filtering |
 | Ubuntu (Linux)                             | N/A                      | ⚠️ via Edge             | ⚠️ in GUI environments | ✅        | ✅      | ⚠️ `--domain` account filtering |
 
 <br/>

--- a/bin/mac/test-macos-broker.sh
+++ b/bin/mac/test-macos-broker.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Functional test script for macOS brokered auth changes
+# Tests AzureAuth CLI with Work IQ's 3P Graph app registration
+#
+# Usage:
+#   ./bin/mac/test-macos-broker.sh                              # defaults (debug verbosity, 120s timeout)
+#   AZUREAUTH_TEST_VERBOSITY=info  ./bin/mac/test-macos-broker.sh   # less noise
+#   AZUREAUTH_TEST_VERBOSITY=trace ./bin/mac/test-macos-broker.sh   # max detail
+#   AZUREAUTH_TEST_TIMEOUT=60     ./bin/mac/test-macos-broker.sh   # shorter timeout
+#
+# Each interactive test has a timeout (default 120s). If azureauth hangs
+# waiting for browser/broker, it will be killed and you can choose to
+# mark it as SKIP or FAIL, then the script continues to the next test.
+#
+# You can also Ctrl+C during any individual test — the script traps it
+# and moves on.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+AZUREAUTH="$REPO_ROOT/src/AzureAuth/bin/Debug/net8.0/azureauth"
+CLIENT="ba081686-5d24-4bc6-a0d6-d034ecffed87"
+TENANT="common"
+RESOURCE="https://graph.microsoft.com"
+TIMEOUT="${AZUREAUTH_TEST_TIMEOUT:-120}"
+VERBOSITY="${AZUREAUTH_TEST_VERBOSITY:-debug}"  # debug, trace, info, warn
+
+PASS=0
+FAIL=0
+SKIP=0
+
+header() {
+    echo ""
+    echo "========================================"
+    echo "  $1"
+    echo "========================================"
+}
+
+result() {
+    local name="$1" exit_code="$2" expected="$3"
+    if [ "$exit_code" -eq "$expected" ]; then
+        echo "✅ PASS: $name (exit=$exit_code, expected=$expected)"
+        PASS=$((PASS + 1))
+    else
+        echo "❌ FAIL: $name (exit=$exit_code, expected=$expected)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run azureauth with a timeout. On Ctrl+C or timeout, offer skip/fail.
+# Usage: run_test "Test Name" expected_exit args...
+run_test() {
+    local test_name="$1" expected_exit="$2"
+    shift 2
+
+    echo ""
+    echo "→ Running: azureauth $*"
+    echo "  (timeout: ${TIMEOUT}s — Ctrl+C to abort this test)"
+    echo ""
+
+    local interrupted=false
+    local pid=""
+
+    # Trap SIGINT (Ctrl+C) for this test only
+    trap 'interrupted=true; [ -n "$pid" ] && kill "$pid" 2>/dev/null' INT
+
+    set +e
+    # Run azureauth in background, then wait with timeout
+    "$AZUREAUTH" "$@" 2>&1 &
+    pid=$!
+
+    # Wait up to TIMEOUT seconds for the process to finish
+    local elapsed=0
+    while [ "$elapsed" -lt "$TIMEOUT" ] && kill -0 "$pid" 2>/dev/null; do
+        sleep 1
+        ((elapsed++))
+        if [ "$interrupted" = true ]; then
+            break
+        fi
+    done
+
+    # If still running after timeout, kill it
+    if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null
+        if [ "$interrupted" = false ]; then
+            echo ""
+            echo "⏱️  Test timed out after ${TIMEOUT}s"
+        fi
+        interrupted=true
+        EXIT_CODE=124
+    else
+        wait "$pid"
+        EXIT_CODE=$?
+    fi
+    pid=""
+    set -e
+
+    # Restore default SIGINT behavior
+    trap - INT
+
+    if [ "$interrupted" = true ]; then
+        echo ""
+        echo "Test was interrupted/timed out."
+        read -p "Mark as [s]kip or [f]ail? (s/f, default=s): " choice </dev/tty || choice="s"
+        choice="${choice:-s}"
+        if [[ "$choice" =~ ^[fF] ]]; then
+            echo "❌ FAIL: $test_name (interrupted, marked as fail)"
+            FAIL=$((FAIL + 1))
+        else
+            echo "⏭️  SKIP: $test_name (interrupted)"
+            SKIP=$((SKIP + 1))
+        fi
+        return
+    fi
+
+    result "$test_name" "$EXIT_CODE" "$expected_exit"
+}
+
+# ── Step 0: Build ──────────────────────────────────────────────
+header "Step 0: Building AzureAuth"
+dotnet build "$REPO_ROOT/AzureAuth.sln" \
+    --no-restore -c Debug -v quiet 2>&1 | tail -3
+
+if [ ! -x "$AZUREAUTH" ]; then
+    echo "❌ Build failed — binary not found at $AZUREAUTH"
+    exit 1
+fi
+echo "✅ Binary ready: $AZUREAUTH"
+echo "   Version: $("$AZUREAUTH" --version)"
+
+# ── Step 0.5: CP version info ─────────────────────────────────
+header "Step 0.5: Company Portal status"
+CP_PLIST="/Applications/Company Portal.app/Contents/Info.plist"
+if [ -f "$CP_PLIST" ]; then
+    CP_VERSION=$(defaults read "/Applications/Company Portal.app/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown")
+    echo "Company Portal version: $CP_VERSION"
+    # Extract release number (middle segment of 5.RRRR.B)
+    RELEASE=$(echo "$CP_VERSION" | awk -F. '{print $2}')
+    if [ "$RELEASE" -ge 2603 ] 2>/dev/null; then
+        echo "⚡ CP >= 2603 — broker tests WILL attempt real broker auth"
+        BROKER_AVAILABLE=true
+    else
+        echo "⚠️  CP $CP_VERSION (release $RELEASE) < 2603 — broker will be gated off"
+        BROKER_AVAILABLE=false
+    fi
+else
+    echo "⚠️  Company Portal not installed — broker will be gated off"
+    BROKER_AVAILABLE=false
+fi
+
+# ── Test 1: Broker-only mode (opt-in) ────────────────────────
+header "Test 1: Broker-only mode (--mode broker)"
+if [ "$BROKER_AVAILABLE" = true ]; then
+    echo "CP >= 2603 detected — this will attempt real broker auth"
+    echo "Expect: broker interactive prompt via Enterprise SSO Extension"
+    EXPECTED_EXIT=0
+else
+    echo "CP < 2603 or not installed — expecting clear error about Company Portal"
+    echo "Expect: InvalidOperationException with CP version/path info"
+    EXPECTED_EXIT=1
+fi
+run_test "Broker-only (opt-in)" "$EXPECTED_EXIT" \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --mode broker --output json --verbosity "$VERBOSITY"
+
+# ── Test 2: Trace verbosity — verify CP diagnostics in logs ───
+header "Test 2: Trace verbosity — CP diagnostic logging"
+echo "Running with --verbosity trace to verify Company Portal metadata is logged."
+echo "🔍 Watch for: CP path, raw version output, release parsing"
+if [ "$BROKER_AVAILABLE" = true ]; then
+    EXPECTED_EXIT=0
+else
+    EXPECTED_EXIT=1
+fi
+run_test "Trace CP diagnostics" "$EXPECTED_EXIT" \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --mode broker --output json --verbosity trace
+
+# ── Test 3: Clear cache ───────────────────────────────────────
+header "Test 3: Clear token cache"
+run_test "Cache clear" 0 \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --clear --verbosity "$VERBOSITY"
+
+# ── Test 4: Clear cache (before re-testing broker interactive) ─
+header "Test 4: Clear token cache"
+run_test "Cache clear (pre-broker retest)" 0 \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --clear --verbosity "$VERBOSITY"
+
+# ── Test 5: Broker interactive again (after cache clear) ──────
+header "Test 5: Broker interactive (after cache clear)"
+if [ "$BROKER_AVAILABLE" = true ]; then
+    echo "Cache was just cleared — broker must prompt interactively again"
+    echo "Expect: broker account picker / SSO Extension prompt"
+    EXPECTED_EXIT=0
+else
+    echo "CP unavailable — broker skipped, CachedAuth only (will fail)"
+    EXPECTED_EXIT=1
+fi
+run_test "Broker interactive (re-prompt)" "$EXPECTED_EXIT" \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --mode broker --output json --verbosity "$VERBOSITY"
+
+# ── Test 6: Final cache clear ─────────────────────────────────
+header "Test 6: Final cache clear"
+run_test "Cache clear (final)" 0 \
+    aad --client "$CLIENT" --tenant "$TENANT" \
+    --resource "$RESOURCE" \
+    --clear --verbosity "$VERBOSITY"
+
+# ── Summary ────────────────────────────────────────────────────
+header "Results"
+echo "✅ Passed: $PASS"
+echo "⏭️  Skipped: $SKIP"
+echo "❌ Failed: $FAIL"
+echo ""
+echo "Broker available: $BROKER_AVAILABLE"
+if [ "$BROKER_AVAILABLE" = false ]; then
+    echo "ℹ️  To test actual broker auth, upgrade Company Portal to >= 5.2603.x"
+fi
+echo ""
+echo "Tip: Set AZUREAUTH_TEST_TIMEOUT=60 to change the per-test timeout (default: 30s)"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,9 @@
 # Usage
 AzureAuth is a generic Azure credential provider. It currently supports the following modes of [public client authentication](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-client-applications) (i.e., authenticating a human user.)
-* [IWA (Integrated Windows Authentication)](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-integrated-windows-authentication)
-* [WAM (Web Account Manager)](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-wam) (Windows only brokered authentication)
+* [IWA (Integrated Windows Authentication)](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-integrated-windows-authentication) (Windows only)
+* [Brokered Authentication](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-wam) (Windows via WAM, macOS via Enterprise SSO Extension)
 * [Embedded Web View](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-net-web-browsers) (Windows Only)
-* [System Web Browser](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-net-web-browsers) (Used on OSX in-place of Embedded Web View)
+* [System Web Browser](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-net-web-browsers) (Used on macOS in-place of Embedded Web View)
 * [Device Code Flow](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Device-Code-Flow) (All platforms, terminal interface only).
 
 ## `aad` subcommand
@@ -22,6 +22,28 @@ The `azureauth aad` subcommand is a "pass-through" for using [MSAL.NET](https://
    5. Select **Configure**.
 
    ![WAM redirect URI configuration](wam-config.png "A screenshot of a WAM URI being configured as a custom redirect URI.")
+
+2b. Configure redirect URIs for the **macOS Enterprise SSO Extension** (the macOS broker)
+   1. Select the **Authentication** blade.
+   2. Under Platform configurations, find **Mobile and desktop applications**.
+   3. Select **Add URI** and enter
+      ```
+      msauth.com.msauth.unsignedapp://auth
+      ```
+   4. Select **Save**.
+   
+   > **Note:** macOS brokered authentication is **opt-in** via `--mode broker` and requires:
+   > - **Company Portal** version 5.2603.0 or later installed on the device
+   > - Device is **MDM-compliant**
+   > 
+   > If Company Portal is unavailable or below the minimum version, broker is
+   > silently skipped and the next auth flow in the chain is attempted.
+   > 
+   > Example usage:
+   > ```
+   > azureauth aad --client <clientID> --resource <resourceID> --tenant <tenantID> --mode broker
+   > azureauth aad --client <clientID> --resource <resourceID> --tenant <tenantID> --mode broker --mode web
+   > ```
 
 3. Configure redirect URIs for the **system web browser**
    1. Select the **Authentication** blade.

--- a/src/AdoPat/AdoPat.csproj
+++ b/src/AdoPat/AdoPat.csproj
@@ -10,7 +10,7 @@
     <AdditionalFiles Include="..\stylecop\stylecop.json" Link="stylecop.json" />
     <Compile Include="..\stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.239.0-preview" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <!-- Transitive dependencies of Microsoft.VisualStudio.Services.Client temporarily pinned for security reasons. -->

--- a/src/AzureAuth.Test/AuthModeExtensionsTest.cs
+++ b/src/AzureAuth.Test/AuthModeExtensionsTest.cs
@@ -58,13 +58,16 @@ namespace AzureAuth.Test
             this.logTarget.Logs.Should().ContainInOrder("Interactive authentication is disabled.", "Only Integrated Windows Authentication will be attempted.");
         }
 #else
+        [Test]
+        [Platform("MacOsX,Linux")]
         public void CombinedAuthMode_Allowed()
         {
             // Arrange
             this.envMock.Setup(e => e.Get(EnvVars.NoUser)).Returns(string.Empty);
             this.envMock.Setup(e => e.Get("Corext_NonInteractive")).Returns(string.Empty);
 
-            var subject = new[] { AuthMode.Web, AuthMode.DeviceCode };
+            // Default on macOS is Web only (broker is opt-in).
+            var subject = new[] { AuthMode.Web };
 
             // Act + Assert
             subject.Combine().PreventInteractionIfNeeded(this.envMock.Object, this.logger).Should().Be(AuthMode.Default);
@@ -73,7 +76,8 @@ namespace AzureAuth.Test
 
         [TestCase("AZUREAUTH_NO_USER")]
         [TestCase("Corext_NonInteractive")]
-        public void Filterinteraction_Interactive_Auth_Disabled(string envVar)
+        [Platform("MacOsX,Linux")]
+        public void Filterinteraction_Interactive_Auth_Disabled_NoBroker(string envVar)
         {
             // Arrange
             this.envMock.Setup(e => e.Get(envVar)).Returns("1");
@@ -82,6 +86,20 @@ namespace AzureAuth.Test
             // Act + Assert
             subject.Combine().PreventInteractionIfNeeded(this.envMock.Object, this.logger).Should().Be(AuthMode.None);
             this.logTarget.Logs.Should().ContainInOrder("Interactive authentication is disabled.");
+        }
+
+        [TestCase("AZUREAUTH_NO_USER")]
+        [TestCase("Corext_NonInteractive")]
+        [Platform("MacOsX,Linux")]
+        public void Filterinteraction_Interactive_Auth_Disabled_WithBroker(string envVar)
+        {
+            // Arrange
+            this.envMock.Setup(e => e.Get(envVar)).Returns("1");
+            var subject = new[] { AuthMode.Broker, AuthMode.Web, AuthMode.DeviceCode };
+
+            // Act + Assert
+            subject.Combine().PreventInteractionIfNeeded(this.envMock.Object, this.logger).Should().Be(AuthMode.Broker);
+            this.logTarget.Logs.Should().ContainInOrder("Interactive authentication is disabled.", "Only Broker silent authentication will be attempted.");
         }
 #endif
     }

--- a/src/AzureAuth/AuthModeExtensions.cs
+++ b/src/AzureAuth/AuthModeExtensions.cs
@@ -28,7 +28,14 @@ namespace Microsoft.Authentication.AzureAuth
                 logger.LogWarning($"Only Integrated Windows Authentication will be attempted.");
                 return AuthMode.IWA;
 #else
-                return 0;
+                // Keep broker for silent auth on macOS, where the broker can resolve tokens silently.
+                var silentMode = authMode & AuthMode.Broker;
+                if (silentMode != 0)
+                {
+                    logger.LogWarning($"Only Broker silent authentication will be attempted.");
+                }
+
+                return silentMode;
 #endif
             }
 

--- a/src/AzureAuth/Commands/CommandAad.cs
+++ b/src/AzureAuth/Commands/CommandAad.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Authentication.AzureAuth.Commands
 #if PlatformWindows
         public const string AuthModeAllowedValues = "all, iwa, broker, web, devicecode";
 #else
-        public const string AuthModeAllowedValues = "all, web, devicecode";
+        public const string AuthModeAllowedValues = "all, broker, web, devicecode";
 #endif
 
         private const string ResourceOption = "--resource";

--- a/src/AzureAuth/Program.cs
+++ b/src/AzureAuth/Program.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Authentication.AzureAuth
     using System;
     using System.Runtime.InteropServices;
     using System.Text;
+    using System.Threading.Tasks;
 
     using McMaster.Extensions.CommandLineUtils;
 
@@ -13,6 +14,7 @@ namespace Microsoft.Authentication.AzureAuth
     using Microsoft.Authentication.MSALWrapper;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client.Utils;
     using Microsoft.Office.Lasso;
     using Microsoft.Office.Lasso.Telemetry;
 
@@ -22,6 +24,34 @@ namespace Microsoft.Authentication.AzureAuth
     public class Program
     {
         private static void Main(string[] args)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // macOS brokered auth requires interactive calls on the main thread.
+                // Start the MSAL message loop on main, dispatch CLI work to a background thread.
+                var scheduler = MacMainThreadScheduler.Instance();
+                var cliTask = Task.Run(() =>
+                {
+                    try
+                    {
+                        MainInner(args);
+                    }
+                    finally
+                    {
+                        scheduler.Stop();
+                    }
+                });
+
+                scheduler.StartMessageLoop();
+                cliTask.GetAwaiter().GetResult();
+            }
+            else
+            {
+                MainInner(args);
+            }
+        }
+
+        private static void MainInner(string[] args)
         {
             // Use UTF-8 output encoding.
             // This will impact the NLog Console Target as well as any other Console usage.

--- a/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
+++ b/src/MSALWrapper.Benchmark/MSALWrapper.Benchmark.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MSALWrapper\MSALWrapper.csproj" />
@@ -32,6 +32,6 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) == false">
         <!-- Not Windows: simple package reference -->
-     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
+     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
   </ItemGroup>
 </Project>

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -250,7 +250,6 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Platform("MacOsX")]
         public void AllModes_Mac()
         {
-            this.MockIsMacOS(true);
             this.MockIsMacOSBrokerAvailable(true);
             this.MockIsWindows10Or11(false);
 

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -129,6 +129,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         public void Windows_Defaults()
         {
             this.MockIsWindows10Or11(false);
+            this.MockIsMacOSBrokerAvailable(false);
+            this.MockIsMacOS(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Default);
 
@@ -164,6 +166,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockIsWindows(true);
             this.MockIsWindows10Or11(false);
+            this.MockIsMacOSBrokerAvailable(false);
+            this.MockIsMacOS(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
@@ -200,6 +204,8 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         {
             this.MockIsWindows(true);
             this.MockIsWindows10Or11(false);
+            this.MockIsMacOSBrokerAvailable(false);
+            this.MockIsMacOS(false);
 
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 

--- a/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/AuthFlowFactoryTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Authentication.MSALWrapper.Test
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -243,6 +244,10 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Platform("MacOsX")]
         public void AllModes_Mac()
         {
+            this.MockIsMacOS(true);
+            this.MockIsMacOSBrokerAvailable(true);
+            this.MockIsWindows10Or11(false);
+
             IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.All);
 
             this.pcaWrapperMock.VerifyAll();
@@ -252,7 +257,7 @@ namespace Microsoft.Authentication.MSALWrapper.Test
                 .Should()
                 .BeEquivalentTo(new[]
                 {
-                    typeof(CachedAuth),
+                    typeof(Broker),
                     typeof(Web),
                     typeof(DeviceCode),
                 });
@@ -262,14 +267,47 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Platform("MacOsx")]
         public void DefaultModes_Not_Windows()
         {
-            // On non-windows platforms the Default Authmode doesn't contain "Broker" as an option to start with.
-            // so we short circuit checking the platform and expect it to not be called.
+            // On macOS, default mode is Web only (broker is opt-in via --mode broker).
             var subject = this.Subject(AuthMode.Default);
 
-            this.platformUtilsMock.VerifyAll();
             subject.Should().HaveCount(2);
             subject
                 .Select(a => a.GetType())
+                .Should()
+                .ContainInOrder(
+                    typeof(CachedAuth),
+                    typeof(Web));
+        }
+
+        [Test]
+        [Platform("MacOsX")]
+        public void BrokerRequested_Mac_CP_Unavailable_SkipsBroker()
+        {
+            this.MockIsWindows10Or11(false);
+            this.MockIsMacOS(true);
+            this.MockIsMacOSBrokerAvailable(false);
+
+            // Broker is silently skipped; only CachedAuth remains when no other modes are requested.
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Broker);
+
+            subject.Should().HaveCount(1);
+            subject.First().Should().BeOfType<CachedAuth>();
+        }
+
+        [Test]
+        [Platform("MacOsX")]
+        public void BrokerAndWeb_Mac_CP_Unavailable_FallsThrough()
+        {
+            this.MockIsWindows10Or11(false);
+            this.MockIsMacOS(true);
+            this.MockIsMacOSBrokerAvailable(false);
+
+            // Broker is skipped but web is still added — fall-through pattern.
+            IEnumerable<IAuthFlow> subject = this.Subject(AuthMode.Broker | AuthMode.Web);
+
+            subject.Should().HaveCount(2);
+            subject
+                .Select(flow => flow.GetType())
                 .Should()
                 .ContainInOrder(
                     typeof(CachedAuth),
@@ -284,6 +322,16 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         private void MockIsWindows(bool value)
         {
             this.platformUtilsMock.Setup(p => p.IsWindows()).Returns(value);
+        }
+
+        private void MockIsMacOS(bool value)
+        {
+            this.platformUtilsMock.Setup(p => p.IsMacOS()).Returns(value);
+        }
+
+        private void MockIsMacOSBrokerAvailable(bool value)
+        {
+            this.platformUtilsMock.Setup(p => p.IsMacOSBrokerAvailable()).Returns(value);
         }
     }
 }

--- a/src/MSALWrapper.Test/AuthFlow/BrokerMacOSTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerMacOSTest.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Authentication.MSALWrapper.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using FluentAssertions;
+
+    using Microsoft.Authentication.MSALWrapper;
+    using Microsoft.Authentication.TestHelper;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Client;
+    using Microsoft.IdentityModel.JsonWebTokens;
+
+    using Moq;
+
+    using NLog.Targets;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for macOS-specific broker authentication behavior.
+    /// Uses a mock IPlatformUtils that reports IsMacOS()=true to simulate macOS.
+    /// </summary>
+    internal class BrokerMacOSTest : AuthFlowTestBase
+    {
+        private Mock<IPlatformUtils> mockPlatformUtils;
+
+        [SetUp]
+        public new void Setup()
+        {
+            this.mockPlatformUtils = new Mock<IPlatformUtils>(MockBehavior.Strict);
+            this.mockPlatformUtils.Setup(p => p.IsMacOS()).Returns(true);
+        }
+
+        public AuthFlow.Broker Subject() => new AuthFlow.Broker(
+            this.logger,
+            this.authParameters,
+            pcaWrapper: this.mockPca.Object,
+            promptHint: PromptHint,
+            platformUtils: this.mockPlatformUtils.Object);
+
+        [Test]
+        public async Task MacOS_GetTokenSilent_WithCachedAccount_Success()
+        {
+            // Cached account exists in the MSAL cache — silent auth succeeds.
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentSuccess();
+
+            AuthFlowResult result = await this.Subject().GetTokenAsync();
+
+            result.TokenResult.Should().Be(this.testToken);
+            result.TokenResult.IsSilent.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+            result.AuthFlowName.Should().Be("broker");
+        }
+
+        [Test]
+        public async Task MacOS_NoCachedAccount_Interactive_Success()
+        {
+            // No cached account — falls through to interactive auth.
+            this.mockPca
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync((IAccount)null);
+
+            this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveSuccess(withAccount: false);
+
+            AuthFlowResult result = await this.Subject().GetTokenAsync();
+
+            result.TokenResult.Should().Be(this.testToken);
+            result.TokenResult.IsSilent.Should().BeFalse();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task MacOS_GeneralException_Windows_Would_Rethrow()
+        {
+            // Verify that on a "Windows" platform mock, general exceptions ARE rethrown.
+            // This is the control test proving the macOS exception filter is meaningful.
+            var windowsPlatform = new Mock<IPlatformUtils>(MockBehavior.Strict);
+            windowsPlatform.Setup(p => p.IsMacOS()).Returns(false);
+
+            var broker = new AuthFlow.Broker(
+                this.logger,
+                this.authParameters,
+                pcaWrapper: this.mockPca.Object,
+                promptHint: PromptHint,
+                platformUtils: windowsPlatform.Object);
+
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+            this.SetupGetTokenSilentReturnsNull();
+            this.SetupWithPromptHint();
+
+            this.mockPca
+                .Setup(pca => pca.GetTokenInteractiveAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Broker crash"));
+
+            Func<Task> act = async () => await broker.GetTokenAsync();
+
+            await act.Should().ThrowExactlyAsync<InvalidOperationException>().WithMessage("Broker crash");
+        }
+
+        [Test]
+        public async Task MacOS_SilentFails_Interactive_RetriesWithClaims_Success()
+        {
+            // No cached account, interactive gets MsalUiRequiredException, retries with claims.
+            this.mockPca
+                .Setup(pca => pca.TryToGetCachedAccountAsync(It.IsAny<string>()))
+                .ReturnsAsync((IAccount)null);
+
+            this.SetupWithPromptHint();
+            this.SetupGetTokenInteractiveMsalUiRequiredException(null);
+            this.SetupGetTokenInteractiveWithClaimsSuccess();
+
+            AuthFlowResult result = await this.Subject().GetTokenAsync();
+
+            result.TokenResult.Should().Be(this.testToken);
+            result.Errors.Should().HaveCount(1);
+            result.Errors[0].Should().BeOfType(typeof(MsalUiRequiredException));
+        }
+
+        [Test]
+        public async Task MacOS_GetTokenSilent_MsalServiceException_ReturnsError()
+        {
+            this.SetupCachedAccount();
+            this.SetupAccountUsername();
+
+            this.mockPca
+                .Setup(pca => pca.GetTokenSilentAsync(Scopes, this.mockAccount.Object, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new MsalServiceException("1", "Service error"));
+
+            AuthFlowResult result = await this.Subject().GetTokenAsync();
+
+            result.TokenResult.Should().BeNull();
+            result.Errors.Should().HaveCount(1);
+            result.Errors[0].Should().BeOfType(typeof(MsalServiceException));
+        }
+    }
+}

--- a/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
+++ b/src/MSALWrapper.Test/AuthFlow/BrokerTest.cs
@@ -24,7 +24,17 @@ namespace Microsoft.Authentication.MSALWrapper.Test
 
     internal class BrokerTest : AuthFlowTestBase
     {
-        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object, promptHint: PromptHint);
+        private Mock<IPlatformUtils> mockPlatformUtils;
+
+        [SetUp]
+        public new void Setup()
+        {
+            this.mockPlatformUtils = new Mock<IPlatformUtils>(MockBehavior.Strict);
+            // Default to Windows behavior so existing tests keep working.
+            this.mockPlatformUtils.Setup(p => p.IsMacOS()).Returns(false);
+        }
+
+        public AuthFlow.Broker Subject() => new AuthFlow.Broker(this.logger, this.authParameters, pcaWrapper: this.mockPca.Object, promptHint: PromptHint, platformUtils: this.mockPlatformUtils.Object);
 
         [Test]
         public async Task GetTokenSilent_Success()

--- a/src/MSALWrapper.Test/AuthModeTest.cs
+++ b/src/MSALWrapper.Test/AuthModeTest.cs
@@ -96,10 +96,11 @@ namespace Microsoft.Authentication.MSALWrapper.Test
         [Test]
         public void AllIsAll()
         {
-            (AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
+            (AuthMode.Broker | AuthMode.Web | AuthMode.DeviceCode).Should().Be(AuthMode.All);
         }
 
-        [TestCase(AuthMode.All, false)]
+        [TestCase(AuthMode.All, true)]
+        [TestCase(AuthMode.Broker, true)]
         [TestCase(AuthMode.Web, false)]
         [TestCase(AuthMode.DeviceCode, false)]
         public void BrokerIsExpected(AuthMode subject, bool expected)

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -41,7 +41,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             // We skip CachedAuth if Broker is present in authMode on windows 10 or 11, since Broker 
             // already tries CachedAuth with its PCAWrapper object built using withBroker(options).
-            if (!(authMode.IsBroker() && platformUtils.IsWindows10Or11()))
+            // The same applies on macOS when the broker is available.
+            // If broker is requested but unavailable, CachedAuth is still added as a first-pass attempt.
+            bool brokerWillRun = authMode.IsBroker() && (platformUtils.IsWindows10Or11() || platformUtils.IsMacOSBrokerAvailable());
+            if (!brokerWillRun)
             {
                 flows.Add(new CachedAuth(logger, authParams, preferredDomain, pcaWrapper));
             }
@@ -53,12 +56,31 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                 flows.Add(new IntegratedWindowsAuthentication(logger, authParams, preferredDomain, pcaWrapper));
             }
 
-            // This check silently fails on winserver if broker has been requested.
-            // Future: Consider making AuthMode platform aware at Runtime.
+            // Broker is silently skipped when unavailable on the current platform
+            // (e.g., Windows Server, macOS without Company Portal). The executor
+            // continues to the next flow in the list (Web, DeviceCode, etc.).
             // https://github.com/AzureAD/microsoft-authentication-cli/issues/55
-            if (authMode.IsBroker() && platformUtils.IsWindows10Or11())
+            if (authMode.IsBroker())
             {
-                flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint));
+                if (platformUtils.IsWindows10Or11())
+                {
+                    flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint, platformUtils: platformUtils));
+                }
+                else if (platformUtils.IsMacOS())
+                {
+                    if (platformUtils.IsMacOSBrokerAvailable())
+                    {
+                        flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint, platformUtils: platformUtils));
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            "Broker authentication was requested but is not available on this machine. " +
+                            "macOS broker requires Company Portal version 5.2603.0 or later " +
+                            $"(checked: {PlatformUtils.CompanyPortalAppPath}). " +
+                            "Skipping broker and falling through to next auth flow.");
+                    }
+                }
             }
 
             if (authMode.IsWeb())

--- a/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
+++ b/src/MSALWrapper/AuthFlow/AuthFlowFactory.cs
@@ -62,24 +62,17 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             // https://github.com/AzureAD/microsoft-authentication-cli/issues/55
             if (authMode.IsBroker())
             {
-                if (platformUtils.IsWindows10Or11())
+                if (platformUtils.IsWindows10Or11() || platformUtils.IsMacOSBrokerAvailable())
                 {
                     flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint, platformUtils: platformUtils));
                 }
                 else if (platformUtils.IsMacOS())
                 {
-                    if (platformUtils.IsMacOSBrokerAvailable())
-                    {
-                        flows.Add(new Broker(logger, authParams, preferredDomain: preferredDomain, pcaWrapper: pcaWrapper, promptHint: promptHint, platformUtils: platformUtils));
-                    }
-                    else
-                    {
-                        logger.LogWarning(
-                            "Broker authentication was requested but is not available on this machine. " +
-                            "macOS broker requires Company Portal version 5.2603.0 or later " +
-                            $"(checked: {PlatformUtils.CompanyPortalAppPath}). " +
-                            "Skipping broker and falling through to next auth flow.");
-                    }
+                    logger.LogWarning(
+                        "Broker authentication was requested but is not available on this machine. " +
+                        "macOS broker requires Company Portal version 5.2603.0 or later " +
+                        $"(checked: {PlatformUtils.CompanyPortalAppPath}). " +
+                        "Skipping broker and falling through to next auth flow.");
                 }
             }
 

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -112,15 +112,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     this.GetTokenInteractiveWithClaims(ex.Claims),
                     this.errors).ConfigureAwait(false);
             }
-            catch (Exception ex) when (this.platformUtils.IsMacOS())
-            {
-                // On macOS, broker interactive auth can fail (e.g., Company Portal not installed,
-                // SSO Extension not running, or main thread issue). Fall back to browser-based auth.
-                this.errors.Add(ex);
-                this.logger.LogDebug($"macOS broker interactive auth failed: {ex.Message}. Falling back to browser auth.");
-
-                tokenResult = await this.FallbackToBrowserAuthAsync(account);
-            }
 
             return tokenResult;
         }
@@ -148,36 +139,6 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
 
             // On Windows, fall back to OperatingSystemAccount sentinel for WAM resolution.
             return PublicClientApplication.OperatingSystemAccount;
-        }
-
-        /// <summary>
-        /// Falls back to browser-based interactive auth on macOS when the broker fails.
-        /// Creates a separate PCA without broker configuration using http://localhost redirect.
-        /// </summary>
-        private async Task<TokenResult> FallbackToBrowserAuthAsync(IAccount account)
-        {
-            this.logger.LogDebug("Creating browser fallback PCA for macOS");
-
-            var fallbackBuilder = PublicClientApplicationBuilder
-                .Create($"{this.authParameters.Client}")
-                .WithAuthority($"https://login.microsoftonline.com/{this.authParameters.Tenant}")
-                .WithRedirectUri(Constants.AadRedirectUri.ToString())
-                .WithLogging(
-                    this.LogMSAL,
-                    Identity.Client.LogLevel.Verbose,
-                    enablePiiLogging: false,
-                    enableDefaultPlatformLogging: true);
-
-            var fallbackPca = new PCAWrapper(this.logger, fallbackBuilder.Build(), this.errors, this.authParameters.Tenant);
-
-            return await TaskExecutor.CompleteWithin(
-                this.logger,
-                this.interactiveAuthTimeout,
-                $"{this.Name} browser fallback",
-                (CancellationToken cancellationToken) => fallbackPca
-                    .WithPromptHint(this.promptHint)
-                    .GetTokenInteractiveAsync(this.scopes, account, cancellationToken),
-                this.errors).ConfigureAwait(false);
         }
 
 #if PlatformWindows

--- a/src/MSALWrapper/AuthFlow/Broker.cs
+++ b/src/MSALWrapper/AuthFlow/Broker.cs
@@ -12,9 +12,10 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Client;
     using Microsoft.Identity.Client.Broker;
+    using Microsoft.Identity.Client.Utils;
 
     /// <summary>
-    /// The broker auth flow.
+    /// The broker auth flow. Supports Windows (WAM) and macOS (Enterprise SSO Extension).
     /// </summary>
     public class Broker : AuthFlowBase
     {
@@ -22,6 +23,8 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         private readonly string preferredDomain;
         private readonly string promptHint;
         private readonly IPCAWrapper pcaWrapper;
+        private readonly AuthParameters authParameters;
+        private readonly IPlatformUtils platformUtils;
 
         /// <summary>
         /// The interactive auth timeout.
@@ -36,15 +39,19 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <param name="preferredDomain">The preferred domain.</param>
         /// <param name="pcaWrapper">Optional: IPCAWrapper to use.</param>
         /// <param name="promptHint">The customized header text in account picker for WAM prompts.</param>
-        public Broker(ILogger logger, AuthParameters authParameters, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null)
+        /// <param name="platformUtils">Optional: IPlatformUtils for platform detection (defaults to runtime detection).</param>
+        public Broker(ILogger logger, AuthParameters authParameters, string preferredDomain = null, IPCAWrapper pcaWrapper = null, string promptHint = null, IPlatformUtils platformUtils = null)
         {
             this.logger = logger;
+            this.authParameters = authParameters;
             this.scopes = authParameters.Scopes;
             this.preferredDomain = preferredDomain;
             this.promptHint = promptHint;
+            this.platformUtils = platformUtils ?? new PlatformUtils(logger);
             this.pcaWrapper = pcaWrapper ?? this.BuildPCAWrapper(authParameters.Client, authParameters.Tenant);
         }
 
+#if PlatformWindows
         private enum GetAncestorType
         {
             /// <summary>
@@ -62,6 +69,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
             /// </summary>
             GetRootOwner = 3,
         }
+#endif
 
         /// <inheritdoc/>
         protected override string Name { get; } = Constants.AuthFlow.Broker;
@@ -69,8 +77,7 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
         /// <inheritdoc/>
         protected override async Task<TokenResult> GetTokenInnerAsync()
         {
-            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain)
-                 ?? PublicClientApplication.OperatingSystemAccount;
+            IAccount account = await this.ResolveAccountAsync();
 
             TokenResult tokenResult = await CachedAuth.GetTokenAsync(
                 this.logger,
@@ -105,46 +112,143 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     this.GetTokenInteractiveWithClaims(ex.Claims),
                     this.errors).ConfigureAwait(false);
             }
+            catch (Exception ex) when (this.platformUtils.IsMacOS())
+            {
+                // On macOS, broker interactive auth can fail (e.g., Company Portal not installed,
+                // SSO Extension not running, or main thread issue). Fall back to browser-based auth.
+                this.errors.Add(ex);
+                this.logger.LogDebug($"macOS broker interactive auth failed: {ex.Message}. Falling back to browser auth.");
+
+                tokenResult = await this.FallbackToBrowserAuthAsync(account);
+            }
 
             return tokenResult;
         }
 
+        /// <summary>
+        /// Resolves the account to use for token acquisition.
+        /// On Windows, falls back to OperatingSystemAccount if no cached account.
+        /// On macOS, returns null to trigger interactive auth if no cached account.
+        /// </summary>
+        private async Task<IAccount> ResolveAccountAsync()
+        {
+            // Try the MSAL cache filtered by preferred domain.
+            IAccount account = await this.pcaWrapper.TryToGetCachedAccountAsync(this.preferredDomain);
+            if (account != null)
+            {
+                return account;
+            }
+
+            if (this.platformUtils.IsMacOS())
+            {
+                // On macOS, OperatingSystemAccount is not supported.
+                // If MSAL cache has no single matching account, trigger interactive auth.
+                return null;
+            }
+
+            // On Windows, fall back to OperatingSystemAccount sentinel for WAM resolution.
+            return PublicClientApplication.OperatingSystemAccount;
+        }
+
+        /// <summary>
+        /// Falls back to browser-based interactive auth on macOS when the broker fails.
+        /// Creates a separate PCA without broker configuration using http://localhost redirect.
+        /// </summary>
+        private async Task<TokenResult> FallbackToBrowserAuthAsync(IAccount account)
+        {
+            this.logger.LogDebug("Creating browser fallback PCA for macOS");
+
+            var fallbackBuilder = PublicClientApplicationBuilder
+                .Create($"{this.authParameters.Client}")
+                .WithAuthority($"https://login.microsoftonline.com/{this.authParameters.Tenant}")
+                .WithRedirectUri(Constants.AadRedirectUri.ToString())
+                .WithLogging(
+                    this.LogMSAL,
+                    Identity.Client.LogLevel.Verbose,
+                    enablePiiLogging: false,
+                    enableDefaultPlatformLogging: true);
+
+            var fallbackPca = new PCAWrapper(this.logger, fallbackBuilder.Build(), this.errors, this.authParameters.Tenant);
+
+            return await TaskExecutor.CompleteWithin(
+                this.logger,
+                this.interactiveAuthTimeout,
+                $"{this.Name} browser fallback",
+                (CancellationToken cancellationToken) => fallbackPca
+                    .WithPromptHint(this.promptHint)
+                    .GetTokenInteractiveAsync(this.scopes, account, cancellationToken),
+                this.errors).ConfigureAwait(false);
+        }
+
+#if PlatformWindows
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetConsoleWindow();
+#endif
 
         private Func<CancellationToken, Task<TokenResult>> GetTokenInteractive(IAccount account)
         {
-            return (CancellationToken cancellationToken) => this.pcaWrapper
-                .WithPromptHint(this.promptHint)
-                .GetTokenInteractiveAsync(this.scopes, account, cancellationToken);
+            return async (CancellationToken cancellationToken) =>
+            {
+                if (this.platformUtils.IsMacOS() && MacMainThreadScheduler.Instance().IsRunning())
+                {
+                    TokenResult result = null;
+                    await MacMainThreadScheduler.Instance().RunOnMainThreadAsync(async () =>
+                    {
+                        result = await this.pcaWrapper
+                            .WithPromptHint(this.promptHint)
+                            .GetTokenInteractiveAsync(this.scopes, account, cancellationToken);
+                    });
+                    return result;
+                }
+
+                return await this.pcaWrapper
+                    .WithPromptHint(this.promptHint)
+                    .GetTokenInteractiveAsync(this.scopes, account, cancellationToken);
+            };
         }
 
         private Func<CancellationToken, Task<TokenResult>> GetTokenInteractiveWithClaims(string claims)
         {
-            return (CancellationToken cancellationToken) => this.pcaWrapper
-                .WithPromptHint(this.promptHint)
-                .GetTokenInteractiveAsync(this.scopes, claims, cancellationToken);
+            return async (CancellationToken cancellationToken) =>
+            {
+                if (this.platformUtils.IsMacOS() && MacMainThreadScheduler.Instance().IsRunning())
+                {
+                    TokenResult result = null;
+                    await MacMainThreadScheduler.Instance().RunOnMainThreadAsync(async () =>
+                    {
+                        result = await this.pcaWrapper
+                            .WithPromptHint(this.promptHint)
+                            .GetTokenInteractiveAsync(this.scopes, claims, cancellationToken);
+                    });
+                    return result;
+                }
+
+                return await this.pcaWrapper
+                    .WithPromptHint(this.promptHint)
+                    .GetTokenInteractiveAsync(this.scopes, claims, cancellationToken);
+            };
         }
 
+#if PlatformWindows
         /// <summary>
         /// Retrieves the handle to the ancestor of the specified window.
         /// </summary>
         /// <param name="windowsHandle">A handle to the window whose ancestor is to be retrieved.
         /// If this parameter is the desktop window, the function returns NULL. </param>
         /// <param name="flags">The ancestor to be retrieved.</param>
-        /// <returns>The return value is the handle to the ancestor window.</returns>[DllImport("user32.dll", ExactSpelling = true)]
+        /// <returns>The return value is the handle to the ancestor window.</returns>
         [DllImport("user32.dll", ExactSpelling = true)]
 #pragma warning disable SA1204 // Static elements should appear before instance elements
         private static extern IntPtr GetAncestor(IntPtr windowsHandle, GetAncestorType flags);
 #pragma warning restore SA1204 // Static elements should appear before instance elements
 
-        // MSAL will be providing a similar helper in the future that we can use to simplify this(AzureAD/microsoft-authentication-library-for-dotnet#3590).
         private IntPtr GetParentWindowHandle()
         {
             IntPtr consoleHandle = GetConsoleWindow();
             IntPtr ancestorHandle = GetAncestor(consoleHandle, GetAncestorType.GetRootOwner);
             return ancestorHandle;
         }
+#endif
 
         private IPCAWrapper BuildPCAWrapper(Guid clientId, string tenantId)
         {
@@ -156,12 +260,25 @@ namespace Microsoft.Authentication.MSALWrapper.AuthFlow
                     this.LogMSAL,
                     Identity.Client.LogLevel.Verbose,
                     enablePiiLogging: false,
-                    enableDefaultPlatformLogging: true)
-                .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
-                {
-                    Title = this.promptHint,
-                })
-                .WithParentActivityOrWindow(() => this.GetParentWindowHandle()); // Pass parent window handle to MSAL so it can parent the authentication dialogs.
+                    enableDefaultPlatformLogging: true);
+
+            if (this.platformUtils.IsMacOS())
+            {
+                clientBuilder
+                    .WithRedirectUri(Constants.MacOSBrokerRedirectUri.ToString())
+                    .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.OSX));
+            }
+            else
+            {
+#if PlatformWindows
+                clientBuilder
+                    .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
+                    {
+                        Title = this.promptHint,
+                    })
+                    .WithParentActivityOrWindow(() => this.GetParentWindowHandle());
+#endif
+            }
 
             return new PCAWrapper(this.logger, clientBuilder.Build(), this.errors, tenantId);
         }

--- a/src/MSALWrapper/AuthMode.cs
+++ b/src/MSALWrapper/AuthMode.cs
@@ -50,12 +50,19 @@ namespace Microsoft.Authentication.MSALWrapper
         Default = Broker | Web,
 #else
         /// <summary>
-        /// All auth modes.
+        /// Broker auth mode (macOS Enterprise SSO Extension).
         /// </summary>
-        All = Web | DeviceCode,
+        Broker = 1 << 2,
 
         /// <summary>
-        /// Default auth mode.
+        /// All auth modes.
+        /// </summary>
+        All = Broker | Web | DeviceCode,
+
+        /// <summary>
+        /// Default auth mode. On macOS, broker is opt-in via --mode broker because
+        /// it requires Company Portal and apps using broker-required CA policies
+        /// will hang indefinitely if web auth is attempted as fallback.
         /// </summary>
         Default = Web,
 #endif
@@ -76,7 +83,7 @@ namespace Microsoft.Authentication.MSALWrapper
 #if PlatformWindows
             return (AuthMode.Broker & authMode) == AuthMode.Broker;
 #else
-            return false;
+            return (AuthMode.Broker & authMode) == AuthMode.Broker;
 #endif
         }
 

--- a/src/MSALWrapper/Constants.cs
+++ b/src/MSALWrapper/Constants.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Authentication.MSALWrapper
         public static readonly Uri AadRedirectUri = new Uri("http://localhost");
 
         /// <summary>
+        /// The redirect uri for macOS brokered authentication (unsigned runtime apps).
+        /// </summary>
+        public static readonly Uri MacOSBrokerRedirectUri = new Uri("msauth.com.msauth.unsignedapp://auth");
+
+        /// <summary>
         /// The name of an environment variable used to disable file cache configuration.
         /// </summary>
         internal const string OEAUTH_MSAL_DISABLE_CACHE = "OEAUTH_MSAL_DISABLE_CACHE";

--- a/src/MSALWrapper/IPlatformUtils.cs
+++ b/src/MSALWrapper/IPlatformUtils.cs
@@ -19,5 +19,17 @@ namespace Microsoft.Authentication.MSALWrapper
         /// </summary>
         /// <returns><see cref="bool"/> - true if running on any version of Windows.</returns>
         bool IsWindows();
+        /// <summary>
+        /// Check if running on macOS.
+        /// </summary>
+        /// <returns><see cref="bool"/> - true if running on macOS.</returns>
+        bool IsMacOS();
+
+        /// <summary>
+        /// Check if macOS brokered authentication is available.
+        /// Requires macOS, Company Portal installed, and CP version >= 2603.
+        /// </summary>
+        /// <returns><see cref="bool"/> - true if macOS broker prerequisites are met.</returns>
+        bool IsMacOSBrokerAvailable();
     }
 }

--- a/src/MSALWrapper/MSALWrapper.csproj
+++ b/src/MSALWrapper/MSALWrapper.csproj
@@ -24,9 +24,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.20.3" />
   </ItemGroup>
 </Project>

--- a/src/MSALWrapper/PlatformUtils.cs
+++ b/src/MSALWrapper/PlatformUtils.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Authentication.MSALWrapper
 {
     using System;
+    using System.Diagnostics;
+    using System.IO;
     using System.Runtime.InteropServices;
     using Microsoft.Extensions.Logging;
 
@@ -15,6 +17,8 @@ namespace Microsoft.Authentication.MSALWrapper
         private ILogger logger;
         private Lazy<bool> isWindows;
         private Lazy<bool> isWindows10;
+        private Lazy<bool> isMacOS;
+        private Lazy<bool> isMacOSBrokerAvailable;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PlatformUtils"/> class.
@@ -25,6 +29,8 @@ namespace Microsoft.Authentication.MSALWrapper
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.isWindows = new Lazy<bool>(() => this.CheckWindows());
             this.isWindows10 = new Lazy<bool>(() => this.CheckWindows10());
+            this.isMacOS = new Lazy<bool>(() => this.CheckMacOS());
+            this.isMacOSBrokerAvailable = new Lazy<bool>(() => this.CheckMacOSBrokerAvailable());
         }
 
         /// <inheritdoc/>
@@ -37,6 +43,107 @@ namespace Microsoft.Authentication.MSALWrapper
         public bool IsWindows()
         {
             return this.isWindows.Value;
+        }
+
+        /// <inheritdoc/>
+        public bool IsMacOS()
+        {
+            return this.isMacOS.Value;
+        }
+
+        /// <inheritdoc/>
+        public bool IsMacOSBrokerAvailable()
+        {
+            return this.isMacOSBrokerAvailable.Value;
+        }
+
+        private bool CheckMacOS()
+        {
+            this.logger.LogTrace($"IsMacOS: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) = {RuntimeInformation.IsOSPlatform(OSPlatform.OSX)}");
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        /// <summary>
+        /// Minimum Company Portal release number required for unsigned app broker support.
+        /// CP 2603 added redirect_uri validation fix for msauth.com.msauth.unsignedapp://auth.
+        /// </summary>
+        private const int MinimumCPRelease = 2603;
+
+        /// <summary>
+        /// Path where Company Portal is expected to be installed on macOS.
+        /// </summary>
+        public const string CompanyPortalAppPath = "/Applications/Company Portal.app";
+
+        private bool CheckMacOSBrokerAvailable()
+        {
+            if (!this.IsMacOS())
+            {
+                return false;
+            }
+
+            this.logger.LogTrace($"Checking for Company Portal at: {CompanyPortalAppPath}");
+
+            if (!Directory.Exists(CompanyPortalAppPath))
+            {
+                this.logger.LogDebug($"macOS broker unavailable: Company Portal not found at {CompanyPortalAppPath}");
+                return false;
+            }
+
+            this.logger.LogTrace($"Company Portal found at: {CompanyPortalAppPath}");
+
+            try
+            {
+                var plistPath = $"{CompanyPortalAppPath}/Contents/Info";
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "defaults",
+                    Arguments = $"read \"{plistPath}\" CFBundleShortVersionString",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+
+                this.logger.LogTrace($"Reading CP version: defaults read \"{plistPath}\" CFBundleShortVersionString");
+
+                using var process = Process.Start(psi);
+                var output = process.StandardOutput.ReadToEnd().Trim();
+                var stderr = process.StandardError.ReadToEnd().Trim();
+                process.WaitForExit(5000);
+
+                this.logger.LogTrace($"CP version raw output: '{output}'");
+                if (!string.IsNullOrEmpty(stderr))
+                {
+                    this.logger.LogTrace($"CP version stderr: '{stderr}'");
+                }
+
+                // Version format: "5.RRRR.B" where RRRR is the release number (e.g., 2603)
+                var parts = output.Split('.');
+                if (parts.Length >= 2 && int.TryParse(parts[1], out int releaseNumber))
+                {
+                    var meetsMinimum = releaseNumber >= MinimumCPRelease;
+                    this.logger.LogDebug($"Company Portal version: {output} (release {releaseNumber}), minimum required: {MinimumCPRelease}, meets minimum: {meetsMinimum}");
+                    this.logger.LogTrace($"Company Portal path: {CompanyPortalAppPath}");
+                    this.logger.LogTrace($"Company Portal version parts: major={parts[0]}, release={parts[1]}{(parts.Length >= 3 ? $", build={parts[2]}" : string.Empty)}");
+
+                    if (!meetsMinimum)
+                    {
+                        this.logger.LogWarning($"macOS broker unavailable: Company Portal {output} (at {CompanyPortalAppPath}) is below minimum required release {MinimumCPRelease}.");
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                this.logger.LogDebug($"macOS broker: unable to parse Company Portal version '{output}' from {CompanyPortalAppPath}");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogDebug($"macOS broker: failed to check Company Portal version at {CompanyPortalAppPath}: {ex.Message}");
+                this.logger.LogTrace($"macOS broker: version check exception: {ex}");
+                return false;
+            }
         }
 
         private bool CheckWindows()


### PR DESCRIPTION
* feat: add macOS brokered authentication support

Add support for macOS Enterprise SSO Extension brokered authentication, bringing feature parity with Windows WAM broker support.

Key changes:
- Upgrade MSAL 4.65.0 → 4.83.1, add NativeInterop v0.20.3
- Extend Broker auth flow with macOS-specific PCA config, account resolution, and browser fallback
- Add DefaultAccountStore to persist account username for silent auth (OperatingSystemAccount not supported on macOS)
- Add MacMainThreadScheduler message loop in Program.cs
- Extend AuthMode enum and CLI parsing to support broker on macOS
- Update docs with macOS broker prerequisites and redirect URI config



* feat: add Company Portal version check before broker auth

Skip macOS broker auth if Company Portal is not installed or is below version 2603 (which added redirect_uri validation fix for unsigned apps). Falls back to web auth transparently in those cases.

- Add IsMacOSBrokerAvailable() to IPlatformUtils/PlatformUtils
- AuthFlowFactory uses IsMacOSBrokerAvailable() as gatekeeper
- Broker.cs still uses IsMacOS() for runtime behavior (fallback, persist)
- Reads CP version from Info.plist via 'defaults read'



* feat: make broker opt-in on macOS, error on missing CP

On macOS, broker is no longer included in default auth modes. Users must explicitly pass '--mode broker' to use it. If broker is requested but Company Portal >= 5.2603.0 is not installed, AuthFlowFactory throws a clear InvalidOperationException instead of silently falling through to web auth (which hangs for apps with broker-required CA policies like token protection).

- AuthMode.Default on non-Windows: Broker|Web -> Web
- AuthFlowFactory: explicit error when broker requested but CP unavailable
- New test: BrokerRequested_Mac_CP_Unavailable_Throws



* improve: CP diagnostics logging and error messages

- Include CP path in broker unavailable error message
- Add trace-level logging: CP path, raw version output, stderr, parsed version parts (major/release/build)
- Expose CompanyPortalAppPath as public const for error messages
- Update test script to reflect broker-opt-in behavior: new tests for broker+web combined, trace diagnostics, reordered



* fix: dispatch broker interactive calls to main thread on macOS

The macOS broker requires AcquireTokenInteractive to run on the main thread. Program.cs starts the MacMainThreadScheduler message loop on main and dispatches CLI work to Task.Run, but the broker interactive calls were still executing on the background thread.

Now GetTokenInteractive/WithClaims dispatch through MacMainThreadScheduler.RunOnMainThreadAsync when running on macOS with the scheduler active (IsRunning check prevents deadlock in tests).

Also: improved CP diagnostics trace logging and included CP path in the broker unavailable error message.



* feat: add SSO Extension registration pre-flight check

Check 'app-sso -l' for registered Enterprise SSO Extensions before attempting broker auth. If no extensions are registered (MDM profile not applied), gives a clear error instead of a cryptic broker failure.

Designed for easy revert:
- Set AZUREAUTH_SKIP_SSO_CHECK=1 to bypass the check entirely
- If app-sso fails or isn't available, assumes broker may work (non-fatal)
- The check is a single method call in CheckMacOSBrokerAvailable()



* chore: move macOS test scripts to bin/mac/

Move test-macos-broker.sh and swap-cp.sh from repo root to bin/mac/ alongside existing macOS build scripts. Update REPO_ROOT to resolve two levels up from the new location.



* improve: configurable verbosity in test script, disable SSO check

- Add AZUREAUTH_TEST_VERBOSITY env var (default: debug) to control log level across all tests (Test 3 always uses trace)
- Comment out SSO Extension check (confirmed unnecessary for broker)



* docs: add usage examples to test script header



* fix: broker falls through to next auth flow when unavailable on macOS

Match the existing Windows pattern where broker is silently skipped on unsupported platforms (e.g., Windows Server). On macOS, if broker is requested but Company Portal is insufficient, log a warning and continue to the next flow (Web, DeviceCode, etc.) instead of throwing.

This means '--mode broker --mode web' will fall through to web when CP is unavailable, and '--mode broker' alone will try CachedAuth only.



* test: comment out web mode tests, add broker re-prompt after clear

Web auth hangs for this broker-required app (token protection CA policy), so comment out Tests 2 and 5. Add cache clear + broker interactive re-prompt cycle (Tests 6-8) to verify full broker lifecycle: authenticate → clear → re-authenticate.



* fix: address PR review comments

- Delete swap-cp.sh (reviewer: no need for checked-in CP swap utility)
- Remove commented-out web mode tests from test script (reviewer: keep checked-in tests clean)
- Add [Platform] attributes to non-Windows AuthModeExtensions tests (reviewer: make OS-specificity explicit)
- Fix help text: non-Windows default is 'web' not 'broker, then web' (reviewer: broker may confuse Linux users; --mode is repeatable so --mode broker explicitly opts in)



* docs: update usage.md to reflect broker opt-in on macOS

- Broker is opt-in via --mode broker, not automatic
- Removed SSO Extension prerequisite (confirmed unnecessary)
- Added CP version requirement (>= 5.2603.0)
- Added example CLI invocations
- Clarified fallthrough behavior when broker unavailable



* Remove unused SSO Extension check code

The IsSSOExtensionRegistered method and its TODO were confirmed unnecessary during testing — broker auth works without SSO Extension registration showing in app-sso output. Removes dead code and the AZUREAUTH_SKIP_SSO_CHECK env var that was only needed for this check.



* Fix async deadlock in PersistDefaultAccount

Changed PersistDefaultAccount from sync .Wait()/.Result to async/await. The previous pattern (calling task.Wait() on an async method inside an async context) is a classic .NET deadlock risk, especially dangerous with the macOS MacMainThreadScheduler SynchronizationContext.



* Remove DefaultAccountStore — rely on MSAL cache instead

DefaultAccountStore persisted account usernames (PII) to plaintext JSON files in ~/.azureauth/ with world-readable permissions. This was only needed to disambiguate multi-account scenarios (TryToGetCachedAccountAsync returns null when >1 accounts are cached).

Without it, multi-account users get an extra broker prompt — which is the safe default for a CLI tool and avoids writing PII to disk.

Changes:
- Delete DefaultAccountStore.cs and DefaultAccountStoreTest.cs
- Simplify Broker.ResolveAccountAsync (no more persisted username lookup)
- Remove PersistDefaultAccountAsync from Broker.cs
- Simplify BrokerMacOSTest.cs (remove store setup/teardown)



---------